### PR TITLE
Better build output

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,13 @@
 
 configuration: Debug
 
+install: 
+  - ps: (new-object Net.WebClient).DownloadString("https://raw.github.com/madskristensen/ExtensionScripts/master/AppVeyor/vsix.ps1") | iex
+
+before_build: 
+  # Updates the version number in the .vsixmanifest and updates the AppVeyor build number to match
+  - ps: Vsix-IncrementVsixVersion | Vsix-UpdateBuildVersion
+
 build:
   project: VimAll.sln
   verbosity: minimal
@@ -8,11 +15,11 @@ build:
 after_build:
   - Src\CleanVsix\bin\Debug\CleanVsix.exe Src\VsVim\bin\Debug\VsVim.vsix
 
-artifacts:
-  - path: Src\VsVim\bin\Debug\VsVim.vsix
-
 test_script:
   - Tools\xunit.console.clr4.x86.exe Test\VimCoreTest\bin\Debug\Vim.Core.UnitTest.dll /silent
   - Tools\xunit.console.clr4.x86.exe Test\VimWpfTest\bin\Debug\Vim.UI.Wpf.UnitTest.dll /silent
   - Tools\xunit.console.clr4.x86.exe Test\VsVimSharedTest\bin\Debug\Vim.VisualStudio.Shared.UnitTest.dll /silent
 
+after_test:
+  # Pushes the compiled vsix to artifacts and publishes it to vsixgallery.com
+  - ps: Vsix-PushArtifacts | Vsix-PublishToGallery


### PR DESCRIPTION
Using this general purpose VSIX build steps for AppVeyor, you get these benefits:

1. The artifacts are pushed with a clean name (`VsVim.vsix` instead of `Src\VsVim\bin\Debug\VsVim.vsix`)
2. The artifacts get a label: `Latest build`
3. The version number is incremented in the .vsixmanifest before build using the AppVeyor {build} property
  - It will then be major.minor.{build}
4. The AppVeyor build version is updated to the same version as your VSIX version
5. You no longer have to make point-point releases like 1.7.1. It will just be 1.7.{build} similar to how VS does it
6. The produced .vsix is automatically uploaded to vsixgallery.com
  - Here you can give your users access to the nightly build
  - You can deep link to the nightly build. AppVeyor doesn't allow deep links to artifacts
     - Example: http://vsixgallery.com/extensions/VsVim.Microsoft.e214908b-0458-4ae2-a583-4310f29687c3/VsVim.vsix

You can see what the AppVeyor build looks like here https://ci.appveyor.com/project/madskristensen/vsvim/build/1.7.5 and the entry in vsixgallery.com here http://vsixgallery.com/extension/VsVim.Microsoft.e214908b-0458-4ae2-a583-4310f29687c3/