### PR TITLE
Tag parser handles some other characters in tag and attributes names

### DIFF
--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -461,6 +461,7 @@ module internal CharUtil =
     let IsLower x = System.Char.IsLower(x)
     let IsLowerLetter x = IsLower x && IsLetter x
     let IsLetterOrDigit x = System.Char.IsLetterOrDigit(x)
+    let IsTagNameChar x = System.Char.IsLetterOrDigit(x) || x = ':' || x = '.' || x = '_'
     let ToLower x = System.Char.ToLower(x)
     let ToUpper x = System.Char.ToUpper(x)
     let ChangeCase x = if IsUpper x then ToLower x else ToUpper x

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -98,7 +98,7 @@ type TagBlockParser (snapshot : ITextSnapshot) =
 
     member x.ParseName startPosition = 
         let mutable position = startPosition
-        while x.TestPosition position (fun c -> CharUtil.IsLetterOrDigit c) do
+        while x.TestPosition position (fun c -> CharUtil.IsTagNameChar c) do
             position <- position + 1
 
         let length = position - startPosition
@@ -205,7 +205,7 @@ type TagBlockParser (snapshot : ITextSnapshot) =
         if x.TestPositionChar position '<' && x.TestPositionChar (position + 1) '/' then
             let textStartPosition = position + 2
             let mutable position = textStartPosition
-            while x.TestPosition position CharUtil.IsLetterOrDigit do
+            while x.TestPosition position CharUtil.IsTagNameChar do
                 position <- position + 1
 
             let length = position - textStartPosition

--- a/Test/VimCoreTest/TagBlockParserTest.cs
+++ b/Test/VimCoreTest/TagBlockParserTest.cs
@@ -80,6 +80,13 @@ namespace Vim.UnitTest
                 Assert.Equal("h2", tagBlock.Text);
                 Assert.Equal(0, tagBlock.Children.Count);
             }
+            [Fact]
+            public void OtherNameCharacters()
+            {
+                var tagBlock = Parse("<ns:some.tag_name>cat</ns:some.tag_name>").Single();
+                Assert.Equal("ns:some.tag_name", tagBlock.Text);
+                Assert.Equal(0, tagBlock.Children.Count);
+            }
         }
 
         public sealed class SpanTest : TagBlockParserTest
@@ -162,6 +169,14 @@ namespace Vim.UnitTest
             public void MultipleAttributes()
             {
                 var tagBlock = Parse("<a name1='foo' name2='bar'></a>").Single();
+                Assert.Equal("a", tagBlock.Text);
+                Assert.Equal(0, tagBlock.Children.Count);
+            }
+
+            [Fact]
+            public void OtherAttributeNameCharacters()
+            {
+                var tagBlock = Parse("<a ns:some.attr_name=\"1\">cat</a>").Single();
                 Assert.Equal("a", tagBlock.Text);
                 Assert.Equal(0, tagBlock.Children.Count);
             }


### PR DESCRIPTION
The tag parser recognises letters, digits and a few other valid characters:
':', '.', and '_' in tag and attribute names.

Fixes issue #1574