### PR TITLE
Support ReSharper 9.1

### DIFF
--- a/Src/VsVimShared/Implementation/ReSharper/ResharperVersionutility.cs
+++ b/Src/VsVimShared/Implementation/ReSharper/ResharperVersionutility.cs
@@ -56,7 +56,8 @@ namespace Vim.VisualStudio.Implementation.ReSharper
 
                 // Starting with ReSharper 9, the assembly we detect is part of the "ReSharper Platform"
                 // Which for ReSharper 9 is of version 6.0
-                if (version.Major == 6)
+                // and Resharper 9.1 has version 102
+                if (version.Major == 6 || version.Major == 102)
                 {
                     switch (version.Minor)
                     {


### PR DESCRIPTION
ReSharper 9.1 has updated version of `JetBrains.Platform.VisualStudio.SinceVs10` assembly. New file version is `102`.