### PR TITLE
Fixed tag block parsing attributes without values

### DIFF
--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -146,12 +146,16 @@ type TagBlockParser (snapshot : ITextSnapshot) =
         let position = x.SkipBlanks startPosition
         _builder { 
             let! nameSpan = x.ParseAttributeName position
-            let! position = x.ParseChar (x.SkipBlanks nameSpan.End) '='
-            let quotePosition = x.SkipBlanks position
-            let! quoteChar = x.ParseQuoteChar quotePosition
-            let! valueSpan = x.ParseAttributeValue (quotePosition + 1) quoteChar
-            let! valueEnd = x.ParseChar valueSpan.End quoteChar
-            return Span.FromBounds(startPosition, valueEnd)
+            let position = x.SkipBlanks nameSpan.End
+            if x.TestPositionChar position '=' then
+                let quotePosition = position + 1
+                let! quoteChar = x.ParseQuoteChar quotePosition
+                let! valueSpan = x.ParseAttributeValue (quotePosition + 1) quoteChar
+                let! valueEnd = x.ParseChar valueSpan.End quoteChar
+                return Span.FromBounds(startPosition, valueEnd)
+            else
+                //The attribute has no value
+                return Span.FromBounds(startPosition, nameSpan.End)
         }
 
     /// This will be called with the position pointing immediately after the end of the 

--- a/Test/VimCoreTest/TagBlockParserTest.cs
+++ b/Test/VimCoreTest/TagBlockParserTest.cs
@@ -168,7 +168,7 @@ namespace Vim.UnitTest
             [Fact]
             public void MultipleAttributes()
             {
-                var tagBlock = Parse("<a name1='foo' name2='bar'></a>").Single();
+                var tagBlock = Parse("<a name1='foo' name2='bar' name-dash='abc' novalue></a>").Single();
                 Assert.Equal("a", tagBlock.Text);
                 Assert.Equal(0, tagBlock.Children.Count);
             }
@@ -205,6 +205,15 @@ namespace Vim.UnitTest
                 Assert.Equal("a", tagBlock.Text);
                 Assert.Equal(0, tagBlock.Children.Count);
             }
+
+            [Fact]
+            public void NoValue()
+            {
+                var tagBlock = Parse(@"<button disabled>search</button>").Single();
+                Assert.Equal("button", tagBlock.Text);
+                Assert.Equal(0, tagBlock.Children.Count);
+            }
+
         }
     }
 }


### PR DESCRIPTION
Fixed parsing tags when containing attributes without values ("\<button disabled\>Search\</button\>"). Please let me know if anything needs to be changed.

An aside: The test projects use XUnit for unit tests, but the XUnit Runner NuGet package isn't part of the test project so I could not get tests to run without installing it. I installed it and then removed it when I was done testing. Is there some other way to get them to run?