### PR TITLE
Fix 1679 (Ctrl-w h/l navigation when multiple windows have the same document)

### DIFF
--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -577,7 +577,7 @@ namespace Vim.VisualStudio
                 .Where(window => window.Kind == "Document" && (window.Left > 0))
                 .ToList();
             topLevelWindows.Sort((a, b) => a.Left < b.Left ? -1 : 1);
-            var indexOfActiveDoc = topLevelWindows.FindIndex(win => win.Document == _dte.ActiveDocument);
+            var indexOfActiveDoc = topLevelWindows.FindIndex(win => win == _dte.ActiveWindow);
             var movedIndex = indexOfActiveDoc - indexDelta;
             var newIndex = (movedIndex < 0 ? movedIndex + topLevelWindows.Count : movedIndex % topLevelWindows.Count);
             if (newIndex >= topLevelWindows.Count)

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -578,7 +578,7 @@ namespace Vim.VisualStudio
                 .ToList();
             topLevelWindows.Sort((a, b) => a.Left < b.Left ? -1 : 1);
             var indexOfActiveDoc = topLevelWindows.FindIndex(win => win == _dte.ActiveWindow);
-            var movedIndex = indexOfActiveDoc - indexDelta;
+            var movedIndex = indexOfActiveDoc + indexDelta;
             var newIndex = (movedIndex < 0 ? movedIndex + topLevelWindows.Count : movedIndex % topLevelWindows.Count);
             if (newIndex >= topLevelWindows.Count)
             {


### PR DESCRIPTION
Fixes issue #1679 

This turned out to be surprisingly easy to deal with; the window object can be equated against directly to solve two windows with the same document.

While I was in there, I noticed that left and right were swapped because the `indexDelta` was subtracted rather than addded to the current index.  I hope you don't mind that I fixed this here rather than creating a separate issue and pull request just for that.