### PR TITLE
Fix 1671 (copy and move commands inserting below first line)

### DIFF
--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -285,6 +285,50 @@ type VimInterpreter
         // TODO: Implement
         None
 
+    member x.GetVimLineNumber lineSpecifier currentLine =
+
+        // Get the ITextSnapshotLine specified by lineSpecifier and then apply the
+        // given adjustment to the number.  Can fail if the line number adjustment
+        // is invalid
+        let getAdjustment adjustment (line : ITextSnapshotLine) = 
+            adjustment + line.LineNumber + 1
+
+        match lineSpecifier with 
+        | LineSpecifier.CurrentLine -> 
+            x.CaretLine.LineNumber + 1 |> Some
+        | LineSpecifier.LastLine ->
+            (SnapshotUtil.GetLastLineNumber x.CurrentSnapshot) + 1 |> Some
+        | LineSpecifier.LineSpecifierWithAdjustment (lineSpecifier, adjustment) ->
+
+            x.GetVimLineNumber lineSpecifier currentLine |> Option.map (fun line -> line + adjustment)
+        | LineSpecifier.MarkLine mark ->
+
+            // Get the line containing the mark in the context of this IVimTextBuffer
+            _markMap.GetMark mark _vimBufferData
+            |> Option.map VirtualSnapshotPointUtil.GetPoint
+            |> Option.map SnapshotPointUtil.GetContainingLine
+            |> Option.map (fun line -> line.LineNumber + 1)
+        | LineSpecifier.NextLineWithPattern pattern ->
+            // TODO: Implement
+            None
+        | LineSpecifier.NextLineWithPreviousPattern ->
+            // TODO: Implement
+            None
+        | LineSpecifier.NextLineWithPreviousSubstitutePattern ->
+            // TODO: Implement
+            None
+        | LineSpecifier.Number number ->
+            number |> Some
+        | LineSpecifier.PreviousLineWithPattern pattern ->
+            // TODO: Implement
+            None
+        | LineSpecifier.PreviousLineWithPreviousPattern ->
+            // TODO: Implement
+            None
+
+        | LineSpecifier.AdjustmentOnCurrent adjustment -> 
+            getAdjustment adjustment currentLine |> Some
+
     /// Get the ITextSnapshotLine specified by the given LineSpecifier
     member x.GetLineCore lineSpecifier currentLine = 
 

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -347,10 +347,6 @@ type VimInterpreter
     member x.GetLineAndVimLineNumber lineSpecifier =
         x.GetLineAndVimLineNumberCore lineSpecifier x.CaretLine
 
-    member x.GetVimLineNumber lineSpecifier currentLine =
-        x.GetLineAndVimLineNumberCore lineSpecifier currentLine
-        |> Option.map (fun (line, vimLine) -> vimLine)
-
     /// Get the ITextSnapshotLine specified by the given LineSpecifier
     member x.GetLine lineSpecifier = 
         x.GetLineCore lineSpecifier x.CaretLine

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -296,15 +296,15 @@ type VimInterpreter
             let number = Util.VimLineToTssLine vimLine
 
             SnapshotUtil.TryGetLine x.CurrentSnapshot number
-            |> Option.map (fun line -> vimLine, line)
+            |> Option.map (fun line -> line, vimLine)
 
         match lineSpecifier with 
         | LineSpecifier.CurrentLine -> 
             let line = x.CaretLine
-            (line.LineNumber + 1, line) |> Some
+            (line, line.LineNumber + 1) |> Some
         | LineSpecifier.LastLine ->
             let line = SnapshotUtil.GetLastLine x.CurrentSnapshot
-            (line.LineNumber + 1, line) |> Some
+            (line, line.LineNumber + 1) |> Some
         | LineSpecifier.LineSpecifierWithAdjustment (lineSpecifier, adjustment) ->
 
             x.GetLine lineSpecifier |> OptionUtil.map2 (getAdjustment adjustment)
@@ -314,7 +314,7 @@ type VimInterpreter
             _markMap.GetMark mark _vimBufferData
             |> Option.map VirtualSnapshotPointUtil.GetPoint
             |> Option.map SnapshotPointUtil.GetContainingLine
-            |> Option.map (fun line -> line.LineNumber + 1, line)
+            |> Option.map (fun line -> line, line.LineNumber + 1)
         | LineSpecifier.NextLineWithPattern pattern ->
             // TODO: Implement
             None
@@ -328,7 +328,7 @@ type VimInterpreter
             // Must be a valid number 
             let tssNumber = Util.VimLineToTssLine number
             SnapshotUtil.TryGetLine x.CurrentSnapshot tssNumber
-            |> Option.map (fun line -> number, line)
+            |> Option.map (fun line -> line, number)
         | LineSpecifier.PreviousLineWithPattern pattern ->
             // TODO: Implement
             None
@@ -342,14 +342,14 @@ type VimInterpreter
     /// Get the ITextSnapshotLine specified by the given LineSpecifier
     member x.GetLineCore lineSpecifier currentLine = 
         x.GetLineAndVimLineNumberCore lineSpecifier currentLine
-        |> Option.map (fun (vimLine, line) -> line)
+        |> Option.map (fun (line, vimLine) -> line)
 
     member x.GetLineAndVimLineNumber lineSpecifier =
         x.GetLineAndVimLineNumberCore lineSpecifier x.CaretLine
 
     member x.GetVimLineNumber lineSpecifier currentLine =
         x.GetLineAndVimLineNumberCore lineSpecifier currentLine
-        |> Option.map (fun (vimLine, line) -> vimLine)
+        |> Option.map (fun (line, vimLine) -> vimLine)
 
     /// Get the ITextSnapshotLine specified by the given LineSpecifier
     member x.GetLine lineSpecifier = 
@@ -521,7 +521,7 @@ type VimInterpreter
             | None ->
                  _statusUtil.OnError Resources.Common_InvalidAddress
             
-            | Some (destLineNum, destLine) -> 
+            | Some (destLine, destLineNum) -> 
 
                 let destPosition = 
                     if destLineNum = 0 then

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -285,11 +285,9 @@ type VimInterpreter
         // TODO: Implement
         None
 
-    member x.GetVimLineNumber lineSpecifier currentLine =
-        x.GetLineAndVimLineNumber lineSpecifier currentLine
-        |> Option.map (fun (vimLine, line) -> vimLine)
-
-    member x.GetLineAndVimLineNumber lineSpecifier currentLine = 
+    // Get a tuple of the ITextSnapshotLine specified by the given LineSpecifier and the 
+    // corresponding vim line number
+    member x.GetLineAndVimLineNumberCore lineSpecifier (currentLine : ITextSnapshotLine) = 
         // Get the ITextSnapshotLine specified by lineSpecifier and then apply the
         // given adjustment to the number.  Can fail if the line number adjustment
         // is invalid
@@ -343,8 +341,15 @@ type VimInterpreter
 
     /// Get the ITextSnapshotLine specified by the given LineSpecifier
     member x.GetLineCore lineSpecifier currentLine = 
-        x.GetLineAndVimLineNumber lineSpecifier currentLine
+        x.GetLineAndVimLineNumberCore lineSpecifier currentLine
         |> Option.map (fun (vimLine, line) -> line)
+
+    member x.GetLineAndVimLineNumber lineSpecifier =
+        x.GetLineAndVimLineNumberCore lineSpecifier x.CaretLine
+
+    member x.GetVimLineNumber lineSpecifier currentLine =
+        x.GetLineAndVimLineNumberCore lineSpecifier currentLine
+        |> Option.map (fun (vimLine, line) -> vimLine)
 
     /// Get the ITextSnapshotLine specified by the given LineSpecifier
     member x.GetLine lineSpecifier = 

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -915,7 +915,7 @@ type Parser
         | LineRangeSpecifier.None -> LineCommand.ParseError Resources.Common_InvalidAddress
         | _ -> LineCommand.CopyTo (sourceLineRange, destinationLineRange, count)
 
-    /// Parse out the :copy command.  It has a single required argument that is the destination
+    /// Parse out the :move command.  It has a single required argument that is the destination
     /// address
     member x.ParseMoveTo sourceLineRange = 
         x.SkipBlanks()

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -578,6 +578,22 @@ namespace Vim.UnitTest
                 Assert.Equal(_textBuffer.GetLine(1).GetText(), "bear");
                 Assert.Equal(_textBuffer.GetLine(2).GetText(), "cat");
             }
+
+
+            /// <summary>
+            /// Specifying "line 0" should move to before the first line.
+            /// </summary>
+            [Fact]
+            public void MoveToBeforeFirstLineInFile() {
+                Create("cat", "dog", "bear");
+
+                _textView.MoveCaretToLine(2);
+                RunCommand("m0");
+
+                Assert.Equal(_textBuffer.GetLine(0).GetText(), "bear");
+                Assert.Equal(_textBuffer.GetLine(1).GetText(), "cat");
+                Assert.Equal(_textBuffer.GetLine(2).GetText(), "dog");
+            }
         }
 
         public sealed class PasteTest : CommandModeIntegrationTest

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -170,6 +170,22 @@ namespace Vim.UnitTest
                     _textBuffer.GetLines().ToArray());
                 Assert.Equal(_textBuffer.GetLine(1).Start, _textView.GetCaretPoint());
             }
+
+            /// <summary>
+            /// Copy to the first line
+            /// </summary>
+            [Fact]
+            public void ToFirstLine() {
+                Create("cat", "dog", "fish", "bear", "tree");
+                _textView.MoveCaretToLine(3);
+                ParseAndRun("co -4");
+
+                Assert.Equal(
+                    new [] {"bear","cat", "dog", "fish", "bear", "tree"},
+                    _textBuffer.GetLines().ToArray());
+
+                Assert.Equal(_textBuffer.GetLine(0).Start, _textView.GetCaretPoint());
+            }
         }
 
         public sealed class DisplayMarkTest : InterpreterTest


### PR DESCRIPTION
I added a new method to the interpreter which I called `GetLineAndVimLineNumber` which returns a tuple of the `ITextSnapshotLine` and the corresponding vim line number specified by the `LineSpecifier` given to the method.  `GetLineCore` was changed to simply call `GetLineAndVimLineNumber` to avoid duplicating the line specifier interpreter logic.

I refactored the `RunCopyTo` and `RunMoveTo` methods to get the destination position injected to them rather than the destination line so that the decision to insert before or after the destination line can happen in a common place.  I modified RunCopyToAndMoveTo to use `GetLineAndVimLineNumber` and decide whether to insert the text before the destination line or after by inspecting the line number (and pass that back to the lambda sent by RunCopyTo or RunMoveTo).

**Overall, my changes feel maybe too invasive to me so I would really appreciate feedback on this!**

As a side note, I noticed that the [line specifier case for the current line in `GetLineCore`](https://github.com/jaredpar/VsVim/blob/master/Src/VimCore/Interpreter_Interpreter.fs#L302-L303) calls out to get the current line even though the method presumably gets the current line as a parameter while the [case for an adjustment from the current line](https://github.com/jaredpar/VsVim/blob/master/Src/VimCore/Interpreter_Interpreter.fs#L335-L336) uses the parameter.
```fsharp`
| LineSpecifier.CurrentLine -> 
    x.CaretLine |> Some

//...

| LineSpecifier.AdjustmentOnCurrent adjustment -> 
    getAdjustment adjustment currentLine
```

In my GetLineAndVimLineNumber method I duplicated this behavior just in case it was intentional, but it looked odd to me so I wanted to bring it to your attention.

Double side note: I hate the name `GetLineAndVimLineNumber`, but I couldn't think of anything better.