### PR TITLE
Normal command implementation

### DIFF
--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -498,6 +498,8 @@ and [<RequireQualifiedAccess>] LineCommand =
     /// then it will be run on the lines which don't match the pattern
     | Global of LineRangeSpecifier * string * bool * LineCommand
 
+    | Normal of string
+
     /// Go to the first tab 
     | GoToFirstTab
 

--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -498,7 +498,7 @@ and [<RequireQualifiedAccess>] LineCommand =
     /// then it will be run on the lines which don't match the pattern
     | Global of LineRangeSpecifier * string * bool * LineCommand
 
-    | Normal of string
+    | Normal of KeyInput list
 
     /// Go to the first tab 
     | GoToFirstTab

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -4,6 +4,7 @@ open EditorUtils
 open Microsoft.VisualStudio.Text
 open Vim
 open Vim.StringBuilderExtensions
+open Vim.VimCoreExtensions
 open System.Collections.Generic
 open System.ComponentModel.Composition
 
@@ -806,6 +807,49 @@ type VimInterpreter
         x.RunWithLineRangeOrDefault lineRange DefaultLineRange.CurrentLine (fun lineRange ->
             if lineRange.Count > 1 then
                 _foldManager.CreateFold lineRange)
+
+    member x.RunNormal (command: string) =
+        let map = System.Collections.Generic.Dictionary<ITextBuffer, IVimBuffer*ILinkedUndoTransaction>();
+        try
+            let reg = RegisterValue(command, OperationKind.CharacterWise)
+
+            let rec inner list = 
+                match list with 
+                | [] -> 
+                    // No more input so we are finished
+                    true
+                | keyInput :: tail -> 
+
+                    // Prefer the focussed IVimBuffer over the current.  It's possible for the 
+                    // macro playback switch the active buffer via gt, gT, etc ... and playback 
+                    // should continue on the newly focussed IVimBuffer.  Should the host API
+                    // fail to return an active IVimBuffer continue using the original one
+                    let buffer = 
+                        match _vim.FocusedBuffer with
+                        | Some buffer -> buffer
+                        | None -> _vimBuffer
+
+                    // Make sure we have an IUndoTransaction open in the ITextBuffer
+                    if not (map.ContainsKey(buffer.TextBuffer)) then
+                        buffer.SwitchMode ModeKind.Normal ModeArgument.None |> ignore
+                        let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Normal Command" LinkedUndoTransactionFlags.CanBeEmpty
+                        map.Add(buffer.TextBuffer, (buffer, transaction))
+
+                    // Actually run the KeyInput.  If processing the KeyInput value results
+                    // in an error then we should stop processing the macro
+                    match buffer.Process keyInput with
+                    | ProcessResult.Handled _ -> inner tail
+                    | ProcessResult.HandledNeedMoreInput -> inner tail
+                    | ProcessResult.NotHandled -> false
+                    | ProcessResult.Error -> false
+
+            inner (reg.KeyInputs) |> ignore
+        finally
+            map.Values |> Seq.iter (fun (buffer, transaction) ->
+                buffer.SwitchPreviousMode() |> ignore
+                transaction.Dispose()
+            )
+
 
     /// Run the global command.  
     member x.RunGlobal lineRange pattern matchPattern lineCommand =
@@ -1632,6 +1676,7 @@ type VimInterpreter
         | LineCommand.MoveTo (sourceLineRange, destLineRange, count) -> x.RunMoveTo sourceLineRange destLineRange count
         | LineCommand.NoHighlightSearch -> x.RunNoHighlightSearch()
         | LineCommand.Nop -> ()
+        | LineCommand.Normal command -> x.RunNormal command
         | LineCommand.Only -> x.RunOnly()
         | LineCommand.ParseError msg -> x.RunParseError msg
         | LineCommand.Print (lineRange, lineCommandFlags)-> x.RunPrint lineRange lineCommandFlags

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -808,11 +808,9 @@ type VimInterpreter
             if lineRange.Count > 1 then
                 _foldManager.CreateFold lineRange)
 
-    member x.RunNormal (command: string) =
+    member x.RunNormal input =
         let map = System.Collections.Generic.Dictionary<ITextBuffer, IVimBuffer*ILinkedUndoTransaction>();
         try
-            let reg = RegisterValue(command, OperationKind.CharacterWise)
-
             let rec inner list = 
                 match list with 
                 | [] -> 
@@ -843,7 +841,7 @@ type VimInterpreter
                     | ProcessResult.NotHandled -> false
                     | ProcessResult.Error -> false
 
-            inner (reg.KeyInputs) |> ignore
+            inner input |> ignore
         finally
             map.Values |> Seq.iter (fun (buffer, transaction) ->
                 buffer.SwitchPreviousMode() |> ignore

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1652,16 +1652,15 @@ type Parser
 
     /// Parse out the :help command
     member x.ParseNormal lineRange =
-        let chars = seq {
+        let inputs = seq {
             while not _tokenizer.IsAtEndOfLine && _tokenizer.CurrentChar = ' ' do
                 _tokenizer.MoveNextChar()
 
             while not _tokenizer.IsAtEndOfLine do
-                yield _tokenizer.CurrentChar
+                yield KeyInputUtil.CharToKeyInput _tokenizer.CurrentChar
                 _tokenizer.MoveNextChar()
         }
-        let command = chars |> System.String.Concat
-        LineCommand.Normal command
+        LineCommand.Normal (List.ofSeq inputs)
 
     member x.ParseHelp() =
         _tokenizer.MoveToEndOfLine()

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -153,6 +153,7 @@ type Parser
         ("make", "mak")
         ("marks", "")
         ("nohlsearch", "noh")
+        ("normal", "norm")
         ("only", "on")
         ("pwd", "pw")
         ("print", "p")
@@ -1650,6 +1651,18 @@ type Parser
         x.ParseGlobalCore lineRange (not hasBang)
 
     /// Parse out the :help command
+    member x.ParseNormal lineRange =
+        let chars = seq {
+            while not _tokenizer.IsAtEndOfLine && _tokenizer.CurrentChar = ' ' do
+                _tokenizer.MoveNextChar()
+
+            while not _tokenizer.IsAtEndOfLine do
+                yield _tokenizer.CurrentChar
+                _tokenizer.MoveNextChar()
+        }
+        let command = chars |> System.String.Concat
+        LineCommand.Normal command
+
     member x.ParseHelp() =
         _tokenizer.MoveToEndOfLine()
         LineCommand.Help
@@ -2067,6 +2080,7 @@ type Parser
                 | "fold" -> x.ParseFold lineRange
                 | "function" -> noRange x.ParseFunctionStart
                 | "global" -> x.ParseGlobal lineRange
+                | "normal" -> x.ParseNormal lineRange
                 | "help" -> noRange x.ParseHelp
                 | "history" -> noRange (fun () -> x.ParseHistory())
                 | "if" -> noRange x.ParseIfStart

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -1757,6 +1757,31 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
+            /// Test out the :normal command with delete line (dd) and put (p) key strokes
+            /// </summary>
+            [Fact]
+            public void Normal_DeletePut()
+            {
+                Create("cat", "dog", "fish");
+                ParseAndRun("norm ddp");
+                Assert.Equal("dog", _textBuffer.GetLine(0).GetText());
+                Assert.Equal("cat", _textBuffer.GetLine(1).GetText());
+                Assert.Equal("fish", _textBuffer.GetLine(2).GetText());
+
+            }
+
+            /// <summary>
+            /// Test out the :normal command with remove (x) with extra leading spaces
+            /// </summary>
+            [Fact]
+            public void Normal_RemoveWithSpaces()
+            {
+                Create("ccat");
+                ParseAndRun("norm  x");
+                Assert.Equal("cat", _textBuffer.GetLine(0).GetText());
+            }
+
+            /// <summary>
             /// Can't get the range for a mark that doesn't exist
             /// </summary>
             [Fact]


### PR DESCRIPTION
Implementing feature request #1678.

I'm not sure if the way I converted a string into a KeyInput list would be the right one (I used RegisterValue class for doing so).