### PR TITLE
Clearing modeSwitchMap after all buffers had its modes reverted

### DIFF
--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -849,6 +849,7 @@ type VimInterpreter
                 modeSwitchMap.Values |> Seq.iter (fun buffer ->
                     buffer.SwitchPreviousMode() |> ignore
                 )
+                modeSwitchMap.Clear()
 
             match x.GetLineRange lineRange  with
             | None ->


### PR DESCRIPTION
Sorry: after you merged my PR #1695, I realized that `modeSwitchMap` should be clear after modes are reverted, as the flow for switching modes and reverting them might occur more than once in case :normal command is used with line range.

Although I hadn't experienced any issues because of that, I think it is a good idea doing so.