### PR TITLE
Make ParseStringConstant able to parse \" and key sequences

### DIFF
--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -32,6 +32,12 @@ module ParseResultUtil =
         | ParseResult.Failed msg -> LineCommand.ParseError msg
         | ParseResult.Succeeded lineCommand -> lineCommand
 
+[<RequireQualifiedAccess>]
+type StringConstantState =
+    | Normal
+    | Escape
+    | Special of System.Text.StringBuilder
+
 type ParseResultBuilder
     (
         _errorMessage : string
@@ -1427,6 +1433,7 @@ type Parser
         let command = x.ParseRestOfLine()
         LineCommand.ShellCommand command
 
+
     /// Parse out a string constant from the token stream.  Loads of special characters are
     /// possible here.  A complete list is available at :help expr-string
     member x.ParseStringConstant() = 
@@ -1435,34 +1442,73 @@ type Parser
 
         let builder = System.Text.StringBuilder()
         let moveNextChar () = _tokenizer.MoveNextChar()
-        let rec inner afterEscape = 
+
+        let rollbackSpecial (specialSequence: System.Text.StringBuilder) =
+            for idx = 0 to specialSequence.Length - 1 do
+                builder.AppendChar(specialSequence.Chars(idx))
+
+        let finish () =
+            builder.ToString()
+            |> VariableValue.String
+            |> Expression.ConstantValue
+            |> ParseResult.Succeeded
+
+        let rec inner state = 
             if _tokenizer.IsAtEndOfLine then
                 ParseResult.Failed Resources.Parser_MissingQuote
             else
                 let c = _tokenizer.CurrentChar
                 moveNextChar()
-                if afterEscape then
+                match state with
+                | StringConstantState.Special(specialSequence) ->
                     match c with
-                    | 't' -> builder.AppendChar '\t'
-                    | 'b' -> builder.AppendChar '\b'
-                    | 'f' -> builder.AppendChar '\f'
-                    | 'n' -> builder.AppendChar '\n'
-                    | 'r' -> builder.AppendChar '\r'
-                    | '\\' -> builder.AppendChar '\\'
-                    | _ -> builder.AppendChar c
-                    inner false
-                elif c = '\\' then
-                    inner true
-                elif c = '"' then
-                    builder.ToString()
-                    |> VariableValue.String
-                    |> Expression.ConstantValue
-                    |> ParseResult.Succeeded
-                else
-                    builder.AppendChar c
-                    inner false
+                    | '>' ->
+                        specialSequence.AppendChar('>')
+                        match KeyNotationUtil.TryStringToKeyInput(specialSequence.ToString()) with
+                        | Some(key) ->
+                            match key.RawChar with
+                            | Some(char) -> builder.AppendChar(char)
+                            | None -> rollbackSpecial specialSequence
+                        | None -> rollbackSpecial specialSequence
+                        inner StringConstantState.Normal
+                    | '"' ->
+                        rollbackSpecial specialSequence
+                        finish ()
 
-        inner false
+                    | '\\' ->
+                        rollbackSpecial specialSequence
+                        inner StringConstantState.Escape
+                        
+                    | _ ->
+                        specialSequence.AppendChar(c)
+                        inner (StringConstantState.Special(specialSequence))
+
+
+                | StringConstantState.Escape ->
+                    if c = '<' then
+                        inner (StringConstantState.Special(System.Text.StringBuilder("<")))
+                    else
+                        match c with
+                        | 't' -> builder.AppendChar '\t'
+                        | 'b' -> builder.AppendChar '\b'
+                        | 'f' -> builder.AppendChar '\f'
+                        | 'n' -> builder.AppendChar '\n'
+                        | 'r' -> builder.AppendChar '\r'
+                        | '"' -> builder.AppendChar '"'
+                        | '\\' -> builder.AppendChar '\\'
+                        | _ -> builder.AppendChar c
+                        inner StringConstantState.Normal
+
+                | StringConstantState.Normal ->
+                    if c = '\\' then
+                        inner StringConstantState.Escape
+                    elif c = '"' then
+                        finish()
+                    else
+                        builder.AppendChar c
+                        inner StringConstantState.Normal
+
+        inner StringConstantState.Normal
 
     /// Parse out a string literal from the token stream.  The only special character here is
     /// an escaped '.  Everything else is taken literally 

--- a/Test/VimCoreTest/ParserTest.cs
+++ b/Test/VimCoreTest/ParserTest.cs
@@ -753,6 +753,30 @@ let x = 42
             {
                 Assert.Equal("\t", ParseStringConstant(@"""\t"""));
             }
+
+            [Fact]
+            public void QuoteEscape()
+            {
+                Assert.Equal("\"", ParseStringConstant(@"""\"""""));
+            }
+
+            [Fact]
+            public void EscChar()
+            {
+                Assert.Equal(string.Format("{0}", CharCodes.Escape), ParseStringConstant(@"""\<ESC>"""));
+            }
+
+            [Fact]
+            public void UncompleteKeySequence()
+            {
+                Assert.Equal("<ESC", ParseStringConstant(@"""\<ESC"""));
+            }
+
+            [Fact]
+            public void UncompleteAndValueKeySequence()
+            {
+                Assert.Equal(string.Format("<ESC{0}", CharCodes.Escape), ParseStringConstant(@"""\<ESC\<ESC>"""));
+            }
         }
 
         public sealed class SubstituteTest : ParserTest


### PR DESCRIPTION
Vim double-quoted string parser has feature to parse things like "<ESC>" to escape char, "<CR>" to return char, and so on.

This functionality was is currently not present in VsVim. They are useful together with global/execute/normal commands. For instance:

:g/regexToComment/exe "norm I<!--\\\<ESC>A-->"

While implementing this feature, I also noted that the parser was not handling quote escape "\"". I've also implemented that one.
