### PR TITLE
Fix normal command used with double quote character

### DIFF
--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1653,6 +1653,7 @@ type Parser
     /// Parse out the :normal command
     member x.ParseNormal lineRange =
         x.SkipBlanks ()
+        _tokenizer.TokenizerFlags <- _tokenizer.TokenizerFlags ||| TokenizerFlags.AllowDoubleQuote
         let inputs = seq {
             while not _tokenizer.IsAtEndOfLine do
                 yield KeyInputUtil.CharToKeyInput _tokenizer.CurrentChar

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -1786,6 +1786,17 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
+            /// Test out the :global command delete until double quote character
+            /// </summary>
+            [Fact]
+            public void Global_Normal_DeleteUntilDoubleQuote()
+            {
+                Create("cat\"dog");
+                ParseAndRun("norm df\"");
+                Assert.Equal("dog", _textBuffer.GetLine(0).GetText());
+            }
+
+            /// <summary>
             /// Test out the :global command with normal command deleting after search pattern
             /// </summary>
             [Fact]


### PR DESCRIPTION
I have just found a bug on normal command implementation: it was not working if expression contained double quote character. For instance:

    :normal df"