### PR TITLE
fix #1714 <C-r><C-w> current word in status line

### DIFF
--- a/Src/VimCore/HistoryUtil.fsi
+++ b/Src/VimCore/HistoryUtil.fsi
@@ -6,7 +6,7 @@ namespace Vim
 type internal HistoryUtil = 
 
     /// Begin a history related operation
-    static member CreateHistorySession<'TData, 'TResult> : IHistoryClient<'TData, 'TResult> -> 'TData -> string -> IHistorySession<'TData, 'TResult>
+    static member CreateHistorySession<'TData, 'TResult> : IHistoryClient<'TData, 'TResult> -> 'TData -> string -> IVimBuffer option -> IHistorySession<'TData, 'TResult>
 
     /// The set of KeyInput values which history considers to be a valid command
     static member CommandNames : KeyInput list

--- a/Src/VimCore/IncrementalSearch.fs
+++ b/Src/VimCore/IncrementalSearch.fs
@@ -133,7 +133,7 @@ type internal IncrementalSearch
                 member this.Cancelled (data : ITrackingPoint) = runActive (fun session -> x.RunCancelled session) ()
             }
 
-        let historySession = HistoryUtil.CreateHistorySession historyClient startPoint StringUtil.Empty
+        let historySession = HistoryUtil.CreateHistorySession historyClient startPoint StringUtil.Empty None
         _incrementalSearchSession <- Some (IncrementalSearchSession(key, historySession, incrementalSearchData))
 
         // Raise the event

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -321,7 +321,6 @@ type internal InsertUtil
         x.DeleteRight(s.Length - 1) |> ignore
         x.Insert s
 
-
     member x.InsertCharacterCore msg lineNumber =
         match SnapshotUtil.TryGetPointInLine _textBuffer.CurrentSnapshot lineNumber x.CaretColumn.Column with
         | None -> 

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -125,7 +125,7 @@ type internal CommandMode
                 member this.Completed _ command = completed command
                 member this.Cancelled _ = cancelled ()
             }
-        HistoryUtil.CreateHistorySession historyClient 0 _command
+        HistoryUtil.CreateHistorySession historyClient 0 _command (Some _buffer)
 
     member x.OnEnter arg = 
         let historySession = x.CreateHistorySession()

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -618,6 +618,36 @@ namespace Vim.UnitTest
                 Assert.Equal("htest", _commandMode.Command);
                 Assert.False(_commandMode.InPasteWait);
             }
+
+            [Fact]
+            public void InsertWordUnderCursor()
+            {
+                // :help c_CTRL-R_CTRL-W
+                Create("dog-bark", "cat-meow", "bear-growl");
+                _textView.MoveCaretToLine(1);
+                var initialCaret = _textView.Caret;
+                var initialSelection = _textView.Selection;
+                _vimBuffer.ProcessNotation(":<C-r><C-w>");
+                Assert.Equal("cat", _commandMode.Command);
+                Assert.False(_commandMode.InPasteWait);
+                Assert.Equal(initialCaret, _textView.Caret);
+                Assert.Equal(initialSelection, _textView.Selection);
+            }
+
+            [Fact]
+            public void InsertAllWordUnderCursor()
+            {
+                // :help c_CTRL-R_CTRL-A
+                Create("dog-bark", "cat-meow", "bear-growl");
+                _textView.MoveCaretToLine(1);
+                var initialCaret = _textView.Caret;
+                var initialSelection = _textView.Selection;
+                _vimBuffer.ProcessNotation(":<C-r><C-a>");
+                Assert.Equal("cat-meow", _commandMode.Command);
+                Assert.False(_commandMode.InPasteWait);
+                Assert.Equal(initialCaret, _textView.Caret);
+                Assert.Equal(initialSelection, _textView.Selection);
+            }
         }
 
         public abstract class SubstituteTest : CommandModeIntegrationTest

--- a/Test/VimCoreTest/HistorySessionTest.cs
+++ b/Test/VimCoreTest/HistorySessionTest.cs
@@ -63,7 +63,7 @@ namespace Vim.UnitTest
         public HistorySessionTest()
         {
             _client = new Client() { HistoryList = new HistoryList(), RegisterMap = Vim.RegisterMap };
-            _historySession = HistoryUtil.CreateHistorySession(_client, 0, "");
+            _historySession = HistoryUtil.CreateHistorySession(_client, 0, "", null);
             _bindData = _historySession.CreateBindDataStorage().CreateBindData();
         }
 
@@ -121,6 +121,14 @@ namespace Vim.UnitTest
                 ProcessNotation("<CR>");
                 Assert.False(_historySession.InPasteWait);
                 Assert.Equal("cat", _client.ProcessValue.Item2);
+            }
+
+            [Fact]
+            public void CantUsePasteSpecialFirst()
+            {
+                ProcessNotation("cat<C-w>");
+                Assert.False(_historySession.InPasteWait);
+                Assert.Equal("", _client.ProcessValue.Item2);
             }
         }
 


### PR DESCRIPTION
HistoryUtil -
move ProcessCore function into Process
move the _inPasteWait in Process to the | None condition
add ProcessPasteSpecial to handle <C-r><C-w> and <C-r><C-a>
add IVimBuffer argument to CreateHistorySession so the current word can be calculated

Vim behavior - when in Command mode with text ":cat" then <C-w> the text is removed to end up with ":"