### PR TITLE
Vim Disable, allow all fall back actions including key chords

### DIFF
--- a/Src/VsVimShared/Implementation/Misc/FallbackKeyProcessor.cs
+++ b/Src/VsVimShared/Implementation/Misc/FallbackKeyProcessor.cs
@@ -22,8 +22,8 @@ namespace Vim.VisualStudio.Implementation.Misc
         /// </summary>
         internal struct KeyCharModifier
         {
-            private char _char;
-            private VimKeyModifiers _keyModifiers;
+            private readonly char _char;
+            private readonly VimKeyModifiers _keyModifiers;
 
             internal KeyCharModifier(char c, VimKeyModifiers keyModifiers)
             {
@@ -45,9 +45,9 @@ namespace Vim.VisualStudio.Implementation.Misc
         /// </summary>
         internal struct FallbackCommand
         {
-            private ScopeKind _scopeKind;
-            private List<KeyCharModifier> _keyBinding;
-            private CommandId _command;
+            private readonly ScopeKind _scopeKind;
+            private readonly List<KeyCharModifier> _keyBinding;
+            private readonly CommandId _command;
 
             internal FallbackCommand(ScopeKind scopeKind, KeyBinding keyBinding, CommandId command)
             {


### PR DESCRIPTION
Fix #1654
Fix #1713

VsVimShared/FallbackKeyProcessor

Handle Shift+C Shift+P as capital C or P:
* GetKeyBinding does not use the AggregateKeyInput which trims off the
* ModifierKeys, it uses the new struct of Char * VimKeyModifiers.
* TryConvertLettersToKeyInput uses the KeyInputUtil methods CharToKeyInput
* and ChangeKeyModifiersDangerous. ApplyKeyModifiersToChar is removing the
* VimKeyModifiers.Shift which causes issues for the TryProcess.

Allow fallback Key Chords when VsVim is disabled:
* Visual Studio allows Key Chord length up to 2, now the fallback can
* support this.
* FallbackCommand has Scope for sorting purposes
* FallbackCommandList is changed to ILookup<char, FallbackCommand>
* All RemovedBindings are added to the FallbackCommandList
* TryParse supports Key Chords of 1 or 2 length
* TryParse uses keyInput.Char and keyInput.KeyModifiers as match criteria.
* When using the standard == operator, this also compares the VimKey which
* is not necessary.

Manual Tests:
type all upper and lower case letters
Ctrl+A (select all); Ctrl+U (lower case selection); Ctrl+Shift+U; (upper
case selection); Ctrl+Z (undo)
Ctrl+M, Ctrl+A (collapse all outlining); Ctrl+M, Ctrl+O (collapse to
definitions); Ctrl+M, Ctrl+X (expand all outlining)
Ctrl+A (select all); Ctrl+K, Ctrl+C (comment selection); Ctrl+K, Ctrl+U
(uncomment selection)
Ctrl+R, Ctrl+W (show whitespace toggle ON); Ctrl+R, Ctrl+W (show
whitespace toggle OFF)
(from C# Interactive window with VsVim enabled) type a space