### PR TITLE
fix #1628 Mouse Visual Selection causes flicker

### DIFF
--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -1501,6 +1501,9 @@ module TextViewUtil =
     let GetCaretPointAndLine textView = (GetCaretPoint textView),(GetCaretLine textView)
 
     /// Get the set of ITextViewLines for the ITextView
+    ///
+    /// Be aware when using GetTextViewLineContainingYCoordinate, may need to add the
+    /// _textView.ViewportTop to the y coordinate
     let GetTextViewLines (textView : ITextView) =
         try
             textView.TextViewLines |> Some

--- a/Src/VimCore/SelectionChangeTracker.fs
+++ b/Src/VimCore/SelectionChangeTracker.fs
@@ -213,7 +213,7 @@ type internal SelectionChangeTracker
             | Some textViewLines, Some wpfPoint ->
                 let x = wpfPoint.X
                 let y = wpfPoint.Y
-                let textViewLine = textViewLines.GetTextViewLineContainingYCoordinate y
+                let textViewLine = textViewLines.GetTextViewLineContainingYCoordinate (y + _textView.ViewportTop)
                 if textViewLine <> null then
                     let point = textViewLine.GetBufferPositionFromXCoordinate x 
                     VimTrace.TraceInfo("Caret {0} Point = {1}", x, if point.HasValue then point.Value.GetChar() else ' ')


### PR DESCRIPTION
no tests created because SelectionChangeTracker is not under test.
manual test notes added to #1628.
Reviewed other uses of `EditorUtil.GetTextViewLines`, they either have the correct `(y +_textView.ViewportTop)` or do not call the `GetTextViewLineContainingYCoordinate` method.