### PR TITLE
fix #1665 High-Contrast command line cursor

### DIFF
--- a/Src/VimWpf/Implementation/CharDisplay/CharDisplayTaggerSource.cs
+++ b/Src/VimWpf/Implementation/CharDisplay/CharDisplayTaggerSource.cs
@@ -107,6 +107,7 @@ namespace Vim.UI.Wpf.Implementation.CharDisplay
                     textBox.BorderThickness = new Thickness(0);
                     textBox.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
                     textBox.Foreground = _foregroundBrush;
+                    textBox.CaretBrush = _foregroundBrush;
                     textBox.FontWeight = FontWeights.Bold;
                     adornment = textBox;
                     _adornmentCache.Insert(cacheIndex, new AdornmentData(position, adornment));

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml
@@ -40,6 +40,7 @@
             Visibility="{Binding Path=IsRecording}"
             Foreground="{Binding Path=TextForeground}"
             Background="{Binding Path=TextBackground}"
+            CaretBrush="{Binding Path=TextForeground}"
             />
 
         <ScrollViewer 
@@ -56,6 +57,7 @@
                 FontSize="{Binding Path=TextFontSize}"
                 Foreground="{Binding Path=TextForeground}"
                 Background="{Binding Path=TextBackground}"
+                CaretBrush="{Binding Path=TextForeground}"
                 />
         </ScrollViewer>
     </Grid>


### PR DESCRIPTION
Set the CommandMargin CaretBrush to the TextForeground. This makes the cursor visible when a High Contrast Theme is applied. Also added to the CharDisplayTaggerSource.

Tested with "High Contrast #1" (foregound: yellow background: black)
 and "High Contrast White" (foreground: black background: white), both worked fine.