### PR TITLE
add Order attribute to CommandMarginProvider

### DIFF
--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginProvider.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginProvider.cs
@@ -19,6 +19,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
     [MarginContainer(PredefinedMarginNames.Bottom)]
     [ContentType(VimConstants.ContentType)]
     [Name(CommandMargin.Name)]
+    [Order(After = "Wpf Horizontal Scrollbar")]
     [TextViewRole(PredefinedTextViewRoles.Editable)]
     internal sealed class CommandMarginProvider : IWpfTextViewMarginProvider
     {


### PR DESCRIPTION
Was not able to reproduce the issue from the images. The command
margin continued to appear after the horizontal scrollbar with this
change.