### PR TITLE
Don't track `virtualedit` on arbitrary mouse position changes

### DIFF
--- a/Src/VimCore/SelectionChangeTracker.fs
+++ b/Src/VimCore/SelectionChangeTracker.fs
@@ -89,8 +89,8 @@ type internal SelectionChangeTracker
         // Don't update the caret if a selection is occuring.  This could be a user double clicking, 
         // dragging, etc ...  Don't want to update the caret in that case, let the mode change handle
         // that.
-        if not _vimBuffer.IsProcessingInput && _vimBuffer.ModeKind <> ModeKind.ExternalEdit && _vimBuffer.ModeKind <> ModeKind.Disabled && _textView.Selection.StreamSelectionSpan.Length <= 1 then
-            _commonOperations.EnsureAtCaret (ViewFlags.ScrollOffset ||| ViewFlags.VirtualEdit)
+        if not _vimBuffer.IsProcessingInput then
+            _commonOperations.EnsureAtCaret ViewFlags.ScrollOffset
 
     member x.OnBufferClosed() = 
         _bag.DisposeAll()

--- a/Test/VimCoreTest/DisabledModeTest.cs
+++ b/Test/VimCoreTest/DisabledModeTest.cs
@@ -166,9 +166,8 @@ namespace Vim.UnitTest
                 _vimBuffer1.TextView.MoveCaretTo(3);
                 Assert.Equal(3, _vimBuffer1.TextView.GetCaretPoint().Position);
                 _vimBuffer1.SwitchMode(ModeKind.Normal, ModeArgument.None);
-                _vimBuffer1.TextView.MoveCaretTo(3);
+                _vimBuffer1.TextView.MoveCaretTo(2);
                 Assert.Equal(2, _vimBuffer1.TextView.GetCaretPoint().Position);
-
             }
         }
     }

--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -2590,7 +2590,7 @@ namespace Vim.UnitTest
                     _localSettings.ExpandTab = true;
                     _vimBuffer.ProcessNotation("<Tab> <Esc>");
                     _textView.MoveCaretTo(0);
-                    _textView.MoveCaretTo(5);
+                    _textView.MoveCaretTo(4);
                     _vimBuffer.ProcessNotation("i<BS><BS>");
                     Assert.Equal(" ", _textBuffer.GetLine(0).GetText());
                 }

--- a/Test/VimCoreTest/InsertUtilTest.cs
+++ b/Test/VimCoreTest/InsertUtilTest.cs
@@ -66,7 +66,7 @@ namespace Vim.UnitTest
                 public void AtEndOfBuffer()
                 {
                     Create("cat");
-                    _textView.MoveCaretTo(3);
+                    _textView.MoveCaretTo(2);
                     _insertUtilRaw.ApplyTextChange(TextChange.NewDeleteRight(4), addNewLines: false);
                     Assert.Equal("ca", _textBuffer.GetLine(0).GetText());
                     Assert.Equal(2, _textView.GetCaretPoint().Position);
@@ -261,7 +261,7 @@ namespace Vim.UnitTest
             {
                 Create("dog bear cat");
                 _globalSettings.Backspace = "start";
-                _textView.MoveCaretTo(12);
+                _textView.MoveCaretTo(11);
                 _insertUtilRaw.DeleteLineBeforeCursor();
                 Assert.Equal("t", _textView.GetLine(0).GetText());
                 Assert.Equal(0, _textView.GetCaretPoint().Position);
@@ -382,12 +382,12 @@ namespace Vim.UnitTest
             {
                 Create("", "dog");
                 _vimBuffer.LocalSettings.ShiftWidth = 4;
-                _textView.MoveCaretTo(0, 8);
+                _textView.MoveCaretTo(0, virtualSpaces: 8);
 
                 _insertUtilRaw.ShiftLineLeft();
 
                 Assert.Equal("    ", _textView.GetLine(0).GetText());
-                Assert.Equal(3, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(4, _insertUtilRaw.CaretColumn.Column);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
@@ -427,7 +427,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineRight();
 
                 Assert.Equal("            ", _textView.GetLine(0).GetText());
-                Assert.Equal(11, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(12, _insertUtilRaw.CaretColumn.Column);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
@@ -443,11 +443,14 @@ namespace Vim.UnitTest
                 Create("    ", "dog");
                 _vimBuffer.LocalSettings.ShiftWidth = 4;
                 _vimBuffer.LocalSettings.ExpandTab = true;
-                _textView.MoveCaretTo(4, 4);
+                _textView.MoveCaretTo(3, virtualSpaces: 4);
 
                 _insertUtilRaw.ShiftLineRight();
 
-                Assert.Equal("        ", _textView.GetLine(0).GetText());
+                var indent = "        ";
+                var text = _textView.GetLine(0).GetText();
+                Assert.Equal(indent.Length, text.Length);
+                Assert.Equal(indent, text);
                 Assert.Equal(8, _insertUtilRaw.CaretColumn.Column);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
@@ -464,12 +467,12 @@ namespace Vim.UnitTest
             {
                 Create("", "dog");
                 _vimBuffer.LocalSettings.ShiftWidth = 4;
-                _textView.MoveCaretTo(0, 8);
+                _textView.MoveCaretTo(0, virtualSpaces: 8);
 
                 _insertUtilRaw.ShiftLineRight();
 
                 Assert.Equal("\t    ", _textView.GetLine(0).GetText());
-                Assert.Equal(4, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(5, _insertUtilRaw.CaretColumn.Column);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);

--- a/Test/VsVimSharedTest/VsIntegrationTest.cs
+++ b/Test/VsVimSharedTest/VsIntegrationTest.cs
@@ -390,10 +390,10 @@ namespace Vim.VisualStudio.UnitTest
                     Create("hello();", "world");
                     _vimBuffer.SwitchMode(ModeKind.Normal, ModeArgument.None);
                     _textView.MoveCaretTo(8);
-                    for (int i = 0; i < 7; i++)
+                    for (int i = 0; i < 8; i++)
                     {
                         _vsSimulation.Run(VimKey.Back);
-                        Assert.Equal(7 - (i + 1), _textView.GetCaretPoint().Position);
+                        Assert.Equal(8 - (i + 1), _textView.GetCaretPoint().Position);
                     }
                 }
 


### PR DESCRIPTION
This essentially reverts a lot of the behavior in 4279e17676102eba70d182ab8bb2924b8534b58d.

When this change first came through I thought it was a good idea.  It seemed natural to properly enforce the `virtualedit` setting on any caret position change, not just when VsVim was processing key strokes.

Since this has shipped though customers have been sending a swarm of scenarios where this change broke behavior:

- #1789
- #1791
- #1792
- #1801

Fixing all these bugs is beginning to feel like a whack a mole problem.  There is simply no way to generalize the fix such that it excludes all of the places customers expect selection to hit EOL irrespective of the `virtualedit` setting.  As such going to revert back to the old behavior of not checking that on arbitrary mouse position changes.