### PR TITLE
Ability to set mode through command window

### DIFF
--- a/Src/VsVim/PkgCmdID.cs
+++ b/Src/VsVim/PkgCmdID.cs
@@ -13,5 +13,6 @@ namespace Vim.VisualStudio
         internal const uint ToggleEnabled = 0x103;
         internal const uint SetEnabled = 0x104;
         internal const uint SetDisabled = 0x105;
+        internal const uint SetMode = 0x106;
     };
 }

--- a/Src/VsVim/VsVim.vsct
+++ b/Src/VsVim/VsVim.vsct
@@ -123,6 +123,16 @@
         </Strings>
       </Button>
    
+      <Button guid="guidVsVimCmdSet" id="cmdidVsVimSetMode" priority="0x0100" type="Button">
+        <Parent guid="guidVsVimCmdSet" id="VsVimMenuGroup" />
+        <CommandFlag>AllowParams</CommandFlag>
+        <Strings>
+          <CommandName>cmdidVsVimSetMode</CommandName>
+          <ButtonText>VsVim Set mode</ButtonText>
+          <CanonicalName>.VsVim.SetMode</CanonicalName>
+          <LocCanonicalName>.VsVim.SetMode</LocCanonicalName>
+        </Strings>
+      </Button>
     </Buttons>
 
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
@@ -151,6 +161,7 @@
       <IDSymbol name="cmdidVsVimToggleEnabled" value="0x0103" />
       <IDSymbol name="cmdidVsVimSetEnabled" value="0x0104" />
       <IDSymbol name="cmdidVsVimSetDisabled" value="0x0105" />
+      <IDSymbol name="cmdidVsVimSetMode" value="0x0106" />
     </GuidSymbol>
     
     <GuidSymbol name="guidImages" value="{b83708de-165c-4166-bc93-05f4efaebdf2}">

--- a/Src/VsVim/VsVimPackage.cs
+++ b/Src/VsVim/VsVimPackage.cs
@@ -73,6 +73,9 @@ namespace Vim.VisualStudio
             {
                 keyBindingService.DumpKeyboard(streamWriter);
             }
+
+            var message = string.Format("Keyboard data dumped to: {0}", filePath);
+            PrintToCommandWindow(message);
         }
 
         /// <summary>
@@ -141,6 +144,17 @@ namespace Vim.VisualStudio
         private void ToggleEnabled()
         {
             _vim.IsDisabled = !_vim.IsDisabled;
+        }
+
+        private void PrintToCommandWindow(string text)
+        {
+            var commandWindow = (IVsCommandWindow)GetService(typeof(SVsCommandWindow));
+            if (commandWindow == null)
+            {
+                return;
+            }
+
+            commandWindow.Print(text);
         }
 
         #region IOleCommandTarget

--- a/Src/VsVimShared/IVsAdapter.cs
+++ b/Src/VsVimShared/IVsAdapter.cs
@@ -118,6 +118,12 @@ namespace Vim.VisualStudio
         Result<ITextBuffer> GetTextBufferForDocCookie(uint cookie);
 
         /// <summary>
+        /// Get the <see cref="IWpfTextView"/>  which has focus.
+        /// </summary>
+        /// <returns></returns>
+        bool TryGetActiveTextView(out IWpfTextView textView);
+
+        /// <summary>
         /// Open a file with the specified name in Visual Studio
         /// </summary>
         void OpenFile(string filePath);

--- a/Src/VsVimShared/Implementation/Misc/VsAdapter.cs
+++ b/Src/VsVimShared/Implementation/Misc/VsAdapter.cs
@@ -461,6 +461,27 @@ namespace Vim.VisualStudio.Implementation.Misc
             }
         }
 
+        private bool TryGetActiveTextView(out IWpfTextView textView)
+        {
+            var textManager = _serviceProvider.GetService<SVsTextManager, IVsTextManager2>();
+            if (textManager == null)
+            {
+                textView = null;
+                return false;
+            }
+
+            IVsTextView vsTextView;
+            var hr = textManager.GetActiveView2(fMustHaveFocus: 0, pBuffer: null, grfIncludeViewFrameType: (uint)_VIEWFRAMETYPE.vftCodeWindow, ppView: out vsTextView);
+            if (ErrorHandler.Failed(hr))
+            {
+                textView = null;
+                return false;
+            }
+
+            textView = _editorAdaptersFactoryService.GetWpfTextView(vsTextView);
+            return textView != null;
+        }
+
         #region IVsAdapter
 
         bool IVsAdapter.InAutomationFunction
@@ -561,6 +582,11 @@ namespace Vim.VisualStudio.Implementation.Misc
         void IVsAdapter.OpenFile(string filePath)
         {
             OpenFile(filePath);
+        }
+
+        bool IVsAdapter.TryGetActiveTextView(out IWpfTextView textView)
+        {
+            return TryGetActiveTextView(out textView);
         }
 
         #endregion


### PR DESCRIPTION
This is available from the command window.  It takes a mode name and will switch the active, or previously active, buffer to that mode.  To get the list of modes just invoke the command without arguments.

Example:

> VsVim.SetMode Insert

