### PR TITLE
Fixing bug #1837. When you give the 'gg' command a count greater than…

### DIFF
--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -2271,7 +2271,7 @@ type internal MotionUtil
 
         let endLine = 
             match numberOpt with
-            | Some number ->  SnapshotUtil.GetLineOrFirst x.CurrentSnapshot (Util.VimLineToTssLine number)
+            | Some number ->  SnapshotUtil.GetLineOrLast x.CurrentSnapshot (Util.VimLineToTssLine number)
             | None -> SnapshotUtil.GetFirstLine x.CurrentSnapshot
         x.LineToLineFirstNonBlankMotion x.CaretLine endLine
 

--- a/Test/VimCoreTest/MotionUtilTest.cs
+++ b/Test/VimCoreTest/MotionUtilTest.cs
@@ -2375,8 +2375,9 @@ more";
             public void LineOrFirstToFirstNonBlank4()
             {
                 Create("foo", "  bar", "baz");
+                _textView.MoveCaretTo(_textBuffer.GetLine(1).Start);
                 var data = _motionUtil.LineOrFirstToFirstNonBlank(FSharpOption.Create(500));
-                Assert.Equal(_textBuffer.GetLineRange(0, 0).ExtentIncludingLineBreak, data.Span);
+                Assert.Equal(_textBuffer.GetLineRange(1, 2).ExtentIncludingLineBreak, data.Span);
                 Assert.True(data.IsForward);
                 Assert.True(data.MotionKind.IsLineWise);
                 Assert.Equal(0, data.CaretColumn.AsInLastLine().Item);


### PR DESCRIPTION
… the number of lines in the file, it now goes to the bottom of the file, just like in Vim