### PR TITLE
Don't dismiss completion in complex key mapping

### DIFF
--- a/Src/VsVimShared/Extensions.cs
+++ b/Src/VsVimShared/Extensions.cs
@@ -1147,6 +1147,25 @@ namespace Vim.VisualStudio
 
         #endregion
 
+        #region InsertCommand
+
+        public static InsertCommand.Insert AsInsert(this InsertCommand command)
+        {
+            return (InsertCommand.Insert)command;
+        }
+
+        public static bool IsInsert(this InsertCommand command, char c)
+        {
+            return IsInsert(command, c.ToString());
+        }
+
+        public static bool IsInsert(this InsertCommand command, string text)
+        {
+            return command.IsInsert && command.AsInsert().Item == text;
+        }
+
+        #endregion
+
         #region IEditorFormatMap
 
         public static Color GetBackgroundColor(this IEditorFormatMap map, string name, Color defaultColor)

--- a/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
+++ b/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
@@ -159,7 +159,6 @@ namespace Vim.VisualStudio.Implementation.Misc
             KeyInput mapped;
             if (!TryGetSingleMapping(keyInput, out mapped))
             {
-                _broker.DismissDisplayWindows();
                 return _vimBuffer.Process(keyInput).IsAnyHandled;
             }
 


### PR DESCRIPTION
The IOleCommandTarget code has special casing around characters that are
lilkey to be involved in intellisense handling.  For example it will
intercept arrow keys and send it them directly to the next
IOleCommandTarget when a completion is active.  The logic being that VS
is better at handling that key than VsVim would.

This code though doesn't handled the key which was typed but instead the
key which would be processed after key mappings were considered.  If the
user types 'j' and that happens to make to Left arrow then Left arrow is
what needs to be considered.

In cases of complex key mappings the code was simply dismissing
completion and passing the key to VsVim.  That code is really old and
pre-dates a lot of the more recent changes I've made to this code path.
The better behavior in that case is to pass along the key to VsVim.

closes #1855