### PR TITLE
Attempt work around for composition error

### DIFF
--- a/Src/VsVimShared/ITelemetry.cs
+++ b/Src/VsVimShared/ITelemetry.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using EnvDTE;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,5 +10,10 @@ namespace Vim.VisualStudio
     public interface ITelemetry
     {
         void WriteEvent(string eventName);
+    }
+
+    public interface ITelemetryProvider
+    {
+        ITelemetry GetOrCreate(IVimApplicationSettings vimApplicationSettings, _DTE dte);
     }
 }

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -197,7 +197,7 @@ namespace Vim.VisualStudio
             IVimApplicationSettings vimApplicationSettings,
             IExtensionAdapterBroker extensionAdapterBroker,
             SVsServiceProvider serviceProvider,
-            ITelemetry telemetry)
+            ITelemetryProvider telemetryProvider)
             : base(textBufferFactoryService, textEditorFactoryService, textDocumentFactoryService, editorOperationsFactoryService)
         {
             _vsAdapter = adapter;
@@ -214,7 +214,7 @@ namespace Vim.VisualStudio
             uint cookie;
             _vsMonitorSelection.AdviseSelectionEvents(this, out cookie);
 
-            InitTelemetry(telemetry, vimApplicationSettings);
+            InitTelemetry(telemetryProvider.GetOrCreate(vimApplicationSettings, _dte), vimApplicationSettings);
         }
 
         private static void InitTelemetry(ITelemetry telemetry, IVimApplicationSettings vimApplicationSettings)

--- a/Test/VsVimSharedTest/VsVimHostTest.cs
+++ b/Test/VsVimSharedTest/VsVimHostTest.cs
@@ -55,6 +55,9 @@ namespace Vim.VisualStudio.UnitTest
             uint cookie = 42;
             vsMonitorSelection.Setup(x => x.AdviseSelectionEvents(It.IsAny<IVsSelectionEvents>(), out cookie)).Returns(VSConstants.S_OK);
 
+            var telemetryProvider = _factory.Create<ITelemetryProvider>(MockBehavior.Loose);
+            telemetryProvider.Setup(x => x.GetOrCreate(_vimApplicationSettings.Object, _dte.Object)).Returns(_factory.Create<ITelemetry>(MockBehavior.Loose).Object);
+
             var sp = _factory.Create<SVsServiceProvider>();
             sp.Setup(x => x.GetService(typeof(_DTE))).Returns(_dte.Object);
             sp.Setup(x => x.GetService(typeof(SVsUIShell))).Returns(_shell.Object);
@@ -74,7 +77,7 @@ namespace Vim.VisualStudio.UnitTest
                 _vimApplicationSettings.Object,
                 _extensionAdapterBroker.Object,
                 sp.Object,
-                _factory.Create<ITelemetry>(MockBehavior.Loose).Object);
+                telemetryProvider.Object);
             _host = _hostRaw;
         }
 


### PR DESCRIPTION
One customer is reporting a reliable composition error using latest
VsVim.  The root cause is a cycle issue with ITelemetry.  That is odd as
it doesn't show up for other users, but it is happening reliably.  Best
I can theorize is another extension on customer machine is causing a
slight change to ordering here that reveals a problem.

Going on this I'm going to try and work around this by breaking up the
dependencies a bit and turning it into a delayed create.

#1876