### PR TITLE
Proof of concept 'l' over surrogate pairs

### DIFF
--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -446,8 +446,11 @@ type internal CommonOperations
 
         /// Move the caret right.  Don't go off the end of the line
         let moveRight () =
-            if x.CaretPoint.Position < x.CaretLine.End.Position then
-                let point = SnapshotPointUtil.AddOne x.CaretPoint
+            let point =
+                x.CaretPoint
+                |> SnapshotPointUtil.AddOne
+                |> (fun y -> if Char.IsSurrogate (y.GetChar()) then SnapshotPointUtil.AddOne y else y)
+            if point.Position <= x.CaretLine.End.Position then
                 x.MoveCaretToPoint point ViewFlags.Standard
                 true
             else


### PR DESCRIPTION
There is an issue where if you try to navigate over a unicode surrogate
pair, you cannot move right over it. If you are before it, you will end up
in the character and get rounded back down to where you were. If you are
on the left of the character and try to move back to the right over the
character, you will end up in the character and get rounded back to the
intended position.

This fixes that in the case of insert mode, but the code is ugly and the
seam that I'm explointing isn't the most elegant. This serves as a good
base to start the fix for both normal and insert mode.

This is a partial fix to [issue 1786](https://github.com/jaredpar/VsVim/issues/1786).