### PR TITLE
Change save of selected item

### DIFF
--- a/Src/VsVimShared/Extensions.cs
+++ b/Src/VsVimShared/Extensions.cs
@@ -1131,6 +1131,19 @@ namespace Vim.VisualStudio
             return QueryStatus(oleCommandTarget, oleCommandData, out command);
         }
 
+        internal static bool QueryStatus(this IOleCommandTarget oleCommandTarget, OleCommandData oleCommandData, OLECMDF status)
+        {
+            OLECMD command;
+            var hr = QueryStatus(oleCommandTarget, oleCommandData, out command);
+            if (hr != VSConstants.S_OK)
+            {
+                return false;
+            }
+
+            var ret = (OLECMDF)command.cmdf;
+            return status == (ret & status);
+        }
+
         internal static int QueryStatus(this IOleCommandTarget oleCommandTarget, OleCommandData oleCommandData, out OLECMD command)
         {
             var commandGroup = oleCommandData.Group;

--- a/Src/VsVimShared/ITextManager.cs
+++ b/Src/VsVimShared/ITextManager.cs
@@ -30,7 +30,7 @@ namespace Vim.VisualStudio
         IEnumerable<ITextView> GetDocumentTextViews(DocumentLoad documentLoad);
 
         /// <summary>
-        /// Get the ITextView instances which are attachked to this ITextBuffer
+        /// Get the ITextView instances which are attached to this ITextBuffer
         /// </summary>
         IEnumerable<ITextView> GetDocumentTextViews(ITextBuffer textBuffer);
 

--- a/Src/VsVimShared/VsCommandTarget.cs
+++ b/Src/VsVimShared/VsCommandTarget.cs
@@ -88,6 +88,8 @@ namespace Vim.VisualStudio
                 return false;
             }
 
+            VimTrace.TraceInfo($"TryCustomProcess {command} and completion {_broker.IsCompletionActive}");
+
             var oleCommandData = OleCommandData.Empty;
             try
             {

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -18,6 +18,7 @@ using Vim.UI.Wpf;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio;
 using Microsoft.FSharp.Core;
+using Microsoft.VisualStudio.OLE.Interop;
 
 namespace Vim.VisualStudio
 {
@@ -461,7 +462,36 @@ namespace Vim.VisualStudio
 
         public override bool Save(ITextBuffer textBuffer)
         {
+            // The best way to save a buffer from an extensbility stand point is to use the DTE command 
+            // system.  This means save goes through IOleCommandTarget and hits the maximum number of 
+            // places other extension could be listening for save events.
+            //
+            // This only works though when we are saving the buffer which currently has focus.  If it's 
+            // not in focus then we need to resort to saving via the ITextDocument.
+            var activeSave = SaveActiveTextView(textBuffer);
+            if (activeSave != null)
+            {
+                return activeSave.Value;
+            }
+
             return _textManager.Save(textBuffer).IsSuccess;
+        }
+
+        /// <summary>
+        /// Do a save operation using the <see cref="IOleCommandTarget"/> approach if this is a buffer
+        /// for the active text view.  Returns null when this operation couldn't be performed and a 
+        /// non-null value when the operation was actually executed.
+        /// </summary>
+        private bool? SaveActiveTextView(ITextBuffer textBuffer)
+        {
+            IWpfTextView activeTextView;
+            if (!_vsAdapter.TryGetActiveTextView(out activeTextView) ||
+                !activeTextView.TextBuffer.GetSourceBuffersRecursive().Contains(textBuffer))
+            {
+                return null;
+            }
+
+            return SafeExecuteCommand(activeTextView, "File.SaveSelectedItems");
         }
 
         public override bool SaveTextAs(string text, string fileName)


### PR DESCRIPTION
In the case :w is used to save the active file use File.SaveSelectedItems command.  This will help with other extensibility points as it will hit the full Visual Studio event pipeline.

closes #1864