### PR TITLE
fix #1750 switching windows in multimonitor configuration

### DIFF
--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -602,7 +602,7 @@ namespace Vim.VisualStudio
         {
             // Thanks to https://github.com/mrdooz/TabGroupJumper/blob/master/TabGroupJumper/Connect.cs
             var topLevelWindows = _dte.Windows.Cast<Window>()
-                .Where(window => window.Kind == "Document" && (window.Left > 0))
+                .Where(window => window.Kind == "Document" && (window.Left != 0))
                 .ToList();
             topLevelWindows.Sort((a, b) => a.Left < b.Left ? -1 : 1);
             var indexOfActiveDoc = topLevelWindows.FindIndex(win => win == _dte.ActiveWindow);


### PR DESCRIPTION
The problems occurs only in multimonitor enviroment.
When VisualStudio is opened on monitor to left from primary monitor window.Left is always < 0 and topLevelWindows list was empty.
Windows with .Left == 0 aren't code editor windows (eg. project settings)

