### PR TITLE
Fix telemetry setting

### DIFF
--- a/Src/VsVimShared/Implementation/OptionPages/DefaultOptionPage.cs
+++ b/Src/VsVimShared/Implementation/OptionPages/DefaultOptionPage.cs
@@ -342,7 +342,7 @@ namespace Vim.VisualStudio.Implementation.OptionPages
             {
                 vimApplicationSettings.DefaultSettings = DefaultSettings;
                 vimApplicationSettings.EnableExternalEditMonitoring = EnableExternalEditMonitoring;
-                vimApplicationSettings.EnableExternalEditMonitoring = EnableTelemetry;
+                vimApplicationSettings.EnableTelemetry = EnableTelemetry;
                 vimApplicationSettings.UseEditorDefaults = UseEditorDefaults;
                 vimApplicationSettings.UseEditorIndent = UseEditorIndent;
                 vimApplicationSettings.UseEditorTabAndBackspace = UseEditorTabAndBackspace;


### PR DESCRIPTION
Typo meant that toggling the setting in the options UI actually toggled
a different setting.