### PR TITLE
Fix escape not exiting visual mode

### DIFF
--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4310,6 +4310,9 @@ and IVimBuffer =
     /// Whether or not the IVimBuffer is currently processing a KeyInput value
     abstract IsProcessingInput : bool
 
+    /// Whether or not the IVimBuffer is currently switching modes
+    abstract IsSwitchingMode : bool
+
     /// Is this IVimBuffer instance closed
     abstract IsClosed : bool
 

--- a/Src/VimCore/SelectionChangeTracker.fs
+++ b/Src/VimCore/SelectionChangeTracker.fs
@@ -80,6 +80,10 @@ type internal SelectionChangeTracker
                 _selectionDirty <- false
             else 
                 _selectionDirty <- true
+        elif _vimBuffer.IsSwitchingMode then
+            // Selection is frequently updated while switching between modes.  It's the responsibility
+            // of the mode switching logic to properly update the mode here. 
+            ()
         else
             x.SetModeForSelection()
 

--- a/Test/VimCoreTest/Mock/MockVimBuffer.cs
+++ b/Test/VimCoreTest/Mock/MockVimBuffer.cs
@@ -34,6 +34,7 @@ namespace Vim.UnitTest.Mock
         public ICommandUtil CommandUtilImpl;
         public IMode ExternalEditModeImpl;
         public bool IsProcessingInputImpl;
+        public bool IsSwitchingModeImpl;
         public PropertyCollection PropertiesImpl;
         public IVimData VimDataImpl;
         public IVim VimImpl;
@@ -93,6 +94,11 @@ namespace Vim.UnitTest.Mock
         public bool IsProcessingInput
         {
             get { return IsProcessingInputImpl; }
+        }
+
+        public bool IsSwitchingMode
+        {
+            get { return IsSwitchingModeImpl; }
         }
 
         public IJumpList JumpList

--- a/Test/VimCoreTest/ModeMapTest.cs
+++ b/Test/VimCoreTest/ModeMapTest.cs
@@ -1,69 +1,83 @@
-﻿using Xunit;
+﻿using Moq;
+using Xunit;
+using Vim.Extensions;
 
 namespace Vim.UnitTest
 {
-    public abstract class ModeMapTest : VimTestBase
+    public sealed class ModeMapTest : VimTestBase
     {
         private readonly IVimBuffer _vimBuffer;
         private readonly ModeMap _modeMap;
 
-        protected ModeMapTest()
+        public ModeMapTest()
         {
             _vimBuffer = CreateVimBuffer();
             _modeMap = ((VimBuffer)_vimBuffer).ModeMap;
+            _modeMap.Reset((new UninitializedMode(_vimBuffer.VimTextBuffer)));
         }
 
-        public sealed class PreviousModeTest : ModeMapTest
+        /// <summary>
+        /// Make sure that "normal" mode is properly logged as the previous mode when 
+        /// transitioning between normal -> insert -> visual 
+        /// </summary>
+        [Fact]
+        public void InsertToNormalToVisualCharacter()
         {
-            public PreviousModeTest()
-            {
-                Assert.Equal(ModeKind.Normal, _modeMap.Mode.ModeKind);
-            }
+            _modeMap.SwitchMode(ModeKind.Insert, ModeArgument.None);
+            _modeMap.SwitchMode(ModeKind.Normal, ModeArgument.None);
+            _modeMap.SwitchMode(ModeKind.VisualCharacter, ModeArgument.None);
+            Assert.Equal(ModeKind.Normal, _modeMap.PreviousMode.Value.ModeKind);
+        }
 
-            /// <summary>
-            /// Make sure that "normal" mode is properly logged as the previous mode when 
-            /// transitioning between normal -> insert -> visual 
-            /// </summary>
-            [Fact]
-            public void InsertToNormalToVisualCharacter()
+        /// <summary>
+        /// When switching between visual modes the previous mode should remain unchanged.  It 
+        /// doesn't actually reset the previous mode value.  Essentially when going from 
+        /// insert -> visual character -> visual block, escape should go back to insert, not
+        /// visual character. 
+        /// </summary>
+        [Fact]
+        public void SwitchBetweenVisualModes()
+        {
+            foreach (var baseMode in new[] { ModeKind.Normal, ModeKind.Command, ModeKind.Insert })
             {
-                _modeMap.SwitchMode(ModeKind.Insert, ModeArgument.None);
-                _modeMap.SwitchMode(ModeKind.Normal, ModeArgument.None);
-                _modeMap.SwitchMode(ModeKind.VisualCharacter, ModeArgument.None);
-                Assert.Equal(ModeKind.Normal, _modeMap.PreviousMode.ModeKind);
-            }
+                _modeMap.SwitchMode(baseMode, ModeArgument.None);
+                foreach (var visualMode in VisualKind.All)
+                {
+                    _modeMap.SwitchMode(visualMode.VisualModeKind, ModeArgument.None);
+                }
 
-            /// <summary>
-            /// When switching between visual modes we don't want to change the previous mode to a 
-            /// non-visual mode.  Instead keep the previous non-visual mode 
-            /// </summary>
-            [Fact]
-            public void VisualCharacterToVisualBlock()
-            {
-                _modeMap.SwitchMode(ModeKind.VisualCharacter, ModeArgument.None);
-                _modeMap.SwitchMode(ModeKind.VisualLine, ModeArgument.None);
-                Assert.Equal(ModeKind.Normal, _modeMap.PreviousMode.ModeKind);
-            }
-
-            [Fact]
-            public void NormalToInsertToNormal()
-            {
-                _modeMap.SwitchMode(ModeKind.Insert, ModeArgument.None);
-                _modeMap.SwitchMode(ModeKind.Normal, ModeArgument.None);
-                Assert.Equal(ModeKind.Insert, _modeMap.PreviousMode.ModeKind);
+                Assert.Equal(baseMode, _modeMap.PreviousMode.Value.ModeKind);
             }
         }
 
-        public sealed class MiscTest : ModeMapTest
+        [Fact]
+        public void NormalToInsertToNormal()
         {
-            /// <summary>
-            /// Make sure that we properly transition to normal mode when leaving visual mode 
-            /// </summary>
-            [Fact]
-            public void Issue1170()
+            _modeMap.SwitchMode(ModeKind.Insert, ModeArgument.None);
+            _modeMap.SwitchMode(ModeKind.Normal, ModeArgument.None);
+            Assert.Equal(ModeKind.Insert, _modeMap.PreviousMode.Value.ModeKind);
+        }
+
+        [Fact]
+        public void InitialNormalHasNoPrevious()
+        {
+            Assert.Equal(ModeKind.Uninitialized, _modeMap.Mode.ModeKind);
+            _modeMap.SwitchMode(ModeKind.Normal, ModeArgument.None);
+            Assert.True(_modeMap.PreviousMode.IsNone());
+        }
+
+        /// <summary>
+        /// Visual mode always needs a mode to fall back.  Make sure there is one available 
+        /// if it's the very first mode and hence would otherwise have an uninitialized mode
+        /// </summary>
+        [Fact]
+        public void InitialVisualHasNormalModeBackup()
+        {
+            foreach (var visualMode in VisualKind.All)
             {
-                _vimBuffer.ProcessNotation(@"i<Esc>v<Esc>");
-                Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+                _modeMap.Reset((new UninitializedMode(_vimBuffer.VimTextBuffer)));
+                _modeMap.SwitchMode(visualMode.VisualModeKind, ModeArgument.None);
+                Assert.Equal(ModeKind.Normal, _modeMap.PreviousMode.value.ModeKind);
             }
         }
     }

--- a/Test/VimCoreTest/ModeMapTest.cs
+++ b/Test/VimCoreTest/ModeMapTest.cs
@@ -96,15 +96,15 @@ namespace Vim.UnitTest
         }
 
         /// <summary>
-        /// The mode switch is not complete until the event listeners have processed the change.
+        /// The mode switch is complete when the <see cref="IVimBuffer.SwitchedMode"/> event is raised.
         /// </summary>
         [Fact]
         public void IsSwitchingModeInEvent()
         {
             _vimBuffer.SwitchedMode += (o, e) =>
             {
-                Assert.True(_modeMap.IsSwitchingMode);
-                Assert.True(_vimBuffer.IsSwitchingMode);
+                Assert.False(_modeMap.IsSwitchingMode);
+                Assert.False(_vimBuffer.IsSwitchingMode);
             };
             _modeMap.SwitchMode(ModeKind.Command, ModeArgument.None);
         }


### PR DESCRIPTION
The core problem here is that I misrepresented previous modes in the Vim
model.  In particular how previous modes should be handled during
startup.  The new logic is as follows:

- In some cases there simply is not a previous mode.  Hence this is now
an option type.
- Visual Mode must alwasy have a previous mode.  When one is not
available then Normal mode will just be picked.

closes #1955