### PR TITLE
Issue 2003: Fix focus not taken on command mode or search entry

### DIFF
--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml.cs
@@ -125,6 +125,11 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             InitializeComponent();
         }
 
+        internal bool IsCaretAtStart()
+        {
+            return _commandLineInput.CaretIndex == 1;
+        }
+
         internal void UpdateCaretPosition(EditPosition editPosition)
         {
             if (IsEditReadOnly)

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -575,10 +575,13 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             // updated at KeyInputEnd (and not KeyInputStart), so we need to check again here
 
             var editKind = CalculateCommandLineEditKind();
-            if (editKind != _editKind && editKind != EditKind.None)
+            if (editKind != _editKind)
             {
                 ChangeEditKind(editKind);
-                _margin.UpdateCaretPosition(EditPosition.End);
+                if (editKind != EditKind.None)
+                {
+                    _margin.UpdateCaretPosition(EditPosition.End);
+                }
             }
         }
 

--- a/Test/VimCoreTest/Mock/MockKeyboardDevice.cs
+++ b/Test/VimCoreTest/Mock/MockKeyboardDevice.cs
@@ -132,6 +132,12 @@ namespace Vim.UnitTest.Mock
                 case VimKey.Back:
                     key = Key.Back;
                     return true;
+                case VimKey.Home:
+                    key = Key.Home;
+                    return true;
+                case VimKey.End:
+                    key = Key.End;
+                    return true;
             }
 
             if (char.IsLetter(keyInput.Char))


### PR DESCRIPTION
The bug is CommandMarginController calculates EditKind changes on OnKeyStart but the
_vimBuffer used to compute that doesn't reflect the state until OnKeyEnd.

The state stays wrong during the entire duration of command mode/search unless the users clicks.

Fix is to correct state in OnKeyInputEnd.