### PR TITLE
Remove "This is a test" from License.txt

### DIFF
--- a/Src/VsVim/License.txt
+++ b/Src/VsVim/License.txt
@@ -1,5 +1,3 @@
-This is a test
-
 Apache License
 Version 2.0, January 2004
 http://www.apache.org/licenses/


### PR DESCRIPTION
I was happy to update VsVim today, but noticed some surprising text in the installation dialog. I'm guessing "This is a test" isn't supposed to be there?

![image](https://user-images.githubusercontent.com/24511/34632793-6ccaadfe-f22c-11e7-8e02-3c6d993a2927.png)
