### PR TITLE
Fix display of window settings

### DIFF
--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1379,9 +1379,12 @@ type VimInterpreter
 
         // Display all of the setings which don't have the default value
         let displayAllNonDefault() = 
+            let allSettings = 
+                _localSettings.Settings
+                |> Seq.append _windowSettings.Settings
+                |> Seq.append _globalSettings.Settings
 
-            // TODO: need to filter out terminal 
-            _localSettings.AllSettings 
+            allSettings
             |> Seq.filter (fun s -> not s.IsValueDefault) 
             |> Seq.map getSettingDisplay 
             |> _statusUtil.OnStatusLong

--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -545,8 +545,8 @@ type internal Vim
         match localSettings with
         | None -> ()
         | Some localSettings ->
-            localSettings.AllSettings
-            |> Seq.filter (fun s -> not s.IsGlobal && not s.IsValueCalculated)
+            localSettings.Settings
+            |> Seq.filter (fun s -> not s.IsValueCalculated)
             |> Seq.iter (fun s -> vimTextBuffer.LocalSettings.TrySetValue s.Name s.Value |> ignore)
 
         // Put the IVimTextBuffer into the ITextBuffer property bag so we can query for it in the future
@@ -574,8 +574,8 @@ type internal Vim
         match windowSettings with
         | None -> ()
         | Some windowSettings ->
-            windowSettings.AllSettings
-            |> Seq.filter (fun s -> not s.IsGlobal && not s.IsValueCalculated)
+            windowSettings.Settings
+            |> Seq.filter (fun s -> not s.IsValueCalculated)
             |> Seq.iter (fun s -> vimBuffer.WindowSettings.TrySetValue s.Name s.Value |> ignore)
 
         // Setup the handlers for KeyInputStart and KeyInputEnd to accurately track the active

--- a/Src/VimCore/VimSettings.fs
+++ b/Src/VimCore/VimSettings.fs
@@ -39,7 +39,7 @@ type internal SettingsMap
         _rawData
         |> Seq.iter (fun setting -> this.AddSetting setting)
 
-    member x.AllSettings = _settingMap.Values |> List.ofSeq
+    member x.Settings = _settingMap.Values |> List.ofSeq
 
     member x.OwnsSetting settingName = x.GetSetting settingName |> Option.isSome
 
@@ -309,7 +309,7 @@ type internal GlobalSettings() =
     interface IVimGlobalSettings with
         // IVimSettings
 
-        member x.AllSettings = _map.AllSettings
+        member x.Settings = _map.Settings
         member x.TrySetValue settingName value = _map.TrySetValue settingName value
         member x.TrySetValueFromString settingName strValue = _map.TrySetValueFromString settingName strValue
         member x.GetSetting settingName = _map.GetSetting settingName
@@ -493,8 +493,8 @@ type internal LocalSettings
 
     static member Copy (settings : IVimLocalSettings) = 
         let copy = LocalSettings(settings.GlobalSettings)
-        settings.AllSettings
-        |> Seq.filter (fun s -> not s.IsGlobal && not s.IsValueCalculated)
+        settings.Settings
+        |> Seq.filter (fun s -> not s.IsValueCalculated)
         |> Seq.iter (fun s -> copy.Map.TrySetValue s.Name s.Value |> ignore)
         copy :> IVimLocalSettings
 
@@ -520,7 +520,7 @@ type internal LocalSettings
     interface IVimLocalSettings with 
         // IVimSettings
         
-        member x.AllSettings = _map.AllSettings |> Seq.append _globalSettings.AllSettings |> List.ofSeq
+        member x.Settings = _map.Settings
         member x.TrySetValue settingName value = 
             if _map.OwnsSetting settingName then _map.TrySetValue settingName value
             else _globalSettings.TrySetValue settingName value
@@ -602,13 +602,13 @@ type internal WindowSettings
 
     static member Copy (settings : IVimWindowSettings) = 
         let copy = WindowSettings(settings.GlobalSettings)
-        settings.AllSettings
-        |> Seq.filter (fun s -> not s.IsGlobal && not s.IsValueCalculated)
+        settings.Settings
+        |> Seq.filter (fun s -> not s.IsValueCalculated)
         |> Seq.iter (fun s -> copy.Map.TrySetValue s.Name s.Value |> ignore)
         copy :> IVimWindowSettings
 
     interface IVimWindowSettings with 
-        member x.AllSettings = _map.AllSettings |> Seq.append _globalSettings.AllSettings |> List.ofSeq
+        member x.Settings = _map.Settings
         member x.TrySetValue settingName value = 
             if _map.OwnsSetting settingName then _map.TrySetValue settingName value
             else _globalSettings.TrySetValue settingName value

--- a/Src/VimCore/VimSettingsInterface.fs
+++ b/Src/VimCore/VimSettingsInterface.fs
@@ -251,8 +251,8 @@ type SettingEventArgs(_setting : Setting, _isValueChanged : bool) =
 /// names tend to have more familiar camel case names
 type IVimSettings =
 
-    /// Returns a sequence of all of the settings and values
-    abstract AllSettings : Setting list
+    /// Collection of settings owned by this IVimSettings instance
+    abstract Settings : Setting list
 
     /// Try and set a setting to the passed in value.  This can fail if the value does not 
     /// have the correct type.  The provided name can be the full name or abbreviation

--- a/Src/VimTestUtils/VimTestBase.cs
+++ b/Src/VimTestUtils/VimTestBase.cs
@@ -293,7 +293,7 @@ namespace Vim.UnitTest
 
             // Reset all of the global settings back to their default values.   Adds quite
             // a bit of sanity to the test bed
-            foreach (var setting in Vim.GlobalSettings.AllSettings)
+            foreach (var setting in Vim.GlobalSettings.Settings)
             {
                 if (!setting.IsValueDefault && !setting.IsValueCalculated)
                 {

--- a/Test/VimCoreTest/GlobalSettingsTest.cs
+++ b/Test/VimCoreTest/GlobalSettingsTest.cs
@@ -210,7 +210,7 @@ namespace Vim.UnitTest
             [Fact]
             public void Sanity1()
             {
-                var all = _globalSettings.AllSettings;
+                var all = _globalSettings.Settings;
                 Assert.Contains(all, x => x.Name == GlobalSettingNames.IgnoreCaseName);
                 Assert.Contains(all, x => x.Name == GlobalSettingNames.ScrollOffsetName);
             }

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -755,6 +755,31 @@ namespace Vim.UnitTest
                 ParseAndRun(@"set ts=3");
                 Assert.Equal(3, _localSettings.TabStop);
             }
+
+            /// <summary>
+            /// Ensure that we don't crash when there is nothing to display
+            /// </summary>
+            [WpfFact]
+            public void PrintEmpty()
+            {
+                Create("");
+                _vimBuffer.GlobalSettings.Timeout = true;
+                ParseAndRun(@"set");
+                Assert.Equal("", _statusUtil.LastStatus);
+            }
+
+            /// <summary>
+            /// Window settings need to be included in the display.
+            /// </summary>
+            [WpfFact]
+            public void PrintIncludeWindow()
+            {
+                Create("");
+                _vimBuffer.WindowSettings.CursorLine = true;
+                _vimBuffer.GlobalSettings.Timeout = true;
+                ParseAndRun(@"set");
+                Assert.Equal("cursorline", _statusUtil.LastStatus);
+            }
         }
 
         public sealed class HelpTest : InterpreterTest

--- a/Test/VimCoreTest/SettingsCommonTest.cs
+++ b/Test/VimCoreTest/SettingsCommonTest.cs
@@ -95,7 +95,7 @@ namespace Vim.UnitTest
         [Fact]
         public void SettingsAreImmutable()
         {
-            var all = _settings.AllSettings;
+            var all = _settings.Settings;
             var value = all.Single(x => x.Name == GlobalSettingNames.ScrollOffsetName);
             var prev = value.Value.AsNumber().Item;
             Assert.NotEqual(42, prev);
@@ -110,7 +110,7 @@ namespace Vim.UnitTest
         [Fact]
         public void GetSettingByName()
         {
-            foreach (var setting in _settings.AllSettings)
+            foreach (var setting in _settings.Settings)
             {
                 var found = _settings.GetSetting(setting.Name);
                 Assert.True(found.IsSome());
@@ -125,7 +125,7 @@ namespace Vim.UnitTest
         [Fact]
         public void GetSettingByAbbreviation()
         {
-            foreach (var setting in _settings.AllSettings)
+            foreach (var setting in _settings.Settings)
             {
                 var found = _settings.GetSetting(setting.Abbreviation);
                 Assert.True(found.IsSome());
@@ -165,7 +165,7 @@ namespace Vim.UnitTest
         [Fact]
         public void TrySetValue3()
         {
-            foreach (var cur in _settings.AllSettings)
+            foreach (var cur in _settings.Settings)
             {
                 SettingValue value = null;
                 if (cur.Kind.IsToggle)
@@ -192,7 +192,7 @@ namespace Vim.UnitTest
         [Fact]
         public void TrySetValueFromString1()
         {
-            foreach (var cur in _settings.AllSettings)
+            foreach (var cur in _settings.Settings)
             {
                 string value = null;
                 if (cur.Kind.IsToggle)
@@ -222,7 +222,7 @@ namespace Vim.UnitTest
         [Fact]
         public void TrySetValueFromString2()
         {
-            foreach (var cur in _settings.AllSettings)
+            foreach (var cur in _settings.Settings)
             {
                 string value = null;
                 if (cur.Kind.IsToggle)
@@ -293,7 +293,7 @@ namespace Vim.UnitTest
         [Fact]
         public void SettingsShouldStartAsDefault()
         {
-            foreach (var setting in _settings.AllSettings)
+            foreach (var setting in _settings.Settings)
             {
                 Assert.True(setting.IsValueDefault);
             }

--- a/Test/VimCoreTest/SettingsCommonTest.cs
+++ b/Test/VimCoreTest/SettingsCommonTest.cs
@@ -96,11 +96,11 @@ namespace Vim.UnitTest
         public void SettingsAreImmutable()
         {
             var all = _settings.Settings;
-            var value = all.Single(x => x.Name == GlobalSettingNames.ScrollOffsetName);
+            var value = all.Single(x => x.Name == NumberSettingName);
             var prev = value.Value.AsNumber().Item;
             Assert.NotEqual(42, prev);
-            Assert.True(_settings.TrySetValue(GlobalSettingNames.ScrollOffsetName, SettingValue.NewNumber(42)));
-            value = all.Single(x => x.Name == GlobalSettingNames.ScrollOffsetName);
+            Assert.True(_settings.TrySetValue(NumberSettingName, SettingValue.NewNumber(42)));
+            value = all.Single(x => x.Name == NumberSettingName);
             Assert.Equal(prev, value.Value.AsNumber().Item);
         }
 

--- a/Test/VimCoreTest/TestableStatusUtil.cs
+++ b/Test/VimCoreTest/TestableStatusUtil.cs
@@ -23,7 +23,7 @@ namespace Vim.UnitTest
 
         public void OnStatusLong(IEnumerable<string> value)
         {
-            LastStatus = value.Aggregate((x, y) => x + Environment.NewLine + y);
+            LastStatus = value.Any() ? value.Aggregate((x, y) => x + Environment.NewLine + y) : "";
             LastStatusLong = value.ToArray();
         }
 


### PR DESCRIPTION
Window settings were not being displayed when the `:set` command was executed. It
lead to the incorrect belief that they were not being sync'd properly.

closes #2061