### PR TITLE
Move back to classic SDK

### DIFF
--- a/Src/VimCore/VimCore.fsproj
+++ b/Src/VimCore/VimCore.fsproj
@@ -1,12 +1,34 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <RootNamespace>Vim.Core</RootNamespace>
     <AssemblyName>Vim.Core</AssemblyName>
-    <TargetFramework>net45</TargetFramework>
     <OtherFlags>--standalone</OtherFlags>
     <NoWarn>2011</NoWarn>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+    <ProjectGuid>{92121d37-d2e5-45ab-853c-99b0a85b7c8d}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>3</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>3</WarningLevel>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets" />
   <ItemGroup>
     <Compile Include="Resources.fs" />
     <Compile Include="VimTrace.fs" />
@@ -120,9 +142,12 @@
     <Compile Include="MefComponents.fs" />
     <Compile Include="FSharpExtensions.fs" />
     <Compile Include="AssemblyInfo.fs" />
+    <PackageReference Include="FSharp.Core">
+      <Version>4.2.3</Version>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.2.3" PrivateAssets="all" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />

--- a/VsVim.sln
+++ b/VsVim.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27106.0
+VisualStudioVersion = 15.0.27130.2024
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7CD56D22-AAAA-4A93-8D98-1A014D9A6D39}"
 	ProjectSection(SolutionItems) = preProject
@@ -12,7 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VsVim", "Src\VsVim\VsVim.csproj", "{11710F28-88D6-44DD-99DB-1F0AAA8CDAA0}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "VimCore", "Src\VimCore\VimCore.fsproj", "{06BE08E7-8626-40BD-877B-8D2DCA6BA451}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "VimCore", "Src\VimCore\VimCore.fsproj", "{15DDED1B-E0CE-4128-9C63-A1D80171A08C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VimCoreTest", "Test\VimCoreTest\VimCoreTest.csproj", "{B4FC7C81-E500-47C8-A884-2DBB7CA77123}"
 EndProject
@@ -71,16 +71,17 @@ Global
 		{11710F28-88D6-44DD-99DB-1F0AAA8CDAA0}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{11710F28-88D6-44DD-99DB-1F0AAA8CDAA0}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{11710F28-88D6-44DD-99DB-1F0AAA8CDAA0}.Release|x86.ActiveCfg = Release|Any CPU
-		{06BE08E7-8626-40BD-877B-8D2DCA6BA451}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{06BE08E7-8626-40BD-877B-8D2DCA6BA451}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{06BE08E7-8626-40BD-877B-8D2DCA6BA451}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{06BE08E7-8626-40BD-877B-8D2DCA6BA451}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{06BE08E7-8626-40BD-877B-8D2DCA6BA451}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{06BE08E7-8626-40BD-877B-8D2DCA6BA451}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{06BE08E7-8626-40BD-877B-8D2DCA6BA451}.Release|Any CPU.Build.0 = Release|Any CPU
-		{06BE08E7-8626-40BD-877B-8D2DCA6BA451}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{06BE08E7-8626-40BD-877B-8D2DCA6BA451}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{06BE08E7-8626-40BD-877B-8D2DCA6BA451}.Release|x86.ActiveCfg = Release|Any CPU
+		{15DDED1B-E0CE-4128-9C63-A1D80171A08C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{15DDED1B-E0CE-4128-9C63-A1D80171A08C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{15DDED1B-E0CE-4128-9C63-A1D80171A08C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{15DDED1B-E0CE-4128-9C63-A1D80171A08C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{15DDED1B-E0CE-4128-9C63-A1D80171A08C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{15DDED1B-E0CE-4128-9C63-A1D80171A08C}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{15DDED1B-E0CE-4128-9C63-A1D80171A08C}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{15DDED1B-E0CE-4128-9C63-A1D80171A08C}.Release|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{15DDED1B-E0CE-4128-9C63-A1D80171A08C}.Release|Mixed Platforms.Build.0 = Debug|Any CPU
+		{15DDED1B-E0CE-4128-9C63-A1D80171A08C}.Release|x86.ActiveCfg = Debug|Any CPU
+		{15DDED1B-E0CE-4128-9C63-A1D80171A08C}.Release|x86.Build.0 = Debug|Any CPU
 		{B4FC7C81-E500-47C8-A884-2DBB7CA77123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B4FC7C81-E500-47C8-A884-2DBB7CA77123}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4FC7C81-E500-47C8-A884-2DBB7CA77123}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
The move to the new SDK uncovered a bug in the F# language services.
It's fairly impactful to typing so temporarily reverting back to the
classic SDK until it's addressed.

https://github.com/Microsoft/visualfsharp/issues/4209