### PR TITLE
Change locals coding style

### DIFF
--- a/Src/VimCore/AutoCommandRunner.fs
+++ b/Src/VimCore/AutoCommandRunner.fs
@@ -16,7 +16,7 @@ open VimCoreExtensions
 type internal AutoCommandRunner
     [<ImportingConstructor>]
     (
-        _vim : IVim
+        _vim: IVim
     ) as this =
 
     let _vimData = _vim.VimData
@@ -28,7 +28,7 @@ type internal AutoCommandRunner
         |> Observable.add this.OnActiveTextViewChanged
 
     /// Create the Regex for the specified pattern.  The allowed items are specified in ':help autocmd-patterns'
-    static let CreateFilePatternRegex (pattern : string) = 
+    static let CreateFilePatternRegex (pattern: string) = 
         let builder = System.Text.StringBuilder()
         let mutable i = 0 
         while i < pattern.Length do 
@@ -66,7 +66,7 @@ type internal AutoCommandRunner
         |> List.ofSeq
 
     /// Run the specified AutoCommand against the IVimBuffer in question 
-    member x.RunAutoCommands (vimBuffer : IVimBuffer) eventKind = 
+    member x.RunAutoCommands (vimBuffer: IVimBuffer) eventKind = 
         if _vimHost.IsAutoCommandEnabled then
             let fileName = _vimHost.GetName vimBuffer.TextBuffer
             let autoCommandList = x.GetAutoCommands fileName eventKind
@@ -81,7 +81,7 @@ type internal AutoCommandRunner
                     |> ignore)
 
     /// Called when the active ITextView changes according to the host
-    member x.OnActiveTextViewChanged (e : TextViewChangedEventArgs) =
+    member x.OnActiveTextViewChanged (e: TextViewChangedEventArgs) =
         match OptionUtil.map2 _vim.GetVimBuffer e.OldTextView with
         | Some vimBuffer -> x.RunAutoCommands vimBuffer EventKind.BufLeave
         | None -> ()
@@ -91,7 +91,7 @@ type internal AutoCommandRunner
         | None -> ()
 
     /// VimBufferCreated is the closest event we have for BufEnter.   
-    member x.OnVimBufferCreated (vimBuffer : IVimBuffer) =
+    member x.OnVimBufferCreated (vimBuffer: IVimBuffer) =
         // TODO: BufEnter should really be raised every time the text buffer gets edit
         // focus.  Hard to detect that in WPF / VS though because keyboard focus is very
         // different than edit focus.  For now just raise it once here.  

--- a/Src/VimCore/CommandFactory.fs
+++ b/Src/VimCore/CommandFactory.fs
@@ -6,8 +6,8 @@ open Microsoft.VisualStudio.Text.Editor
 
 type internal CommandFactory
     ( 
-        _operations : ICommonOperations, 
-        _capture : IMotionCapture
+        _operations: ICommonOperations, 
+        _capture: IMotionCapture
     ) =
 
     let _textView = _operations.TextView
@@ -82,7 +82,7 @@ type internal CommandFactory
     /// Build up a set of NormalCommandBinding values from applicable Motion values.  These will 
     /// move the cursor to the result of the motion
     member x.CreateMovementsFromMotions() =
-        let processMotionBinding (binding : MotionBinding) =
+        let processMotionBinding (binding: MotionBinding) =
 
             match binding with
             | MotionBinding.Simple (name, _, motion) -> 
@@ -114,7 +114,7 @@ type internal CommandFactory
     /// Create movement commands for the text-object Motions.  These are described in :help text-objects
     /// section.  All text-object motions will contain the TextObjectSelection flag
     member x.CreateMovementTextObjectCommands() =
-        let processMotionBinding (binding : MotionBinding) =
+        let processMotionBinding (binding: MotionBinding) =
 
             // Determine what kind of text object we are dealing with here
             let textObjectKind = 
@@ -166,7 +166,7 @@ type internal CommandFactory
     /// Create the macro editing commands for the given information.  This relies on listening to events
     /// and the observable values are added to the Disposable bag so the caller may unsubscribe at a 
     /// later time
-    member x.CreateMacroEditCommands (runner : ICommandRunner) (macroRecorder : IMacroRecorder) (bag : DisposableBag) = 
+    member x.CreateMacroEditCommands (runner: ICommandRunner) (macroRecorder: IMacroRecorder) (bag: DisposableBag) = 
 
         // Check IMacroRecorder state and return the proper command based on it
         let getMacroCommand () = 

--- a/Src/VimCore/CommandFactory.fsi
+++ b/Src/VimCore/CommandFactory.fsi
@@ -4,23 +4,23 @@ open Microsoft.VisualStudio.Text.Editor
 
 /// Factory for creating certain commands which are shared between visual and normal mode
 type internal CommandFactory =
-    new : ICommonOperations * IMotionCapture -> CommandFactory
+    new: ICommonOperations * IMotionCapture -> CommandFactory
 
     /// Returns the set of commands which move the cursor.  This includes all motions which are 
     /// valid as movements.  Several of these are overridden with custom movement behavior though.
-    member CreateMovementCommands : unit -> CommandBinding list
+    member CreateMovementCommands: unit -> CommandBinding list
 
     /// Returns the set of commands which move the cursor that are a result of a text object
     /// motion
-    member CreateMovementTextObjectCommands : unit -> CommandBinding list
+    member CreateMovementTextObjectCommands: unit -> CommandBinding list
 
     /// Returns the set of commands which move the caret as a scroll operation
-    member CreateScrollCommands : unit -> CommandBinding list
+    member CreateScrollCommands: unit -> CommandBinding list
 
     /// Returns the set of commands that initiate select mode
-    member CreateSelectionCommands : unit -> CommandBinding list
+    member CreateSelectionCommands: unit -> CommandBinding list
 
     /// Adds in the macro edit commands
-    member CreateMacroEditCommands : ICommandRunner -> IMacroRecorder -> DisposableBag -> unit
+    member CreateMacroEditCommands: ICommandRunner -> IMacroRecorder -> DisposableBag -> unit
 
 

--- a/Src/VimCore/CommandRunner.fs
+++ b/Src/VimCore/CommandRunner.fs
@@ -8,27 +8,27 @@ open Microsoft.VisualStudio.Text.Editor
 type internal CommandRunnerData = {
 
     /// Name of the current command
-    KeyInputSet : KeyInputSet
+    KeyInputSet: KeyInputSet
 
     /// Reverse ordered List of all KeyInput for a given command
-    Inputs : KeyInput list
+    Inputs: KeyInput list
 
     /// Once a CommandBinding is chosen this will be the flags of that 
     /// CommandBinding instance
-    CommandFlags : CommandFlags option
+    CommandFlags: CommandFlags option
 }
 
 /// Implementation of the ICommandRunner interface.  
 type internal CommandRunner
     ( 
-        _textView : ITextView,
-        _registerMap : IRegisterMap,
-        _motionCapture : IMotionCapture,
-        _localSettings : IVimLocalSettings,
-        _commandUtil : ICommandUtil,
-        _statusUtil : IStatusUtil,
-        _visualKind : VisualKind,
-        _defaultKeyRemapMode : KeyRemapMode
+        _textView: ITextView,
+        _registerMap: IRegisterMap,
+        _motionCapture: IMotionCapture,
+        _localSettings: IVimLocalSettings,
+        _commandUtil: ICommandUtil,
+        _statusUtil: IStatusUtil,
+        _visualKind: VisualKind,
+        _defaultKeyRemapMode: KeyRemapMode
     ) =
 
     /// Represents the empty state for processing commands.  Holds all of the default
@@ -41,13 +41,13 @@ type internal CommandRunner
 
     let _commandRanEvent = StandardEvent<CommandRunDataEventArgs>()
     
-    let mutable _commandMap : Map<KeyInputSet, CommandBinding> = Map.empty
+    let mutable _commandMap: Map<KeyInputSet, CommandBinding> = Map.empty
 
     /// Contains all of the state data for a Command operation
     let mutable _data = _emptyData
 
     /// The latest BindData we are waiting to receive KeyInput to complete
-    let mutable _runBindData : BindData<Command * CommandBinding> option = None
+    let mutable _runBindData: BindData<Command * CommandBinding> option = None
 
     /// True during the running of a particular KeyInput 
     let mutable _inBind = false
@@ -55,9 +55,9 @@ type internal CommandRunner
     /// True during the binding of the count
     let mutable _inCount = false
 
-    let mutable _registerName : RegisterName option = None 
+    let mutable _registerName: RegisterName option = None 
 
-    let mutable _count : int option = None 
+    let mutable _count: int option = None 
 
     member x.HasRegisterName = Option.isSome _registerName
 
@@ -80,7 +80,7 @@ type internal CommandRunner
     /// is found it will be passed to completeFunc
     member x.BindRegister completeFunc = 
 
-        let inner (keyInput : KeyInput) = 
+        let inner (keyInput: KeyInput) = 
             match RegisterNameUtil.CharToRegister keyInput.Char with
             | None -> BindResult.Error
             | Some name -> 
@@ -91,7 +91,7 @@ type internal CommandRunner
 
     /// Used to wait for a count value to complete.  Passed in the initial digit 
     /// in the count
-    member x.BindCount (initialDigit : KeyInput) completeFunc =
+    member x.BindCount (initialDigit: KeyInput) completeFunc =
 
         let rec inner (num:string) (ki:KeyInput) = 
             if ki.IsDigit then
@@ -108,13 +108,13 @@ type internal CommandRunner
 
     /// Bind the optional register and count operations and then pass that off to the command 
     /// infrastructure
-    member x.BindCountAndRegister (keyInput : KeyInput) =
+    member x.BindCountAndRegister (keyInput: KeyInput) =
 
-        let tryRegister (keyInput : KeyInput) foundFunc missingFunc = 
+        let tryRegister (keyInput: KeyInput) foundFunc missingFunc = 
             if keyInput.Char = '"' then x.BindRegister foundFunc
             else missingFunc keyInput
 
-        let tryCount (keyInput : KeyInput) foundFunc missingFunc = 
+        let tryCount (keyInput: KeyInput) foundFunc missingFunc = 
             if keyInput.IsDigit && keyInput.Char <> '0' then x.BindCount keyInput foundFunc
             else missingFunc keyInput
 
@@ -152,7 +152,7 @@ type internal CommandRunner
     ///
     /// This makes the function feel a bit hacky but sadly it's just a special case in Vim which requires a 
     /// corresponding special case here
-    member x.BindMotion (commandBinding : CommandBinding) (commandData : CommandData) motionFunc keyInput =
+    member x.BindMotion (commandBinding: CommandBinding) (commandData: CommandData) motionFunc keyInput =
 
         // Convert the motion information into a BindResult.Complete value
         let convertMotion motion motionCount =
@@ -204,7 +204,7 @@ type internal CommandRunner
     member x.BindCommand registerName count keyInput = 
 
         // Find any commands which have the given prefix
-        let findPrefixMatches (commandName : KeyInputSet) =
+        let findPrefixMatches (commandName: KeyInputSet) =
             let commandInputs = commandName.KeyInputs
             let count = List.length commandInputs
             let commandInputsSeq = commandInputs |> Seq.ofList
@@ -217,7 +217,7 @@ type internal CommandRunner
 
         let commandData = { RegisterName = registerName; Count = count }
 
-        let rec inner (commandName : KeyInputSet) previousCommandName currentInput = 
+        let rec inner (commandName: KeyInputSet) previousCommandName currentInput = 
 
             // Used to continue driving the 'inner' function a BindData value.
             let bindNext keyRemapMode = 
@@ -356,7 +356,7 @@ type internal CommandRunner
                 _runBindData <- Some bindData
                 BindResult.NeedMoreInput { KeyRemapMode = bindData.KeyRemapMode; BindFunction = x.Run }
             
-    member x.Add (command : CommandBinding) = 
+    member x.Add (command: CommandBinding) = 
         if Map.containsKey command.KeyInputSet _commandMap then 
             invalidArg "command" Resources.CommandRunner_CommandNameAlreadyAdded
         _commandMap <- Map.add command.KeyInputSet command _commandMap

--- a/Src/VimCore/CommandRunner.fsi
+++ b/Src/VimCore/CommandRunner.fsi
@@ -8,5 +8,5 @@ open Vim
 
 type internal CommandRunner =
     interface ICommandRunner
-    new : ITextView * IRegisterMap * IMotionCapture * IVimLocalSettings * ICommandUtil * IStatusUtil * VisualKind * KeyRemapMode -> CommandRunner
+    new: ITextView * IRegisterMap * IMotionCapture * IVimLocalSettings * ICommandUtil * IStatusUtil * VisualKind * KeyRemapMode -> CommandRunner
 

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -39,7 +39,7 @@ type internal NumberValue =
 /// if this happens.
 type internal NormalModeSelectionGuard
     (
-        _vimBufferData : IVimBufferData
+        _vimBufferData: IVimBufferData
     ) =
 
     let _beganInNormalMode = _vimBufferData.VimTextBuffer.ModeKind = ModeKind.Normal
@@ -66,14 +66,14 @@ type internal NormalModeSelectionGuard
 /// amount of stored state low here I believe it counters the size of the type
 type internal CommandUtil
     (
-        _vimBufferData : IVimBufferData,
-        _motionUtil : IMotionUtil,
-        _commonOperations : ICommonOperations,
-        _foldManager : IFoldManager,
-        _insertUtil : IInsertUtil,
-        _bulkOperations : IBulkOperations,
-        _mouseDevice : IMouseDevice,
-        _lineChangeTracker : ILineChangeTracker
+        _vimBufferData: IVimBufferData,
+        _motionUtil: IMotionUtil,
+        _commonOperations: ICommonOperations,
+        _foldManager: IFoldManager,
+        _insertUtil: IInsertUtil,
+        _bulkOperations: IBulkOperations,
+        _mouseDevice: IMouseDevice,
+        _lineChangeTracker: ILineChangeTracker
     ) =
 
     let _vimTextBuffer = _vimBufferData.VimTextBuffer
@@ -155,7 +155,7 @@ type internal CommandUtil
     /// based on the edits about to be made.  It's possible for other extensions to listen
     /// to the events fired by an edit and make fix up edits.  This code accounts for that
     /// and returns the position mapped into the current ITextSnapshot
-    member x.ApplyEditAndMapPoint (textEdit : ITextEdit) position =
+    member x.ApplyEditAndMapPoint (textEdit: ITextEdit) position =
         let editSnapshot = textEdit.Apply()
         let editPoint = SnapshotPoint(editSnapshot, position)
         let currentSnapshot = x.CurrentSnapshot
@@ -163,13 +163,13 @@ type internal CommandUtil
         | None -> SnapshotPoint(currentSnapshot, 0)
         | Some point -> point
 
-    member x.ApplyEditAndMapPosition (textEdit : ITextEdit) position =
+    member x.ApplyEditAndMapPosition (textEdit: ITextEdit) position =
         let point = x.ApplyEditAndMapPoint textEdit position
         point.Position
 
     /// Calculate the new RegisterValue for the provided one for put with indent
     /// operations.
-    member x.CalculateIdentStringData (registerValue : RegisterValue) =
+    member x.CalculateIdentStringData (registerValue: RegisterValue) =
 
         // Get the indent string to apply to the lines which are indented
         let indent =
@@ -179,7 +179,7 @@ type internal CommandUtil
 
         // Adjust the indentation on a given line of text to have the indentation
         // previously calculated
-        let adjustTextLine (textLine : TextLine) =
+        let adjustTextLine (textLine: TextLine) =
             let oldIndent = textLine.Text |> Seq.takeWhile CharUtil.IsBlank |> StringUtil.OfCharSeq
             let text = indent + (textLine.Text.Substring(oldIndent.Length))
             { textLine with Text = text }
@@ -237,12 +237,12 @@ type internal CommandUtil
             let blockSpan = BlockSpan(x.CaretPoint, _localSettings.TabStop, width, height)
             VisualSpan.Block blockSpan
 
-    member x.CalculateDeleteOperation (result : MotionResult) =
+    member x.CalculateDeleteOperation (result: MotionResult) =
         if Util.IsFlagSet result.MotionResultFlags MotionResultFlags.BigDelete then RegisterOperation.BigDelete
         else RegisterOperation.Delete
 
     /// Change the characters in the given span via the specified change kind
-    member x.ChangeCaseSpanCore kind (editSpan : EditSpan) =
+    member x.ChangeCaseSpanCore kind (editSpan: EditSpan) =
 
         let func =
             match kind with
@@ -288,7 +288,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Change the case of the specified motion
-    member x.ChangeCaseMotion kind (result : MotionResult) =
+    member x.ChangeCaseMotion kind (result: MotionResult) =
 
         // The caret should be placed at the start of the motion for both
         // undo / redo so move before and inside the transaction
@@ -321,7 +321,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Change the case of the selected text.
-    member x.ChangeCaseVisual kind (visualSpan : VisualSpan) =
+    member x.ChangeCaseVisual kind (visualSpan: VisualSpan) =
 
         // The caret should be positioned at the start of the VisualSpan for both
         // undo / redo so move it before and inside the transaction
@@ -335,7 +335,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.SwitchPreviousMode
 
     /// Delete the specified motion and enter insert mode
-    member x.ChangeMotion registerName (result : MotionResult) =
+    member x.ChangeMotion registerName (result: MotionResult) =
 
         // This command has legacy / special case behavior for forward word motions.  It will
         // not delete any trailing whitespace in the span if the motion is created for a forward
@@ -409,7 +409,7 @@ type internal CommandUtil
 
     /// Core routine for changing a set of lines in the ITextBuffer.  This is the backing function
     /// for changing lines in both normal and visual mode
-    member x.ChangeLinesCore (range : SnapshotLineRange) registerName =
+    member x.ChangeLinesCore (range: SnapshotLineRange) registerName =
 
         // Caret position for the undo operation depends on the number of lines which are in
         // range being deleted.  If there is a single line then we position it before the first
@@ -449,10 +449,10 @@ type internal CommandUtil
     /// Delete the selected lines and begin insert mode (implements the 'S', 'C' and 'R' visual
     /// mode commands.  This is very similar to DeleteLineSelection except that block deletion
     /// can be special cased depending on the command it's used in
-    member x.ChangeLineSelection registerName (visualSpan : VisualSpan) specialCaseBlock =
+    member x.ChangeLineSelection registerName (visualSpan: VisualSpan) specialCaseBlock =
 
         // The majority of cases simply delete a SnapshotLineRange directly.  Handle that here
-        let deleteRange (range : SnapshotLineRange) =
+        let deleteRange (range: SnapshotLineRange) =
 
             // In an undo the caret position has 2 cases.
             //  - Single line range: Start of the first line
@@ -472,7 +472,7 @@ type internal CommandUtil
             (EditSpan.Single range.Extent, commandResult)
 
         // The special casing of block deletion is handled here
-        let deleteBlock (col : NonEmptyCollection<SnapshotOverlapSpan>) =
+        let deleteBlock (col: NonEmptyCollection<SnapshotOverlapSpan>) =
 
             // First step is to change the SnapshotSpan instances to extent from the start to the
             // end of the current line
@@ -527,7 +527,7 @@ type internal CommandUtil
 
     /// Delete the selected text in Visual Mode and begin insert mode with a linked
     /// transaction.
-    member x.ChangeSelection registerName (visualSpan : VisualSpan) =
+    member x.ChangeSelection registerName (visualSpan: VisualSpan) =
 
         match visualSpan with
         | VisualSpan.Character _ ->
@@ -553,7 +553,7 @@ type internal CommandUtil
         | VisualSpan.Line range -> x.ChangeLinesCore range registerName
 
     /// Close a single fold under the caret
-    member x.CloseFoldInSelection (visualSpan : VisualSpan) =
+    member x.CloseFoldInSelection (visualSpan: VisualSpan) =
         let range = visualSpan.LineRange
         let offset = range.StartLineNumber
         for i = 0 to range.Count - 1 do
@@ -579,7 +579,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Close all folds in the selection
-    member x.CloseAllFoldsInSelection (visualSpan : VisualSpan) =
+    member x.CloseAllFoldsInSelection (visualSpan: VisualSpan) =
         let span = visualSpan.LineRange.Extent
         _foldManager.CloseAllFolds span
         CommandResult.Completed ModeSwitch.NoSwitch
@@ -658,7 +658,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Delete a fold from the selection
-    member x.DeleteAllFoldInSelection (visualSpan : VisualSpan) =
+    member x.DeleteAllFoldInSelection (visualSpan: VisualSpan) =
         let span = visualSpan.LineRange.Extent
         _foldManager.DeleteAllFolds span
         CommandResult.Completed ModeSwitch.NoSwitch
@@ -677,7 +677,7 @@ type internal CommandUtil
 
     /// Delete the selected text from the buffer and put it into the specified
     /// register.
-    member x.DeleteLineSelection registerName (visualSpan : VisualSpan) =
+    member x.DeleteLineSelection registerName (visualSpan: VisualSpan) =
 
         // For each of the 3 cases the caret should begin at the start of the
         // VisualSpan during undo so move the caret now.
@@ -730,7 +730,7 @@ type internal CommandUtil
     /// Delete the highlighted text from the buffer and put it into the specified
     /// register.  The caret should be positioned at the beginning of the text for
     /// undo / redo
-    member x.DeleteSelection registerName (visualSpan : VisualSpan) =
+    member x.DeleteSelection registerName (visualSpan: VisualSpan) =
         let startPoint = visualSpan.Start
 
         // Use a transaction to guarantee caret position.  Caret should be at the start
@@ -776,7 +776,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Delete the specified motion of text
-    member x.DeleteMotion registerName (result : MotionResult) =
+    member x.DeleteMotion registerName (result: MotionResult) =
 
         // The d{motion} command has an exception listed which is visible by typing ':help d' in
         // gVim.  In summary, if the motion is characterwise, begins and ends on different
@@ -880,7 +880,7 @@ type internal CommandUtil
 
     /// Run the specified action with a wrapped undo transaction.  This is often necessary when
     /// an edit command manipulates the caret
-    member x.EditWithUndoTransaction<'T> (name : string) (action : unit -> 'T) : 'T =
+    member x.EditWithUndoTransaction<'T> (name: string) (action: unit -> 'T): 'T =
         _undoRedoOperations.EditWithUndoTransaction name _textView action
 
     /// Used for the several commands which make an edit here and need the edit to be linked
@@ -933,13 +933,13 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Create a fold for the given MotionResult
-    member x.FoldMotion (result : MotionResult) =
+    member x.FoldMotion (result: MotionResult) =
         _foldManager.CreateFold result.LineRange
 
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Fold the specified selection
-    member x.FoldSelection (visualSpan : VisualSpan) =
+    member x.FoldSelection (visualSpan: VisualSpan) =
         _foldManager.CreateFold visualSpan.LineRange
 
         CommandResult.Completed ModeSwitch.SwitchPreviousMode
@@ -962,7 +962,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.SwitchPreviousMode
 
     /// Format the lines in the Motion
-    member x.FormatMotion (result : MotionResult) =
+    member x.FormatMotion (result: MotionResult) =
         _commonOperations.FormatLines result.LineRange
         CommandResult.Completed ModeSwitch.NoSwitch
 
@@ -974,7 +974,7 @@ type internal CommandUtil
     ///
     /// TODO: Need to integrate the parsing functions here with that of the tokenizer
     /// which also parses out the same set of numbers
-    member x.GetNumberValueAtCaret() : (NumberValue * SnapshotSpan) option=
+    member x.GetNumberValueAtCaret(): (NumberValue * SnapshotSpan) option=
 
         // Calculate the forward span of the line
         let span =
@@ -1082,7 +1082,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// GoTo the file name under the cursor using a new window (tab)
-    member x.GoToFileInSelectionInNewWindow (visualSpan : VisualSpan) =
+    member x.GoToFileInSelectionInNewWindow (visualSpan: VisualSpan) =
         let goToFile name =
             _commonOperations.GoToFileInNewWindow name
             CommandResult.Completed (ModeSwitch.SwitchMode ModeKind.Normal)
@@ -1092,7 +1092,7 @@ type internal CommandUtil
         | VisualSpan.Block _ -> CommandResult.Completed ModeSwitch.NoSwitch
 
     /// GoTo the file name under the cursor in the same window
-    member x.GoToFileInSelection (visualSpan : VisualSpan) =
+    member x.GoToFileInSelection (visualSpan: VisualSpan) =
         let goToFile name =
             _commonOperations.GoToFile name
             CommandResult.Completed (ModeSwitch.SwitchMode ModeKind.Normal)
@@ -1152,7 +1152,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Join the selection of lines in the buffer
-    member x.JoinSelection kind (visualSpan : VisualSpan) =
+    member x.JoinSelection kind (visualSpan: VisualSpan) =
         let range = SnapshotLineRangeUtil.CreateForSpan visualSpan.EditSpan.OverarchingSpan
 
         // Extend the range to at least 2 lines if possible
@@ -1182,7 +1182,7 @@ type internal CommandUtil
             CommandResult.Completed ModeSwitch.SwitchPreviousMode
 
     /// Invert the current selection
-    member x.InvertSelection (visualSpan : VisualSpan) (streamSelectionSpan : VirtualSnapshotSpan) columnOnlyInBlock =
+    member x.InvertSelection (visualSpan: VisualSpan) (streamSelectionSpan: VirtualSnapshotSpan) columnOnlyInBlock =
 
         // Do the selection change with the new values.  The only elements that must be correct
         // are the anchor point and caret position.  The selection tracker will be responsible
@@ -1363,7 +1363,7 @@ type internal CommandUtil
         let before = x.CaretPoint
 
         // Jump to the given point in the ITextBuffer
-        let jumpLocal (point : VirtualSnapshotPoint) =
+        let jumpLocal (point: VirtualSnapshotPoint) =
             let point =
                 if exact then
                     point
@@ -1429,7 +1429,7 @@ type internal CommandUtil
     ///
     /// Be wary of using this function.  It has the implicit contract that the Start position
     /// of the line is still valid.
-    member x.MoveCaretToDeletedLineStart (deletedLine : ITextSnapshotLine) =
+    member x.MoveCaretToDeletedLineStart (deletedLine: ITextSnapshotLine) =
         Contract.Requires (deletedLine.Start.Position <= x.CurrentSnapshot.Length)
 
         if _localSettings.AutoIndent then
@@ -1476,7 +1476,7 @@ type internal CommandUtil
     /// The caret should be positioned one after the second to last line in the
     /// join.  It should have it's original position during an undo so don't
     /// move the caret until we're inside the transaction
-    member x.MoveCaretFollowingJoin (range : SnapshotLineRange) =
+    member x.MoveCaretFollowingJoin (range: SnapshotLineRange) =
         let point =
             let number = range.StartLineNumber + range.Count - 2
             let line = SnapshotUtil.GetLine range.Snapshot number
@@ -1520,7 +1520,7 @@ type internal CommandUtil
                 CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Move the caret to the result of the text object selection
-    member x.MoveCaretToTextObject count motion textObjectKind (visualSpan : VisualSpan) =
+    member x.MoveCaretToTextObject count motion textObjectKind (visualSpan: VisualSpan) =
 
         // First step is to get the desired final mode of the text object movement
         let desiredVisualKind =
@@ -1630,7 +1630,7 @@ type internal CommandUtil
 
     /// Open a fold in visual mode.  In Visual Mode a single fold level is opened for every
     /// line in the selection
-    member x.OpenFoldInSelection (visualSpan : VisualSpan) =
+    member x.OpenFoldInSelection (visualSpan: VisualSpan) =
         let range = visualSpan.LineRange
         let offset = range.StartLineNumber
         for i = 0 to range.Count - 1 do
@@ -1667,13 +1667,13 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Open all folds under the caret in visual mode
-    member x.OpenAllFoldsInSelection (visualSpan : VisualSpan) =
+    member x.OpenAllFoldsInSelection (visualSpan: VisualSpan) =
         let span = visualSpan.LineRange.ExtentIncludingLineBreak
         _foldManager.OpenAllFolds span
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Run the Ping command
-    member x.Ping (pingData : PingData) data =
+    member x.Ping (pingData: PingData) data =
         pingData.Function data
 
     /// Put the contents of the specified register after the cursor.  Used for the
@@ -1684,7 +1684,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Core put after function used by many of the put after operations
-    member x.PutAfterCaretCore (registerValue : RegisterValue) count moveCaretAfterText =
+    member x.PutAfterCaretCore (registerValue: RegisterValue) count moveCaretAfterText =
         let stringData = registerValue.StringData.ApplyCount count
 
         // Adjust for simple putting line-wise "after" in an empty buffer.
@@ -1766,7 +1766,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Core put function used by many of the put before operations
-    member x.PutBeforeCaretCore (registerValue : RegisterValue) count moveCaretAfterText =
+    member x.PutBeforeCaretCore (registerValue: RegisterValue) count moveCaretAfterText =
         let stringData = registerValue.StringData.ApplyCount count
         let point =
             match registerValue.OperationKind with
@@ -1995,7 +1995,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Repeat the last executed command against the current buffer
-    member x.RepeatLastCommand (repeatData : CommandData) =
+    member x.RepeatLastCommand (repeatData: CommandData) =
 
         // Chain the running of the next command on the basis of the success of
         // the previous command
@@ -2054,7 +2054,7 @@ type internal CommandUtil
                 commandResult
 
         // Function to actually repeat the last change
-        let rec repeat (command : StoredCommand) (repeatData : CommandData option) =
+        let rec repeat (command: StoredCommand) (repeatData: CommandData option) =
 
             // Before repeating a command it needs to be updated in the context of the repeat operation. This
             // includes recalculating the visual span and considering explicit counts that are passed into
@@ -2197,7 +2197,7 @@ type internal CommandUtil
             CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Replace the char under the cursor in visual mode.
-    member x.ReplaceSelection keyInput (visualSpan : VisualSpan) =
+    member x.ReplaceSelection keyInput (visualSpan: VisualSpan) =
 
         let replaceText =
             if keyInput = KeyInputUtil.EnterKey then EditUtil.NewLine _options
@@ -2342,7 +2342,7 @@ type internal CommandUtil
         _insertUtil.RunInsertCommand command
 
     /// Run a NormalCommand against the buffer
-    member x.RunNormalCommand command (data : CommandData) =
+    member x.RunNormalCommand command (data: CommandData) =
         let registerName = data.RegisterName
         let count = data.CountOrDefault
         match command with
@@ -2436,7 +2436,7 @@ type internal CommandUtil
         | NormalCommand.YankLines -> x.YankLines count registerName
 
     /// Run a VisualCommand against the buffer
-    member x.RunVisualCommand command (data : CommandData) (visualSpan : VisualSpan) =
+    member x.RunVisualCommand command (data: CommandData) (visualSpan: VisualSpan) =
 
         let streamSelectionSpan = _textView.Selection.StreamSelectionSpan
 
@@ -2485,7 +2485,7 @@ type internal CommandUtil
 
     /// Get the MotionResult value for the provided MotionData and pass it
     /// if found to the provided function
-    member x.RunWithMotion (motion : MotionData) func =
+    member x.RunWithMotion (motion: MotionData) func =
         match _motionUtil.GetMotion motion.Motion motion.MotionArgument with
         | None ->
             _commonOperations.Beep()
@@ -2643,7 +2643,7 @@ type internal CommandUtil
 
             // If the scroll of the window has taken the caret off of the visible portion of the ITextView
             // then we need to move it back at the same column
-            let updateCaret (textViewLine : ITextViewLine) =
+            let updateCaret (textViewLine: ITextViewLine) =
 
                 // This is one operation which does maintain the column spacing as we go up and down the
                 // lines.  Make sure to use spaces here not column
@@ -2808,12 +2808,12 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.SwitchPreviousMode
 
     /// Shift 'motion' lines to the left
-    member x.ShiftMotionLinesLeft (result : MotionResult) =
+    member x.ShiftMotionLinesLeft (result: MotionResult) =
         x.ShiftLinesLeftCore result.LineRange 1
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Shift 'motion' lines to the right
-    member x.ShiftMotionLinesRight (result : MotionResult) =
+    member x.ShiftMotionLinesRight (result: MotionResult) =
         x.ShiftLinesRightCore result.LineRange 1
         CommandResult.Completed ModeSwitch.NoSwitch
 
@@ -2915,7 +2915,7 @@ type internal CommandUtil
 
     /// Switch from the current visual mode into insert.  If we are in block mode this
     /// will start a block insertion
-    member x.SwitchModeInsert (visualSpan : VisualSpan) =
+    member x.SwitchModeInsert (visualSpan: VisualSpan) =
 
         match visualSpan with
         | VisualSpan.Block blockSpan ->
@@ -3031,13 +3031,13 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Yank the contents of the motion into the specified register
-    member x.YankMotion registerName (result : MotionResult) =
+    member x.YankMotion registerName (result: MotionResult) =
         let value = x.CreateRegisterValue (StringData.OfSpan result.Span) result.OperationKind
         _commonOperations.SetRegisterValue registerName RegisterOperation.Yank value
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Yank the lines in the specified selection
-    member x.YankLineSelection registerName (visualSpan : VisualSpan) =
+    member x.YankLineSelection registerName (visualSpan: VisualSpan) =
         let editSpan, operationKind =
             match visualSpan with
             | VisualSpan.Character characterSpan ->
@@ -3057,7 +3057,7 @@ type internal CommandUtil
         CommandResult.Completed ModeSwitch.SwitchPreviousMode
 
     /// Yank the selection into the specified register
-    member x.YankSelection registerName (visualSpan : VisualSpan) =
+    member x.YankSelection registerName (visualSpan: VisualSpan) =
         let data = StringData.OfEditSpan visualSpan.EditSpan
         let value = x.CreateRegisterValue data visualSpan.OperationKind
         _commonOperations.SetRegisterValue registerName RegisterOperation.Yank value

--- a/Src/VimCore/CommandUtil.fsi
+++ b/Src/VimCore/CommandUtil.fsi
@@ -7,7 +7,7 @@ open Microsoft.VisualStudio.Text.Outlining
 
 type internal CommandUtil =
 
-    new : IVimBufferData * IMotionUtil * ICommonOperations * IFoldManager * IInsertUtil * IBulkOperations  * IMouseDevice * ILineChangeTracker -> CommandUtil
+    new: IVimBufferData * IMotionUtil * ICommonOperations * IFoldManager * IInsertUtil * IBulkOperations  * IMouseDevice * ILineChangeTracker -> CommandUtil
 
     interface ICommandUtil
 

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -15,7 +15,7 @@ open StringBuilderExtensions
 module internal CommonUtil = 
 
     /// Raise the error / warning messages for a given SearchResult
-    let RaiseSearchResultMessage (statusUtil : IStatusUtil) searchResult =
+    let RaiseSearchResultMessage (statusUtil: IStatusUtil) searchResult =
 
         match searchResult with 
         | SearchResult.Found (searchData, _, _, didWrap) ->
@@ -38,9 +38,9 @@ module internal CommonUtil =
 
 type internal CommonOperations
     (
-        _vimBufferData : IVimBufferData,
-        _editorOperations : IEditorOperations,
-        _outliningManager : IOutliningManager option
+        _vimBufferData: IVimBufferData,
+        _editorOperations: IEditorOperations,
+        _outliningManager: IOutliningManager option
     ) =
 
     let _vimTextBuffer = _vimBufferData.VimTextBuffer
@@ -151,7 +151,7 @@ type internal CommonOperations
     // Convert any virtual spaces to real normalized spaces
     member x.FillInVirtualSpace () =
         if x.CaretVirtualPoint.IsInVirtualSpace then
-            let blanks : string = 
+            let blanks: string = 
                 let blanks = StringUtil.RepeatChar x.CaretVirtualPoint.VirtualSpaces ' '
                 x.NormalizeBlanks blanks
 
@@ -323,7 +323,7 @@ type internal CommonOperations
     /// This is needed in outlining cases where a visual line has a different edit line 
     /// at the start and line break of the visual line.  The function will map the line at the
     /// line break back to the line of the start. 
-    member x.AdjustEditLineForVisualSnapshotLine (line : ITextSnapshotLine) = 
+    member x.AdjustEditLineForVisualSnapshotLine (line: ITextSnapshotLine) = 
         let bufferGraph = _textView.BufferGraph
         let visualSnapshot = _textView.TextViewModel.VisualBuffer.CurrentSnapshot
         match BufferGraphUtil.MapSpanUpToSnapshot bufferGraph line.ExtentIncludingLineBreak SpanTrackingMode.EdgeInclusive visualSnapshot with
@@ -337,7 +337,7 @@ type internal CommonOperations
 
     /// Delete count lines from the cursor.  The caret should be positioned at the start
     /// of the first line for both undo / redo
-    member x.DeleteLines (startLine : ITextSnapshotLine) count registerName =
+    member x.DeleteLines (startLine: ITextSnapshotLine) count registerName =
 
         // Function to actually perform the delete
         let doDelete spanOnVisualSnapshot caretPointOnVisualSnapshot includesLastLine =  
@@ -558,7 +558,7 @@ type internal CommonOperations
         _maintainCaretColumn <- MaintainCaretColumn.Spaces spaces
 
     /// Move the caret to the position dictated by the given MotionResult value
-    member x.MoveCaretToMotionResult (result : MotionResult) =
+    member x.MoveCaretToMotionResult (result: MotionResult) =
 
         let shouldMaintainCaretColumn = Util.IsFlagSet result.MotionResultFlags MotionResultFlags.MaintainCaretColumn
         match shouldMaintainCaretColumn, result.CaretColumn with
@@ -610,7 +610,7 @@ type internal CommonOperations
     /// Many operations for moving a motion result need to be calculated in the
     /// visual snapshot.  This method will return the DirectionLastLine value
     /// in that snapshot or the original value if no mapping is possible. 
-    member x.GetDirectionLastLineInVisualSnapshot (result : MotionResult) : ITextSnapshotLine =
+    member x.GetDirectionLastLineInVisualSnapshot (result: MotionResult): ITextSnapshotLine =
         let line = result.DirectionLastLine
         x.AdjustEditLineForVisualSnapshotLine line
 
@@ -618,7 +618,7 @@ type internal CommonOperations
     ///
     /// Note: This method mixes points from the edit and visual snapshot.  Take care
     /// when changing this function to account for both. 
-    member x.MoveCaretToMotionResultCore (result : MotionResult) =
+    member x.MoveCaretToMotionResultCore (result: MotionResult) =
 
         let point = 
 
@@ -686,7 +686,7 @@ type internal CommonOperations
 
     /// Move the caret to the proper indentation on a newly created line.  The context line 
     /// is provided to calculate an indentation off of
-    member x.GetNewLineIndent  (contextLine : ITextSnapshotLine) (newLine : ITextSnapshotLine) =
+    member x.GetNewLineIndent  (contextLine: ITextSnapshotLine) (newLine: ITextSnapshotLine) =
         match _vimHost.GetNewLineIndent _textView contextLine newLine with
         | Some indent -> Some indent
         | None ->
@@ -785,7 +785,7 @@ type internal CommonOperations
         |> OptionUtil.getOrDefault (SnapshotSpanUtil.CreateEmpty point)
         |> SnapshotSpanUtil.GetText
 
-    member x.NavigateToPoint (point : VirtualSnapshotPoint) = 
+    member x.NavigateToPoint (point: VirtualSnapshotPoint) = 
         let textBuffer = point.Position.Snapshot.TextBuffer
         if textBuffer = _textView.TextBuffer then 
             x.MoveCaretToPoint point.Position (ViewFlags.Visible ||| ViewFlags.ScrollOffset)
@@ -805,7 +805,7 @@ type internal CommonOperations
 
     /// Normalize any blanks to the appropriate number of space characters based on the 
     /// Vim settings
-    member x.NormalizeBlanksToSpaces (text : string) =
+    member x.NormalizeBlanksToSpaces (text: string) =
         Contract.Assert(StringUtil.IsBlanks text)
         let builder = System.Text.StringBuilder()
         let tabSize = _localSettings.TabStop
@@ -825,7 +825,7 @@ type internal CommonOperations
         builder.ToString()
 
     /// Normalize spaces into tabs / spaces based on the ExpandTab, TabStop settings
-    member x.NormalizeSpaces (text : string) = 
+    member x.NormalizeSpaces (text: string) = 
         Contract.Assert(Seq.forall (fun c -> c = ' ') text)
         if _localSettings.ExpandTab then
             text
@@ -848,7 +848,7 @@ type internal CommonOperations
     /// Given the specified blank 'text' at the specified column normalize it out to the
     /// correct spaces / tab based on the 'expandtab' setting.  This has to consider the 
     /// difficulty of mixed spaces and tabs filling up the remaining tab boundary 
-    member x.NormalizeBlanksAtColumn text (column : SnapshotColumn) = 
+    member x.NormalizeBlanksAtColumn text (column: SnapshotColumn) = 
         let spacesToColumn = SnapshotLineUtil.GetSpacesToColumn  column.Line column.Column _localSettings.TabStop
         if spacesToColumn % _localSettings.TabStop = 0 then
             // If the column is on a 'tabstop' boundary then there is no difficulty here
@@ -933,7 +933,7 @@ type internal CommonOperations
 
     /// Shift lines in the specified range to the left by one shiftwidth
     /// item.  The shift will done against 'column' in the line
-    member x.ShiftLineRangeLeft (range : SnapshotLineRange) multiplier =
+    member x.ShiftLineRangeLeft (range: SnapshotLineRange) multiplier =
         let count = _localSettings.ShiftWidth * multiplier
 
         use edit = _textBuffer.CreateEdit()
@@ -951,7 +951,7 @@ type internal CommonOperations
 
     /// Shift lines in the specified range to the right by one shiftwidth 
     /// item.  The shift will occur against column 'column'
-    member x.ShiftLineRangeRight (range : SnapshotLineRange) multiplier =
+    member x.ShiftLineRangeRight (range: SnapshotLineRange) multiplier =
         let shiftText = 
             let count = _localSettings.ShiftWidth * multiplier
             StringUtil.RepeatChar count ' '
@@ -971,13 +971,13 @@ type internal CommonOperations
 
         edit.Apply() |> ignore
 
-    member x.Substitute pattern replace (range : SnapshotLineRange) flags = 
+    member x.Substitute pattern replace (range: SnapshotLineRange) flags = 
 
         /// Actually do the replace with the given regex
-        let doReplace (regex : VimRegex) = 
+        let doReplace (regex: VimRegex) = 
             use edit = _textView.TextBuffer.CreateEdit()
 
-            let replaceOne line (c : Capture) = 
+            let replaceOne line (c: Capture) = 
                 let replaceData = x.GetReplaceData x.CaretPoint
                 let newText =  regex.Replace c.Value replace replaceData _registerMap
                 let offset = 
@@ -1112,7 +1112,7 @@ type internal CommonOperations
         builder.ToString(), text.Length
 
     /// Join the lines in the specified line range together. 
-    member x.Join (lineRange : SnapshotLineRange) joinKind = 
+    member x.Join (lineRange: SnapshotLineRange) joinKind = 
 
         if lineRange.Count > 1 then
 
@@ -1314,7 +1314,7 @@ type internal CommonOperations
             outliningManager.ExpandAll(span, fun _ -> true) |> ignore
 
     /// Ensure the point is on screen / visible
-    member x.EnsurePointVisible (point : SnapshotPoint) = 
+    member x.EnsurePointVisible (point: SnapshotPoint) = 
         if point.Position = x.CaretPoint.Position then
             TextViewUtil.EnsureCaretOnScreen _textView
         else
@@ -1336,7 +1336,7 @@ type internal CommonOperations
     /// Updates the given register with the specified value.  This will also update 
     /// other registers based on the type of update that is being performed.  See 
     /// :help registers for the full details
-    member x.SetRegisterValue (name : RegisterName option) operation (value : RegisterValue) = 
+    member x.SetRegisterValue (name: RegisterName option) operation (value: RegisterValue) = 
         let name, isUnnamedOrMissing = 
             match name with 
             | None -> x.GetRegisterName None, true
@@ -1446,9 +1446,9 @@ type internal CommonOperations
 type CommonOperationsFactory
     [<ImportingConstructor>]
     (
-        _editorOperationsFactoryService : IEditorOperationsFactoryService,
-        _outliningManagerService : IOutliningManagerService,
-        _undoManagerProvider : ITextBufferUndoManagerProvider
+        _editorOperationsFactoryService: IEditorOperationsFactoryService,
+        _outliningManagerService: IOutliningManagerService,
+        _undoManagerProvider: ITextBufferUndoManagerProvider
     ) = 
 
     /// Use an object instance as a key.  Makes it harder for components to ignore this
@@ -1456,7 +1456,7 @@ type CommonOperationsFactory
     let _key = System.Object()
 
     /// Create an ICommonOperations instance for the given VimBufferData
-    member x.CreateCommonOperations (vimBufferData : IVimBufferData) =
+    member x.CreateCommonOperations (vimBufferData: IVimBufferData) =
         let textView = vimBufferData.TextView
         let editorOperations = _editorOperationsFactoryService.GetEditorOperations(textView)
 
@@ -1469,7 +1469,7 @@ type CommonOperationsFactory
         CommonOperations(vimBufferData, editorOperations, outlining) :> ICommonOperations
 
     /// Get or create the ICommonOperations for the given buffer
-    member x.GetCommonOperations (bufferData : IVimBufferData) = 
+    member x.GetCommonOperations (bufferData: IVimBufferData) = 
         let properties = bufferData.TextView.Properties
         properties.GetOrCreateSingletonProperty(_key, (fun () -> x.CreateCommonOperations bufferData))
 

--- a/Src/VimCore/CommonOperations.fsi
+++ b/Src/VimCore/CommonOperations.fsi
@@ -8,4 +8,4 @@ open Microsoft.VisualStudio.Text.Outlining
 
 module internal CommonUtil =
 
-    val RaiseSearchResultMessage : IStatusUtil -> SearchResult -> unit
+    val RaiseSearchResultMessage: IStatusUtil -> SearchResult -> unit

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -42,7 +42,7 @@ type CaretMovement =
         | Direction.Left -> CaretMovement.Left
         | _ -> raise (Contract.GetInvalidEnumException direction)
 
-type TextViewEventArgs(_textView : ITextView) =
+type TextViewEventArgs(_textView: ITextView) =
     inherit System.EventArgs()
 
     member x.TextView = _textView
@@ -54,10 +54,10 @@ type VimRcKind =
 type VimRcPath = { 
 
     /// Which type of file was loaded 
-    VimRcKind : VimRcKind 
+    VimRcKind: VimRcKind 
 
     /// Full path to the file which the contents were loaded from
-    FilePath : string
+    FilePath: string
 }
 
 [<RequireQualifiedAccess>]
@@ -91,39 +91,39 @@ type ChangeCharacterKind =
 type IStatusUtil =
 
     /// Raised when there is a special status message that needs to be reported
-    abstract OnStatus : string -> unit
+    abstract OnStatus: string -> unit
 
     /// Raised when there is a long status message that needs to be reported
-    abstract OnStatusLong : string seq -> unit 
+    abstract OnStatusLong: string seq -> unit 
 
     /// Raised when there is an error message that needs to be reported
-    abstract OnError : string -> unit 
+    abstract OnError: string -> unit 
 
     /// Raised when there is a warning message that needs to be reported
-    abstract OnWarning : string -> unit 
+    abstract OnWarning: string -> unit 
 
 /// Abstracts away VsVim's interaction with the file system to facilitate testing
 type IFileSystem =
 
     /// Create the specified directory, returns true if it was actually created
-    abstract CreateDirectory : path : string -> bool 
+    abstract CreateDirectory: path: string -> bool 
 
     /// Get the directories to probe for RC files
-    abstract GetVimRcDirectories : unit -> string[]
+    abstract GetVimRcDirectories: unit -> string[]
 
     /// Get the possible paths for a vimrc file in the order they should be 
     /// considered 
-    abstract GetVimRcFilePaths : unit -> VimRcPath[]
+    abstract GetVimRcFilePaths: unit -> VimRcPath[]
 
     /// Attempt to read all of the lines from the given file 
-    abstract ReadAllLines : filePath : string -> string[] option
+    abstract ReadAllLines: filePath: string -> string[] option
 
     /// Read the contents of the directory 
-    abstract ReadDirectoryContents : directoryPath : string -> string[] option
+    abstract ReadDirectoryContents: directoryPath: string -> string[] option
 
-    abstract Read : filePath : string -> Stream option
+    abstract Read: filePath: string -> Stream option
 
-    abstract Write : filePath : string -> stream : Stream -> bool
+    abstract Write: filePath: string -> stream: Stream -> bool
 
 /// Utility function for searching for Word values.  This is a MEF importable
 /// component
@@ -131,15 +131,15 @@ type IFileSystem =
 type IWordUtil = 
 
     /// Get the full word span for the word value which crosses the given SnapshotPoint
-    abstract GetFullWordSpan : wordKind : WordKind -> point : SnapshotPoint -> SnapshotSpan option
+    abstract GetFullWordSpan: wordKind: WordKind -> point: SnapshotPoint -> SnapshotSpan option
 
     /// Get the SnapshotSpan for Word values from the given point.  If the provided point is 
     /// in the middle of a word the span of the entire word will be returned
-    abstract GetWords : wordKind : WordKind -> path : SearchPath -> point : SnapshotPoint -> SnapshotSpan seq
+    abstract GetWords: wordKind: WordKind -> path: SearchPath -> point: SnapshotPoint -> SnapshotSpan seq
 
     /// Create an ITextStructureNavigator where the extent of words is calculated for
     /// the specified WordKind value
-    abstract CreateTextStructureNavigator : wordKind : WordKind -> contentType : IContentType -> ITextStructureNavigator
+    abstract CreateTextStructureNavigator: wordKind: WordKind -> contentType: IContentType -> ITextStructureNavigator
 
 /// Used to display a word completion list to the user
 type IWordCompletionSession =
@@ -147,25 +147,25 @@ type IWordCompletionSession =
     inherit IPropertyOwner
 
     /// Is the session dismissed
-    abstract IsDismissed : bool
+    abstract IsDismissed: bool
 
     /// The associated ITextView instance
-    abstract TextView : ITextView
+    abstract TextView: ITextView
 
     /// Select the next word in the session
-    abstract MoveNext : unit -> bool
+    abstract MoveNext: unit -> bool
 
     /// Select the previous word in the session.
-    abstract MovePrevious : unit -> bool
+    abstract MovePrevious: unit -> bool
 
     /// Dismiss the completion session 
-    abstract Dismiss : unit -> unit
+    abstract Dismiss: unit -> unit
 
     /// Raised when the session is dismissed
     [<CLIEvent>]
-    abstract Dismissed : IDelegateEvent<System.EventHandler>
+    abstract Dismissed: IDelegateEvent<System.EventHandler>
 
-type WordCompletionSessionEventArgs(_wordCompletionSession : IWordCompletionSession) =
+type WordCompletionSessionEventArgs(_wordCompletionSession: IWordCompletionSession) =
     inherit System.EventArgs()
 
     member x.WordCompletionSession = _wordCompletionSession
@@ -174,20 +174,20 @@ type WordCompletionSessionEventArgs(_wordCompletionSession : IWordCompletionSess
 type IWordCompletionSessionFactoryService = 
 
     /// Create a session with the given set of words
-    abstract CreateWordCompletionSession : textView : ITextView -> wordSpan : SnapshotSpan -> words : string seq -> isForward : bool -> IWordCompletionSession
+    abstract CreateWordCompletionSession: textView: ITextView -> wordSpan: SnapshotSpan -> words: string seq -> isForward: bool -> IWordCompletionSession
 
     /// Raised when the session is created
     [<CLIEvent>]
-    abstract Created : IDelegateEvent<System.EventHandler<WordCompletionSessionEventArgs>>
+    abstract Created: IDelegateEvent<System.EventHandler<WordCompletionSessionEventArgs>>
 
 /// Wraps an ITextUndoTransaction so we can avoid all of the null checks
 type IUndoTransaction =
 
     /// Call when it completes
-    abstract Complete : unit -> unit
+    abstract Complete: unit -> unit
 
     /// Cancels the transaction
-    abstract Cancel : unit -> unit
+    abstract Cancel: unit -> unit
 
     inherit System.IDisposable
 
@@ -196,11 +196,11 @@ type ITextViewUndoTransaction =
 
     /// Adds an ITextUndoPrimitive which will reset the selection to the current
     /// state when redoing this edit
-    abstract AddAfterTextBufferChangePrimitive : unit -> unit
+    abstract AddAfterTextBufferChangePrimitive: unit -> unit
 
     /// Adds an ITextUndoPrimitive which will reset the selection to the current
     /// state when undoing this change
-    abstract AddBeforeTextBufferChangePrimitive : unit -> unit
+    abstract AddBeforeTextBufferChangePrimitive: unit -> unit
 
     inherit IUndoTransaction
 
@@ -216,7 +216,7 @@ type LinkedUndoTransactionFlags =
 type ILinkedUndoTransaction =
 
     /// Complete the linked operation
-    abstract Complete : unit -> unit
+    abstract Complete: unit -> unit
 
     inherit System.IDisposable
 
@@ -224,37 +224,37 @@ type ILinkedUndoTransaction =
 type IUndoRedoOperations = 
 
     /// Is there an open linked undo transaction
-    abstract InLinkedUndoTransaction : bool
+    abstract InLinkedUndoTransaction: bool
 
     /// StatusUtil instance that is used to report errors
-    abstract StatusUtil : IStatusUtil
+    abstract StatusUtil: IStatusUtil
 
     /// Close the IUndoRedoOperations and remove any attached event handlers
-    abstract Close : unit -> unit
+    abstract Close: unit -> unit
 
     /// Creates an Undo Transaction
-    abstract CreateUndoTransaction : name : string -> IUndoTransaction
+    abstract CreateUndoTransaction: name: string -> IUndoTransaction
 
     /// Creates an Undo Transaction specific to the given ITextView.  Use when operations
     /// like caret position need to be a part of the undo / redo stack
-    abstract CreateTextViewUndoTransaction : name : string -> textView : ITextView -> ITextViewUndoTransaction
+    abstract CreateTextViewUndoTransaction: name: string -> textView: ITextView -> ITextViewUndoTransaction
 
     /// Creates a linked undo transaction
-    abstract CreateLinkedUndoTransaction : name : string -> ILinkedUndoTransaction
+    abstract CreateLinkedUndoTransaction: name: string -> ILinkedUndoTransaction
 
     /// Creates a linked undo transaction with flags
-    abstract CreateLinkedUndoTransactionWithFlags : name : string -> flags : LinkedUndoTransactionFlags -> ILinkedUndoTransaction
+    abstract CreateLinkedUndoTransactionWithFlags: name: string -> flags: LinkedUndoTransactionFlags -> ILinkedUndoTransaction
 
     /// Wrap the passed in "action" inside an undo transaction.  This is needed
     /// when making edits such as paste so that the cursor will move properly 
     /// during an undo operation
-    abstract EditWithUndoTransaction<'T> : name : string -> textView : ITextView -> action : (unit -> 'T) -> 'T
+    abstract EditWithUndoTransaction: name: string -> textView: ITextView -> action: (unit -> 'T) -> 'T
 
     /// Redo the last "count" operations
-    abstract Redo : count:int -> unit
+    abstract Redo: count:int -> unit
 
     /// Undo the last "count" operations
-    abstract Undo : count:int -> unit
+    abstract Undo: count:int -> unit
 
 /// Represents a set of changes to a contiguous region. 
 [<RequireQualifiedAccess>]
@@ -268,7 +268,7 @@ type TextChange =
 
     /// Get the insert text resulting from the change if there is any
     member x.InsertText = 
-        let rec inner textChange (text : string) = 
+        let rec inner textChange (text: string) = 
             match textChange with 
             | Insert data -> text + data |> Some
             | DeleteLeft count -> 
@@ -320,7 +320,7 @@ type TextChange =
 
         // Insert can only merge with a previous insert operation.  It can't 
         // merge with any deletes that came before it
-        let reduceInsert before (text : string) =
+        let reduceInsert before (text: string) =
             match before with
             | Insert otherText -> Some (Insert (otherText + text))
             | _ -> None 
@@ -394,7 +394,7 @@ type TextChange =
         | None -> Combination (left, right)
         | Some textChange -> textChange
 
-type TextChangeEventArgs(_textChange : TextChange) =
+type TextChangeEventArgs(_textChange: TextChange) =
     inherit System.EventArgs()
 
     member x.TextChange = _textChange
@@ -416,13 +416,13 @@ type SearchOptions =
 type PatternData = {
 
     /// The Pattern to search for
-    Pattern : string
+    Pattern: string
 
     /// The direction in which the pattern was searched for
-    Path : SearchPath
+    Path: SearchPath
 }
 
-type PatternDataEventArgs(_patternData : PatternData) =
+type PatternDataEventArgs(_patternData: PatternData) =
     inherit System.EventArgs()
 
     member x.PatternData = _patternData
@@ -442,7 +442,7 @@ type SearchOffsetData =
 
     with 
 
-    static member private ParseCore (offset : string) =
+    static member private ParseCore (offset: string) =
         Contract.Requires (offset.Length > 0)
 
         let index = ref 0
@@ -528,7 +528,7 @@ type SearchOffsetData =
             | ';' -> parseSearch () 
             | _ -> SearchOffsetData.None
 
-    static member Parse (offset : string) =
+    static member Parse (offset: string) =
         if StringUtil.IsNullOrEmpty offset then
             SearchOffsetData.None
         else
@@ -538,17 +538,17 @@ type SearchOffsetData =
 [<DebuggerDisplay("{ToString(),nq}")>]
 type SearchData
     (
-        _pattern : string,
-        _offset : SearchOffsetData,
-        _kind : SearchKind,
-        _options : SearchOptions
+        _pattern: string,
+        _offset: SearchOffsetData,
+        _kind: SearchKind,
+        _options: SearchOptions
     ) = 
 
-    new (pattern : string, path : SearchPath, isWrap : bool) =
+    new (pattern: string, path: SearchPath, isWrap: bool) =
         let kind = SearchKind.OfPathAndWrap path isWrap
         SearchData(pattern, SearchOffsetData.None, kind, SearchOptions.Default)
 
-    new (pattern : string, path : SearchPath) = 
+    new (pattern: string, path: SearchPath) = 
         let kind = SearchKind.OfPathAndWrap path true
         SearchData(pattern, SearchOffsetData.None, kind, SearchOptions.Default)
 
@@ -588,7 +588,7 @@ type SearchData
             _kind = other.Kind &&
             _options = other.Options
 
-    override x.Equals(other : obj) = 
+    override x.Equals(other: obj) = 
         match other with
         | :? SearchData as otherSearchData -> x.Equals(otherSearchData);
         | _ -> false 
@@ -604,7 +604,7 @@ type SearchData
 
     /// Parse out a SearchData value given the specific pattern and SearchKind.  The pattern should
     /// not include a beginning / or ?.  That should be removed by this point
-    static member Parse (pattern : string) (searchKind : SearchKind) searchOptions =
+    static member Parse (pattern: string) (searchKind: SearchKind) searchOptions =
         let mutable index = -1
         let mutable i = 1
         let targetChar = 
@@ -627,7 +627,7 @@ type SearchData
     interface System.IEquatable<SearchData> with
         member x.Equals other = x.Equals(other)
 
-type SearchDataEventArgs(_searchData : SearchData) =
+type SearchDataEventArgs(_searchData: SearchData) =
     inherit System.EventArgs()
 
     member x.SearchData = _searchData
@@ -666,7 +666,7 @@ type SearchResult =
         | SearchResult.NotFound (searchData, _) -> searchData
         | SearchResult.Error (searchData, _) -> searchData
 
-type SearchResultEventArgs(_searchResult : SearchResult) = 
+type SearchResultEventArgs(_searchResult: SearchResult) = 
     inherit System.EventArgs()
 
     member x.SearchResult = _searchResult
@@ -679,11 +679,11 @@ type ISearchService =
 
     /// Find the next occurrence of the pattern in the buffer starting at the 
     /// given SnapshotPoint
-    abstract FindNext : searchPoint : SnapshotPoint -> searchData : SearchData -> navigator : ITextStructureNavigator -> SearchResult
+    abstract FindNext: searchPoint: SnapshotPoint -> searchData: SearchData -> navigator: ITextStructureNavigator -> SearchResult
 
     /// Find the next 'count' occurrence of the specified pattern.  Note: The first occurrence won't
     /// match anything at the provided start point.  That will be adjusted appropriately
-    abstract FindNextPattern : searchPoint : SnapshotPoint -> searchPoint : SearchData -> navigator : ITextStructureNavigator -> count : int -> SearchResult
+    abstract FindNextPattern: searchPoint: SnapshotPoint -> searchPoint: SearchData -> navigator: ITextStructureNavigator -> count: int -> SearchResult
 
 /// Column information about the caret in relation to this Motion Result
 [<RequireQualifiedAccess>]
@@ -757,25 +757,25 @@ type MotionKind =
 type MotionResult = {
 
     /// Span of the motion.
-    Span : SnapshotSpan
+    Span: SnapshotSpan
 
     /// In the case this MotionResult is the result of an exclusive promotion, this will 
     /// hold the original SnapshotSpan
-    OriginalSpan : SnapshotSpan
+    OriginalSpan: SnapshotSpan
 
     /// Is the motion forward
-    IsForward : bool
+    IsForward: bool
 
     /// Kind of the motion
-    MotionKind : MotionKind
+    MotionKind: MotionKind
 
     /// The flags on the MotionRelult
-    MotionResultFlags : MotionResultFlags
+    MotionResultFlags: MotionResultFlags
 
     /// In addition to recording the Span, certain motions like j, k, and | also
     /// record data about the desired column within the span.  This value may or may not
     /// be a valid point within the line
-    DesiredColumn : CaretColumn
+    DesiredColumn: CaretColumn
 
 } with
 
@@ -856,13 +856,13 @@ type MotionContext =
 type MotionArgument = {
 
     /// Context of the Motion
-    MotionContext : MotionContext
+    MotionContext: MotionContext
 
     /// Count passed to the operator
-    OperatorCount : int option
+    OperatorCount: int option
 
     /// Count passed to the motion 
-    MotionCount : int option 
+    MotionCount: int option 
 
 } with
 
@@ -1144,16 +1144,16 @@ type Motion =
 and IMotionUtil =
 
     /// The associated ITextView instance
-    abstract TextView : ITextView
+    abstract TextView: ITextView
 
     /// Get the specified Motion value 
-    abstract GetMotion : motion : Motion -> motionArgument : MotionArgument -> MotionResult option 
+    abstract GetMotion: motion: Motion -> motionArgument: MotionArgument -> MotionResult option 
 
     /// Get the specific text object motion from the given SnapshotPoint
-    abstract GetTextObject : motion : Motion -> point : SnapshotPoint -> MotionResult option
+    abstract GetTextObject: motion: Motion -> point: SnapshotPoint -> MotionResult option
 
     /// Get the expanded tag point for the given tag block kind
-    abstract GetExpandedTagBlock : point : SnapshotPoint -> kind : TagBlockKind -> SnapshotSpan option
+    abstract GetExpandedTagBlock: point: SnapshotPoint -> kind: TagBlockKind -> SnapshotSpan option
 
 type ModeKind = 
     | Normal = 1
@@ -1298,7 +1298,7 @@ type KeyInputSet =
         | ManyKeyInputs list -> ManyKeyInputs (list @ [ki])
 
     /// Does the name start with the given KeyInputSet
-    member x.StartsWith (targetName : KeyInputSet) = 
+    member x.StartsWith (targetName: KeyInputSet) = 
         match targetName,x with
         | Empty, _ -> true
         | OneKeyInput leftKi, OneKeyInput rightKi ->  leftKi = rightKi
@@ -1310,7 +1310,7 @@ type KeyInputSet =
                 SeqUtil.contentsEqual (left |> Seq.ofList) (right |> Seq.ofList |> Seq.take left.Length)
             else false
 
-    member x.CompareTo (other : KeyInputSet) = 
+    member x.CompareTo (other: KeyInputSet) = 
         let rec inner (left:KeyInput list) (right:KeyInput list) =
             if left.IsEmpty && right.IsEmpty then 0
             elif left.IsEmpty then -1
@@ -1391,7 +1391,7 @@ module KeyInputSetUtil =
         |> Seq.map KeyInputUtil.VimKeyToKeyInput
         |> OfSeq
 
-    let Combine (left : KeyInputSet) (right : KeyInputSet) =
+    let Combine (left: KeyInputSet) (right: KeyInputSet) =
         let all = left.KeyInputs @ right.KeyInputs
         OfList all
 
@@ -1441,13 +1441,13 @@ type KeyMappingResult =
 [<DebuggerDisplay("{ToString()}")>]
 type CharacterSpan = 
 
-    val private _start : SnapshotPoint
+    val private _start: SnapshotPoint
 
-    val private _lineCount : int
+    val private _lineCount: int
 
-    val private _lastLineLength : int
+    val private _lastLineLength: int
 
-    new (start : SnapshotPoint, lineCount : int, lastLineLength : int) =
+    new (start: SnapshotPoint, lineCount: int, lastLineLength: int) =
 
         // Don't let the last line of the CharacterSpan end partially into a line 
         // break.  Encompass the entire line break instead 
@@ -1465,7 +1465,7 @@ type CharacterSpan =
             _lineCount = lineCount
             _lastLineLength = lastLineLength }
 
-    new (span : SnapshotSpan) = 
+    new (span: SnapshotSpan) = 
         let lineCount = SnapshotSpanUtil.GetLineCount span
         let lastLine = SnapshotSpanUtil.GetLastLine span
         let lastLineLength = 
@@ -1476,7 +1476,7 @@ type CharacterSpan =
                 max 0 diff
         CharacterSpan(span.Start, lineCount, lastLineLength)
 
-    new (startPoint : SnapshotPoint, endPoint: SnapshotPoint) =
+    new (startPoint: SnapshotPoint, endPoint: SnapshotPoint) =
         let span = SnapshotSpan(startPoint, endPoint)
         CharacterSpan(span)
 
@@ -1497,7 +1497,7 @@ type CharacterSpan =
 
     /// The last point included in the CharacterSpan
     member x.Last = 
-        let endPoint : SnapshotPoint = x.End
+        let endPoint: SnapshotPoint = x.End
         if endPoint.Position = x.Start.Position then
             None
         else
@@ -1552,10 +1552,10 @@ type CharacterSpan =
 [<Struct>]
 type BlockSpan =
 
-    val private _startPoint : SnapshotPoint
-    val private _tabStop : int
-    val private _spaces : int
-    val private _height : int
+    val private _startPoint: SnapshotPoint
+    val private _tabStop: int
+    val private _spaces: int
+    val private _height: int
 
     new (startPoint, tabStop, spaces, height) = 
         { _startPoint = startPoint; _tabStop = tabStop; _spaces = spaces; _height = height }
@@ -1600,7 +1600,7 @@ type BlockSpan =
     member x.TextBuffer =  x.Start.Snapshot.TextBuffer
 
     /// Get the NonEmptyCollection<SnapshotSpan> for the given block information
-    member x.BlockSpans : NonEmptyCollection<SnapshotSpan> =
+    member x.BlockSpans: NonEmptyCollection<SnapshotSpan> =
         let snapshot = SnapshotPointUtil.GetSnapshot x.Start
         let offset = x.ColumnSpaces
         let lineNumber = SnapshotPointUtil.GetLineNumber x.Start
@@ -1621,7 +1621,7 @@ type BlockSpan =
     /// Get a NonEmptyCollection indicating of the SnapshotSpan that each line of
     /// this block spans, along with the offset (measured in cells) of the block
     /// with respect to the start point and end point.
-    member x.BlockOverlapSpans : NonEmptyCollection<SnapshotOverlapSpan> =
+    member x.BlockOverlapSpans: NonEmptyCollection<SnapshotOverlapSpan> =
         let snapshot = SnapshotPointUtil.GetSnapshot x.Start
         let offset = x.ColumnSpaces
         let lineNumber = SnapshotPointUtil.GetLineNumber x.Start
@@ -1649,7 +1649,7 @@ type BlockSpan =
     /// height and width.  The start of the BlockSpan is not necessarily the Start of the SnapshotSpan
     /// as an End column which occurs before the start could cause the BlockSpan start to be before the 
     /// SnapshotSpan start
-    static member CreateForSpan (span : SnapshotSpan) tabStop =
+    static member CreateForSpan (span: SnapshotSpan) tabStop =
         let startPoint, width = 
             let startColumnSpaces = SnapshotPointUtil.GetSpacesToPoint span.Start tabStop
             let endColumnSpaces = SnapshotPointUtil.GetSpacesToPoint span.End tabStop
@@ -1774,7 +1774,7 @@ type VisualSpan =
             x
 
     /// Select the given VisualSpan in the ITextView
-    member x.Select (textView : ITextView) path =
+    member x.Select (textView: ITextView) path =
 
         // Select the given SnapshotSpan
         let selectSpan startPoint endPoint = 
@@ -1847,7 +1847,7 @@ type VisualSpan =
     /// Create the VisualSpan based on the specified points.  The activePoint is assumed
     /// to be the end of the selection and hence not included (exclusive) just as it is 
     /// in ITextSelection
-    static member CreateForSelectionPoints visualKind (anchorPoint : SnapshotPoint) (activePoint : SnapshotPoint) tabStop =
+    static member CreateForSelectionPoints visualKind (anchorPoint: SnapshotPoint) (activePoint: SnapshotPoint) tabStop =
 
         match visualKind with
         | VisualKind.Character ->
@@ -1876,7 +1876,7 @@ type VisualSpan =
 
     /// Create a VisualSelection based off of the current selection.  If no selection is present
     /// then an empty VisualSpan will be created at the caret
-    static member CreateForSelection (textView : ITextView) visualKind tabStop =
+    static member CreateForSelection (textView: ITextView) visualKind tabStop =
         let selection = textView.Selection
         if selection.IsEmpty then
             let caretPoint = TextViewUtil.GetCaretPoint textView
@@ -1896,7 +1896,7 @@ type VisualSpan =
                 let visualSpan = VisualSpan.CreateForSelectionPoints visualKind anchorPoint activePoint tabStop
                 visualSpan.AdjustForExtendIntoLineBreak selection.End.IsInVirtualSpace
 
-    static member CreateForSpan (span : SnapshotSpan) visualKind tabStop =
+    static member CreateForSpan (span: SnapshotSpan) visualKind tabStop =
         match visualKind with
         | VisualKind.Character -> CharacterSpan(span) |> Character
         | VisualKind.Line -> span |> SnapshotLineRangeUtil.CreateForSpan |> Line
@@ -1992,7 +1992,7 @@ type VisualSelection =
     /// specified SelectionKind.  
     member x.GetCaretPoint selectionKind = 
 
-        let getAdjustedEnd (span : SnapshotSpan) = 
+        let getAdjustedEnd (span: SnapshotSpan) = 
             if span.Length = 0 then
                 span.Start
             else
@@ -2043,7 +2043,7 @@ type VisualSelection =
 
 
     /// Select the given VisualSpan in the ITextView
-    member x.Select (textView : ITextView) =
+    member x.Select (textView: ITextView) =
         let path =
             match x with
             | Character (_, path) -> path
@@ -2063,7 +2063,7 @@ type VisualSelection =
             VisualSelection.Block (blockSpan, BlockCaretLocation.BottomRight)
 
     /// Create the VisualSelection over the VisualSpan with the specified caret location
-    static member Create (visualSpan : VisualSpan) path (caretPoint : SnapshotPoint) =
+    static member Create (visualSpan: VisualSpan) path (caretPoint: SnapshotPoint) =
         match visualSpan with
         | VisualSpan.Character characterSpan ->
             Character (characterSpan, path)
@@ -2089,7 +2089,7 @@ type VisualSelection =
     /// Create a VisualSelection for the given anchor point and caret.  The position, anchorPoint or 
     /// caretPoint, which is greater position wise is the last point included in the selection.  It
     /// is inclusive
-    static member CreateForPoints visualKind (anchorPoint : SnapshotPoint) (caretPoint : SnapshotPoint) tabStop =
+    static member CreateForPoints visualKind (anchorPoint: SnapshotPoint) (caretPoint: SnapshotPoint) tabStop =
 
         let createBlock () =
             let anchorSpaces = SnapshotPointUtil.GetSpacesToPoint anchorPoint tabStop
@@ -2139,7 +2139,7 @@ type VisualSelection =
     /// Create a VisualSelection based off of the current selection and position of the caret.  The
     /// SelectionKind should specify what the current mode is (or the mode which produced the 
     /// active ITextSelection)
-    static member CreateForSelection (textView : ITextView) visualKind selectionKind tabStop =
+    static member CreateForSelection (textView: ITextView) visualKind selectionKind tabStop =
         let caretPoint = TextViewUtil.GetCaretPoint textView
         let visualSpan = VisualSpan.CreateForSelection textView visualKind tabStop
 
@@ -2195,13 +2195,13 @@ type VisualSelection =
 [<RequireQualifiedAccess>]
 [<NoComparison>]
 type StoredVisualSelection =
-    | Character of width : int
-    | CharacterLine of lineCount : int * lastLineOffset : int 
-    | Line of lineCount : int
+    | Character of width: int
+    | CharacterLine of lineCount: int * lastLineOffset: int 
+    | Line of lineCount: int
 
     with 
 
-    member x.GetVisualSelection (point : SnapshotPoint) count =
+    member x.GetVisualSelection (point: SnapshotPoint) count =
 
         // Get the point which is 'count' columns forward from the passed in point (exclusive). If the point
         // extends past the line break the point past the line break will be returned if possible.
@@ -2399,20 +2399,20 @@ type CommandFlags =
 type MotionData = {
 
     /// The associated Motion value
-    Motion : Motion
+    Motion: Motion
 
     /// The argument which should be supplied to the given Motion
-    MotionArgument : MotionArgument
+    MotionArgument: MotionArgument
 }
 
 /// Data needed to execute a command
 type CommandData = {
 
     /// The raw count provided to the command
-    Count : int option 
+    Count: int option 
 
     /// The register name specified for the command 
-    RegisterName : RegisterName option
+    RegisterName: RegisterName option
 
 } with
 
@@ -2425,7 +2425,7 @@ type CommandData = {
 /// to ease testing requirements.  In order to do this and support Ping we need a 
 /// separate type here to wrap the Func to be comparable.  Does so in a reference 
 /// fashion
-type PingData (_func : CommandData -> CommandResult) = 
+type PingData (_func: CommandData -> CommandResult) = 
 
     member x.Function = _func
 
@@ -3109,26 +3109,26 @@ type BindResult<'T> =
 
     /// Used to compose to BindResult<'T> functions together by forwarding from
     /// one to the other once the value is completed
-    member x.Map (mapFunc : 'T -> BindResult<'U>) : BindResult<'U> =
+    member x.Map (mapFunc: 'T -> BindResult<'U>): BindResult<'U> =
         match x with
         | Complete value -> mapFunc value 
-        | NeedMoreInput (bindData : BindData<'T>) -> NeedMoreInput (bindData.Map mapFunc)
+        | NeedMoreInput (bindData: BindData<'T>) -> NeedMoreInput (bindData.Map mapFunc)
         | Error -> Error
         | Cancelled -> Cancelled
 
     /// Used to convert a BindResult<'T>.Completed to BindResult<'U>.Completed through a conversion
     /// function
-    member x.Convert (convertFunc : 'T -> 'U) : BindResult<'U> = 
+    member x.Convert (convertFunc: 'T -> 'U): BindResult<'U> = 
         x.Map (fun value -> convertFunc value |> BindResult.Complete)
 
 and BindData<'T> = {
 
     /// The optional KeyRemapMode which should be used when binding
     /// the next KeyInput in the sequence
-    KeyRemapMode : KeyRemapMode 
+    KeyRemapMode: KeyRemapMode 
 
     /// Function to call to get the BindResult for this data
-    BindFunction : KeyInput -> BindResult<'T>
+    BindFunction: KeyInput -> BindResult<'T>
 
 } with
 
@@ -3154,7 +3154,7 @@ and BindData<'T> = {
 
     /// Very similar to the Convert function.  This will instead map a BindData<'T>.Completed
     /// to a BindData<'U> of any form 
-    member x.Map<'U> (mapFunc : 'T -> BindResult<'U>) : BindData<'U> = 
+    member x.Map<'U> (mapFunc: 'T -> BindResult<'U>): BindData<'U> = 
 
         let rec inner bindFunction keyInput = 
             match x.BindFunction keyInput with
@@ -3168,7 +3168,7 @@ and BindData<'T> = {
     /// Often types bindings need to compose together because we need an inner binding
     /// to succeed so we can create a projected value.  This function will allow us
     /// to translate a BindResult<'T>.Completed -> BindResult<'U>.Completed
-    member x.Convert (convertFunc : 'T -> 'U) : BindData<'U> = 
+    member x.Convert (convertFunc: 'T -> 'U): BindData<'U> = 
         x.Map (fun value -> convertFunc value |> BindResult.Complete)
 
 /// Several types of BindData<'T> need to take an action when a binding begins against
@@ -3270,27 +3270,27 @@ type CommandBinding =
 and ICommandUtil = 
 
     /// Run a normal command
-    abstract RunNormalCommand : command : NormalCommand -> commandData : CommandData -> CommandResult
+    abstract RunNormalCommand: command: NormalCommand -> commandData: CommandData -> CommandResult
 
     /// Run a visual command
-    abstract RunVisualCommand : command : VisualCommand -> commandData: CommandData -> visualSpan : VisualSpan -> CommandResult
+    abstract RunVisualCommand: command: VisualCommand -> commandData: CommandData -> visualSpan: VisualSpan -> CommandResult
 
     /// Run a insert command
-    abstract RunInsertCommand : command : InsertCommand -> CommandResult
+    abstract RunInsertCommand: command: InsertCommand -> CommandResult
 
     /// Run a command
-    abstract RunCommand : command : Command -> CommandResult
+    abstract RunCommand: command: Command -> CommandResult
 
 type internal IInsertUtil = 
 
     /// Run a insert command
-    abstract RunInsertCommand : insertCommand : InsertCommand -> CommandResult
+    abstract RunInsertCommand: insertCommand: InsertCommand -> CommandResult
 
     /// Repeat the given edit series. 
-    abstract RepeatEdit : textChange : TextChange -> addNewLines : bool -> count : int -> unit
+    abstract RepeatEdit: textChange: TextChange -> addNewLines: bool -> count: int -> unit
 
     /// Repeat the given edit series. 
-    abstract RepeatBlock : command : InsertCommand -> blockSpan : BlockSpan -> string option
+    abstract RepeatBlock: command: InsertCommand -> blockSpan: BlockSpan -> string option
 
 /// Contains the stored information about a Visual Span.  This instance *will* be 
 /// stored for long periods of time and used to repeat a Command instance across
@@ -3300,14 +3300,14 @@ type StoredVisualSpan =
 
     /// Storing a character wise span.  Need to know the line count and the offset 
     /// in the last line for the end.  
-    | Character of lineCount : int * lastLineLength : int
+    | Character of lineCount: int * lastLineLength: int
 
     /// Storing a line wise span just stores the count of lines
-    | Line of count : int
+    | Line of count: int
 
     /// Storing of a block span records the length of the span and the number of
     /// lines which should be affected by the Span
-    | Block of width : int * height : int
+    | Block of width: int * height: int
 
     with
 
@@ -3358,7 +3358,7 @@ type StoredCommand =
         | LinkedCommand (_, right) -> right.LastCommand
 
     /// Create a StoredCommand instance from the given Command value
-    static member OfCommand command (commandBinding : CommandBinding) = 
+    static member OfCommand command (commandBinding: CommandBinding) = 
         match command with 
         | Command.NormalCommand (command, data) -> 
             StoredCommand.NormalCommand (command, data, commandBinding.CommandFlags)
@@ -3427,17 +3427,17 @@ type MotionBinding =
 type CommandRunData = {
 
     /// The binding which the command was invoked from
-    CommandBinding : CommandBinding
+    CommandBinding: CommandBinding
 
     /// The Command which was run
-    Command : Command
+    Command: Command
 
     /// The result of the Command Run
-    CommandResult : CommandResult
+    CommandResult: CommandResult
 
 }
 
-type CommandRunDataEventArgs(_commandRunData : CommandRunData) =
+type CommandRunDataEventArgs(_commandRunData: CommandRunData) =
     inherit System.EventArgs()
 
     member x.CommandRunData = _commandRunData
@@ -3447,67 +3447,67 @@ type CommandRunDataEventArgs(_commandRunData : CommandRunData) =
 type IMotionCapture =
 
     /// Associated ITextView
-    abstract TextView : ITextView
+    abstract TextView: ITextView
     
     /// Set of MotionBinding values supported
-    abstract MotionBindings : MotionBinding list
+    abstract MotionBindings: MotionBinding list
 
     /// Get the motion and count starting with the given KeyInput
-    abstract GetMotionAndCount : KeyInput -> BindResult<Motion * int option>
+    abstract GetMotionAndCount: KeyInput -> BindResult<Motion * int option>
 
     /// Get the motion with the provided KeyInput
-    abstract GetMotion : KeyInput -> BindResult<Motion>
+    abstract GetMotion: KeyInput -> BindResult<Motion>
 
 /// Responsible for managing a set of Commands and running them
 type ICommandRunner =
 
     /// Set of Commands currently supported
-    abstract Commands : CommandBinding seq
+    abstract Commands: CommandBinding seq
 
     /// In certain circumstances a specific type of key remapping needs to occur for input.  This 
     /// option will have the appropriate value in those circumstances.  For example while processing
     /// the {char} argument to f,F,t or T the Language mapping will be used
-    abstract KeyRemapMode : KeyRemapMode 
+    abstract KeyRemapMode: KeyRemapMode 
 
     /// True when in the middle of a count operation
-    abstract InCount : bool
+    abstract InCount: bool
 
     /// Is the command runner currently binding a command which needs to explicitly handle escape
-    abstract IsHandlingEscape : bool
+    abstract IsHandlingEscape: bool
 
     /// True if waiting on more input
-    abstract IsWaitingForMoreInput : bool
+    abstract IsWaitingForMoreInput: bool
 
     /// True if the current command has a register associated with it 
-    abstract HasRegisterName : bool 
+    abstract HasRegisterName: bool 
 
     /// True if the current command has a count associated with it 
-    abstract HasCount : bool
+    abstract HasCount: bool
 
     /// When HasRegister is true this has the associated RegisterName 
-    abstract RegisterName : RegisterName
+    abstract RegisterName: RegisterName
 
     /// When HasCount is true this has the associated count
-    abstract Count : int 
+    abstract Count: int 
 
     /// Add a Command.  If there is already a Command with the same name an exception will
     /// be raised
-    abstract Add : CommandBinding -> unit
+    abstract Add: CommandBinding -> unit
 
     /// Remove a command with the specified name
-    abstract Remove : KeyInputSet -> unit
+    abstract Remove: KeyInputSet -> unit
 
     /// Process the given KeyInput.  If the command completed it will return a result.  A
     /// None value implies more input is needed to finish the operation
-    abstract Run : KeyInput -> BindResult<CommandRunData>
+    abstract Run: KeyInput -> BindResult<CommandRunData>
 
     /// If currently waiting for more input on a Command, reset to the 
     /// initial state
-    abstract ResetState : unit -> unit
+    abstract ResetState: unit -> unit
 
     /// Raised when a command is successfully run
     [<CLIEvent>]
-    abstract CommandRan : IDelegateEvent<System.EventHandler<CommandRunDataEventArgs>>
+    abstract CommandRan: IDelegateEvent<System.EventHandler<CommandRunDataEventArgs>>
 
 /// Information about a single key mapping
 [<NoComparison>]
@@ -3515,48 +3515,48 @@ type ICommandRunner =
 type KeyMapping = {
 
     // The LHS of the key mapping
-    Left : KeyInputSet
+    Left: KeyInputSet
 
     // The RHS of the key mapping
-    Right : KeyInputSet 
+    Right: KeyInputSet 
 
     // Does the expansion participate in remapping
-    AllowRemap : bool
+    AllowRemap: bool
 }
 
 /// Manages the key map for Vim.  Responsible for handling all key remappings
 type IKeyMap =
 
     /// Is the mapping of the 0 key currently enabled
-    abstract IsZeroMappingEnabled : bool with get, set 
+    abstract IsZeroMappingEnabled: bool with get, set 
 
     /// Get all mappings for the specified mode
-    abstract GetKeyMappingsForMode : KeyRemapMode -> KeyMapping list
+    abstract GetKeyMappingsForMode: KeyRemapMode -> KeyMapping list
 
     /// Get the mapping for the provided KeyInput for the given mode.  If no mapping exists
     /// then a sequence of a single element containing the passed in key will be returned.  
     /// If a recursive mapping is detected it will not be persued and treated instead as 
     /// if the recursion did not exist
-    abstract GetKeyMapping : KeyInputSet -> KeyRemapMode -> KeyMappingResult
+    abstract GetKeyMapping: KeyInputSet -> KeyRemapMode -> KeyMappingResult
 
     /// Map the given key sequence without allowing for remaping
-    abstract MapWithNoRemap : lhs : string -> rhs : string -> KeyRemapMode -> bool
+    abstract MapWithNoRemap: lhs: string -> rhs: string -> KeyRemapMode -> bool
 
     /// Map the given key sequence allowing for a remap 
-    abstract MapWithRemap : lhs : string -> rhs : string -> KeyRemapMode -> bool
+    abstract MapWithRemap: lhs: string -> rhs: string -> KeyRemapMode -> bool
 
     /// Unmap the specified key sequence for the specified mode
-    abstract Unmap : lhs : string -> KeyRemapMode -> bool
+    abstract Unmap: lhs: string -> KeyRemapMode -> bool
 
     /// Unmap the specified key sequence for the specified mode by considering
     /// the passed in value to be an expansion
-    abstract UnmapByMapping : righs : string -> KeyRemapMode -> bool
+    abstract UnmapByMapping: righs: string -> KeyRemapMode -> bool
 
     /// Clear the Key mappings for the specified mode
-    abstract Clear : KeyRemapMode -> unit
+    abstract Clear: KeyRemapMode -> unit
 
     /// Clear the Key mappings for all modes
-    abstract ClearAll : unit -> unit
+    abstract ClearAll: unit -> unit
 
 /// Jump list information associated with an IVimBuffer.  This is maintained as a forward
 /// and backwards traversable list of points with which to navigate to
@@ -3568,89 +3568,89 @@ type IKeyMap =
 type IJumpList = 
 
     /// Associated ITextView instance
-    abstract TextView : ITextView
+    abstract TextView: ITextView
 
     /// Current value in the jump list.  Will be None if we are not currently traversing the
     /// jump list
-    abstract Current : SnapshotPoint option
+    abstract Current: SnapshotPoint option
 
     /// Current index into the jump list.  Will be None if we are not currently traversing
     /// the jump list
-    abstract CurrentIndex : int option
+    abstract CurrentIndex: int option
 
     /// True if we are currently traversing the list
-    abstract IsTraversing : bool
+    abstract IsTraversing: bool
 
     /// Get all of the jumps in the jump list.  Returns in order of most recent to oldest
-    abstract Jumps : VirtualSnapshotPoint list
+    abstract Jumps: VirtualSnapshotPoint list
 
     /// The SnapshotPoint when the last jump occurred
-    abstract LastJumpLocation : VirtualSnapshotPoint option
+    abstract LastJumpLocation: VirtualSnapshotPoint option
 
     /// Add a given SnapshotPoint to the jump list.  This will reset Current to point to 
     /// the begining of the jump list
-    abstract Add : SnapshotPoint -> unit
+    abstract Add: SnapshotPoint -> unit
 
     /// Clear out all of the stored jump information.  Removes all tracking information from
     /// the IJumpList
-    abstract Clear : unit -> unit
+    abstract Clear: unit -> unit
 
     /// Move to the previous point in the jump list.  This will fail if we are not traversing
     /// the list or at the end 
-    abstract MoveOlder : int -> bool
+    abstract MoveOlder: int -> bool
 
     /// Move to the next point in the jump list.  This will fail if we are not traversing
     /// the list or at the start
-    abstract MoveNewer : int -> bool
+    abstract MoveNewer: int -> bool
 
     /// Set the last jump location to the given line and column
-    abstract SetLastJumpLocation : line : int -> column : int -> unit
+    abstract SetLastJumpLocation: line: int -> column: int -> unit
 
     /// Start a traversal of the list
-    abstract StartTraversal : unit -> unit
+    abstract StartTraversal: unit -> unit
 
 type IIncrementalSearch = 
 
     /// True when a search is occurring
-    abstract InSearch : bool
+    abstract InSearch: bool
 
     /// True when the search is in a paste wait state
-    abstract InPasteWait : bool
+    abstract InPasteWait: bool
 
     /// When in the middle of a search this will return the SearchData for 
     /// the search
-    abstract CurrentSearchData : SearchData 
+    abstract CurrentSearchData: SearchData 
 
     /// When in the middle of a search this will return the SearchResult for the 
     /// search
-    abstract CurrentSearchResult : SearchResult 
+    abstract CurrentSearchResult: SearchResult 
 
     /// When in the middle of a search this will return the actual text which
     /// is being searched for
-    abstract CurrentSearchText : string
+    abstract CurrentSearchText: string
 
     /// The ITextStructureNavigator used for finding 'word' values in the ITextBuffer
-    abstract WordNavigator : ITextStructureNavigator
+    abstract WordNavigator: ITextStructureNavigator
 
     /// Begin an incremental search in the ITextView
-    abstract Begin : path : SearchPath -> BindData<SearchResult>
+    abstract Begin: path: SearchPath -> BindData<SearchResult>
 
     /// Cancel an incremental search which is currently in progress
-    abstract Cancel : unit -> unit
+    abstract Cancel: unit -> unit
 
     /// Reset the current search to be the given value 
-    abstract ResetSearch : pattern : string -> unit
+    abstract ResetSearch: pattern: string -> unit
 
     [<CLIEvent>]
-    abstract CurrentSearchUpdated : IDelegateEvent<System.EventHandler<SearchResultEventArgs>>
+    abstract CurrentSearchUpdated: IDelegateEvent<System.EventHandler<SearchResultEventArgs>>
 
     [<CLIEvent>]
-    abstract CurrentSearchCompleted : IDelegateEvent<System.EventHandler<SearchResultEventArgs>>
+    abstract CurrentSearchCompleted: IDelegateEvent<System.EventHandler<SearchResultEventArgs>>
 
     [<CLIEvent>]
-    abstract CurrentSearchCancelled : IDelegateEvent<System.EventHandler<SearchDataEventArgs>>
+    abstract CurrentSearchCancelled: IDelegateEvent<System.EventHandler<SearchDataEventArgs>>
 
-type RecordRegisterEventArgs(_register : Register, _isAppend : bool) =
+type RecordRegisterEventArgs(_register: Register, _isAppend: bool) =
     inherit System.EventArgs()
     
     member x.Register = _register
@@ -3661,26 +3661,26 @@ type RecordRegisterEventArgs(_register : Register, _isAppend : bool) =
 type IMacroRecorder =
 
     /// The current recording 
-    abstract CurrentRecording : KeyInput list option
+    abstract CurrentRecording: KeyInput list option
 
     /// Is a macro currently recording
-    abstract IsRecording : bool
+    abstract IsRecording: bool
 
     /// Start recording a macro into the specified Register.  Will fail if the recorder
     /// is already recording
-    abstract StartRecording : register : Register -> isAppend : bool -> unit
+    abstract StartRecording: register: Register -> isAppend: bool -> unit
 
     /// Stop recording a macro.  Will fail if it's not actually recording
-    abstract StopRecording : unit -> unit
+    abstract StopRecording: unit -> unit
 
     /// Raised when a macro recording is started.  Passes the Register where the recording
     /// will take place.  The bool is whether the record is an append or not
     [<CLIEvent>]
-    abstract RecordingStarted : IDelegateEvent<System.EventHandler<RecordRegisterEventArgs>>
+    abstract RecordingStarted: IDelegateEvent<System.EventHandler<RecordRegisterEventArgs>>
 
     /// Raised when a macro recording is completed.
     [<CLIEvent>]
-    abstract RecordingStopped : IDelegateEvent<System.EventHandler>
+    abstract RecordingStopped: IDelegateEvent<System.EventHandler>
 
 [<RequireQualifiedAccess>]
 type ProcessResult = 
@@ -3768,21 +3768,21 @@ type ProcessResult =
         | CommandResult.Completed modeSwitch -> Handled modeSwitch
         | CommandResult.Error -> Error
 
-type StringEventArgs(_message : string) =
+type StringEventArgs(_message: string) =
     inherit System.EventArgs()
 
     member x.Message = _message
 
     override x.ToString() = _message
 
-type KeyInputEventArgs (_keyInput : KeyInput) = 
+type KeyInputEventArgs (_keyInput: KeyInput) = 
     inherit System.EventArgs()
 
     member x.KeyInput = _keyInput
 
     override x.ToString() = _keyInput.ToString()
 
-type KeyInputStartEventArgs (_keyInput : KeyInput) =
+type KeyInputStartEventArgs (_keyInput: KeyInput) =
     inherit KeyInputEventArgs(_keyInput)
 
     let mutable _handled = false
@@ -3793,14 +3793,14 @@ type KeyInputStartEventArgs (_keyInput : KeyInput) =
 
     override x.ToString() = _keyInput.ToString()
 
-type KeyInputSetEventArgs (_keyInputSet : KeyInputSet) = 
+type KeyInputSetEventArgs (_keyInputSet: KeyInputSet) = 
     inherit System.EventArgs()
 
     member x.KeyInputSet = _keyInputSet
 
     override x.ToString() = _keyInputSet.ToString()
 
-type KeyInputProcessedEventArgs(_keyInput : KeyInput, _processResult : ProcessResult) =
+type KeyInputProcessedEventArgs(_keyInput: KeyInput, _processResult: ProcessResult) =
     inherit System.EventArgs()
 
     member x.KeyInput = _keyInput
@@ -3813,7 +3813,7 @@ type KeyInputProcessedEventArgs(_keyInput : KeyInput, _processResult : ProcessRe
 /// of history lists in Vim (:help history).  
 type HistoryList () = 
 
-    let mutable _list : string list = List.empty
+    let mutable _list: string list = List.empty
     let mutable _limit = VimConstants.DefaultHistoryLength
     let mutable _totalCount = 0
 
@@ -3873,118 +3873,118 @@ type HistoryList () =
 type internal IHistoryClient<'TData, 'TResult> =
 
     /// History list used by this client
-    abstract HistoryList : HistoryList
+    abstract HistoryList: HistoryList
 
     /// Get the register map 
-    abstract RegisterMap : IRegisterMap
+    abstract RegisterMap: IRegisterMap
 
     /// What remapping mode if any should be used for key input
-    abstract RemapMode : KeyRemapMode
+    abstract RemapMode: KeyRemapMode
 
     /// Beep
-    abstract Beep : unit -> unit
+    abstract Beep: unit -> unit
 
     /// Process the new command with the previous TData value
-    abstract ProcessCommand : data : 'TData -> command : string -> 'TData
+    abstract ProcessCommand: data: 'TData -> command: string -> 'TData
 
     /// Called when the command is completed.  The last valid TData and command
     /// string will be provided
-    abstract Completed : data : 'TData -> command : string -> 'TResult
+    abstract Completed: data: 'TData -> command: string -> 'TResult
 
     /// Called when the command is cancelled.  The last valid TData value will
     /// be provided
-    abstract Cancelled : data : 'TData -> unit
+    abstract Cancelled: data: 'TData -> unit
 
 /// An active use of an IHistoryClient instance 
 type internal IHistorySession<'TData, 'TResult> =
 
     /// The IHistoryClient this session is using 
-    abstract HistoryClient : IHistoryClient<'TData, 'TResult>
+    abstract HistoryClient: IHistoryClient<'TData, 'TResult>
 
     /// The current command that is being used 
-    abstract Command : string 
+    abstract Command: string 
 
     /// Is the session currently waiting for a register paste operation to complete
-    abstract InPasteWait : bool
+    abstract InPasteWait: bool
 
     /// The current client data 
-    abstract ClientData : 'TData
+    abstract ClientData: 'TData
 
     /// Cancel the IHistorySession
-    abstract Cancel : unit -> unit
+    abstract Cancel: unit -> unit
 
     /// Reset the command to the current value
-    abstract ResetCommand : string -> unit
+    abstract ResetCommand: string -> unit
 
     /// Create an BindDataStorage for this session which will process relevant KeyInput values
     /// as manipulating the current history
-    abstract CreateBindDataStorage : unit -> BindDataStorage<'TResult>
+    abstract CreateBindDataStorage: unit -> BindDataStorage<'TResult>
 
 /// Represents shared state which is available to all IVimBuffer instances.
 type IVimData = 
 
     /// The set of supported auto command groups
-    abstract AutoCommandGroups : AutoCommandGroup list with get, set
+    abstract AutoCommandGroups: AutoCommandGroup list with get, set
 
     /// The set of auto commands
-    abstract AutoCommands : AutoCommand list with get, set
+    abstract AutoCommands: AutoCommand list with get, set
 
     /// The current directory Vim is positioned in
-    abstract CurrentDirectory : string with get, set
+    abstract CurrentDirectory: string with get, set
 
-    /// The history of the : command list
-    abstract CommandHistory : HistoryList with get, set
+    /// The history of the: command list
+    abstract CommandHistory: HistoryList with get, set
 
     /// This is the pattern for which all occurences should be highlighted in the visible
     /// IVimBuffer instances.  When this value is empty then no pattern should be highlighted
-    abstract DisplayPattern : string
+    abstract DisplayPattern: string
 
     /// The ordered list of incremental search values
-    abstract SearchHistory : HistoryList with get, set
+    abstract SearchHistory: HistoryList with get, set
 
     /// Motion function used with the last f, F, t or T motion.  The 
     /// first item in the tuple is the forward version and the second item
     /// is the backwards version
-    abstract LastCharSearch : (CharSearchKind * SearchPath * char) option with get, set
+    abstract LastCharSearch: (CharSearchKind * SearchPath * char) option with get, set
 
     /// The last command which was ran 
-    abstract LastCommand : StoredCommand option with get, set
+    abstract LastCommand: StoredCommand option with get, set
 
     /// The last command line which was ran
-    abstract LastCommandLine : string with get, set
+    abstract LastCommandLine: string with get, set
 
     /// The last shell command that was run
-    abstract LastShellCommand : string option with get, set
+    abstract LastShellCommand: string option with get, set
 
     /// The last macro register which was run
-    abstract LastMacroRun : char option with get, set
+    abstract LastMacroRun: char option with get, set
 
     /// Last pattern searched for in any buffer.
-    abstract LastSearchData : SearchData with get, set
+    abstract LastSearchData: SearchData with get, set
 
     /// Data for the last substitute command performed
-    abstract LastSubstituteData : SubstituteData option with get, set
+    abstract LastSubstituteData: SubstituteData option with get, set
 
     /// Last text inserted into any buffer. Used for the '.' register
-    abstract LastTextInsert : string option with get, set
+    abstract LastTextInsert: string option with get, set
 
     /// Last, unescaped, visual selection that occurred
-    abstract LastVisualSelection : StoredVisualSelection option with get, set
+    abstract LastVisualSelection: StoredVisualSelection option with get, set
 
     /// The previous value of the current directory Vim is positioned in
-    abstract PreviousCurrentDirectory : string
+    abstract PreviousCurrentDirectory: string
 
     /// Suspend the display of patterns in the visible IVimBuffer instances.  This is usually
     /// associated with the use of the :nohl command
-    abstract SuspendDisplayPattern : unit -> unit
+    abstract SuspendDisplayPattern: unit -> unit
 
     /// Resume the display of patterns in the visible IVimBuffer instance.  If the display
     /// isn't currently suspended then tihs command will have no effect on the system
-    abstract ResumeDisplayPattern : unit -> unit
+    abstract ResumeDisplayPattern: unit -> unit
 
     /// Raised when the DisplayPattern property changes
     [<CLIEvent>]
-    abstract DisplayPatternChanged : IDelegateEvent<System.EventHandler>
+    abstract DisplayPatternChanged: IDelegateEvent<System.EventHandler>
 
 [<RequireQualifiedAccess>]
 [<NoComparison>]
@@ -3994,8 +3994,8 @@ type QuickFix =
 
 type TextViewChangedEventArgs
     (
-        _oldTextView : ITextView option,
-        _newTextView : ITextView option
+        _oldTextView: ITextView option,
+        _newTextView: ITextView option
     ) =
 
     inherit System.EventArgs()
@@ -4016,322 +4016,322 @@ type IVimHost =
 
     /// Should vim automatically start synchronization of IVimBuffer instances when they are 
     /// created
-    abstract AutoSynchronizeSettings : bool 
+    abstract AutoSynchronizeSettings: bool 
 
     /// What settings defaults should be used when there is no vimrc file present
-    abstract DefaultSettings : DefaultSettings
+    abstract DefaultSettings: DefaultSettings
 
     /// Is auto-command enabled for this host
-    abstract IsAutoCommandEnabled : bool
+    abstract IsAutoCommandEnabled: bool
 
     /// Is undo / redo expected at this point in time due to a host operation.
-    abstract IsUndoRedoExpected : bool 
+    abstract IsUndoRedoExpected: bool 
 
     /// Get the count of window tabs that are active in the host. This refers to tabs for actual 
     /// edit windows, not anything to do with tabs in the text file.  If window tabs are not supported 
     /// then -1 should be returned
-    abstract TabCount : int
+    abstract TabCount: int
 
-    abstract Beep : unit -> unit
+    abstract Beep: unit -> unit
 
     /// Called at the start of a bulk operation such as a macro replay or a repeat of
     /// a last command
-    abstract BeginBulkOperation : unit -> unit
+    abstract BeginBulkOperation: unit -> unit
 
     /// Close the provided view
-    abstract Close : ITextView -> unit
+    abstract Close: ITextView -> unit
 
     /// Close all tabs but this one
-    abstract CloseAllOtherTabs : ITextView -> unit
+    abstract CloseAllOtherTabs: ITextView -> unit
 
     /// Close all windows but this one within this tab
-    abstract CloseAllOtherWindows : ITextView -> unit
+    abstract CloseAllOtherWindows: ITextView -> unit
 
     /// Create a hidden ITextView instance.  This is primarily used to load the contents
     /// of the vimrc
-    abstract CreateHiddenTextView : unit -> ITextView
+    abstract CreateHiddenTextView: unit -> ITextView
 
     /// Called at the end of a bulk operation such as a macro replay or a repeat of
     /// a last command
-    abstract EndBulkOperation : unit -> unit
+    abstract EndBulkOperation: unit -> unit
 
     /// Ensure that the given point is visible
-    abstract EnsureVisible : textView : ITextView -> point : SnapshotPoint -> unit
+    abstract EnsureVisible: textView: ITextView -> point: SnapshotPoint -> unit
 
     /// Format the provided lines
-    abstract FormatLines : textView : ITextView -> range : SnapshotLineRange -> unit
+    abstract FormatLines: textView: ITextView -> range: SnapshotLineRange -> unit
 
     /// Get the ITextView which currently has keyboard focus
-    abstract GetFocusedTextView : unit -> ITextView option
+    abstract GetFocusedTextView: unit -> ITextView option
 
     /// Get the tab index of the tab containing the given ITextView.  A number less
     /// than 0 indicates the value couldn't be determined
-    abstract GetTabIndex : textView : ITextView -> int
+    abstract GetTabIndex: textView: ITextView -> int
 
     /// Get the indent for the new line.  This has precedence over the 'autoindent'
     /// setting
-    abstract GetNewLineIndent : textView : ITextView -> contextLine : ITextSnapshotLine -> newLine : ITextSnapshotLine -> int option
+    abstract GetNewLineIndent: textView: ITextView -> contextLine: ITextSnapshotLine -> newLine: ITextSnapshotLine -> int option
 
     /// Get the WordWrap style which should be used for the specified ITextView if word 
     /// wrap is enabled
-    abstract GetWordWrapStyle : textView : ITextView -> WordWrapStyles
+    abstract GetWordWrapStyle: textView: ITextView -> WordWrapStyles
 
     /// Go to the definition of the value under the cursor
-    abstract GoToDefinition : unit -> bool
+    abstract GoToDefinition: unit -> bool
 
     /// Go to the local declaration of the value under the cursor
-    abstract GoToLocalDeclaration : textView : ITextView -> identifier : string -> bool
+    abstract GoToLocalDeclaration: textView: ITextView -> identifier: string -> bool
 
     /// Go to the local declaration of the value under the cursor
-    abstract GoToGlobalDeclaration : tetxView : ITextView -> identifier : string -> bool
+    abstract GoToGlobalDeclaration: tetxView: ITextView -> identifier: string -> bool
 
     /// Go to the nth tab in the tab list.  This value is always a 0 based index 
     /// into the set of tabs.  It does not correspond to vim's handling of tab
     /// values which is not a standard 0 based index
-    abstract GoToTab : index : int -> unit
+    abstract GoToTab: index: int -> unit
 
     /// Go to the specified entry in the quick fix list
-    abstract GoToQuickFix : quickFix : QuickFix -> count : int -> hasBang : bool -> bool
+    abstract GoToQuickFix: quickFix: QuickFix -> count: int -> hasBang: bool -> bool
 
     /// Get the name of the given ITextBuffer
-    abstract GetName : textBuffer : ITextBuffer -> string
+    abstract GetName: textBuffer: ITextBuffer -> string
 
     /// Is the ITextBuffer in a dirty state?
-    abstract IsDirty : textBuffer : ITextBuffer -> bool
+    abstract IsDirty: textBuffer: ITextBuffer -> bool
 
     /// Is the ITextBuffer read only
-    abstract IsReadOnly : textBuffer : ITextBuffer -> bool
+    abstract IsReadOnly: textBuffer: ITextBuffer -> bool
 
     /// Is the ITextView visible to the user
-    abstract IsVisible : textView : ITextView -> bool
+    abstract IsVisible: textView: ITextView -> bool
 
     /// Is the ITextView in focus
-    abstract IsFocused : textView : ITextView -> bool
+    abstract IsFocused: textView: ITextView -> bool
 
     /// Loads the new file into the existing window
-    abstract LoadFileIntoExistingWindow : filePath : string -> textView : ITextView -> bool
+    abstract LoadFileIntoExistingWindow: filePath: string -> textView: ITextView -> bool
 
     /// Loads the new file into a new existing window
-    abstract LoadFileIntoNewWindow : filePath : string -> bool
+    abstract LoadFileIntoNewWindow: filePath: string -> bool
 
     /// Run the host specific make operation
-    abstract Make : jumpToFirstError : bool -> arguments : string -> unit
+    abstract Make: jumpToFirstError: bool -> arguments: string -> unit
 
     /// Move the focus to the ITextView in the open document in the specified direction
-    abstract MoveFocus : textView : ITextView -> direction : Direction -> unit
+    abstract MoveFocus: textView: ITextView -> direction: Direction -> unit
 
-    abstract NavigateTo : point : VirtualSnapshotPoint -> bool
+    abstract NavigateTo: point: VirtualSnapshotPoint -> bool
 
     // Open the quick fix window (:cwindow)
-    abstract OpenQuickFixWindow : unit -> unit
+    abstract OpenQuickFixWindow: unit -> unit
 
     /// Quit the application
-    abstract Quit : unit -> unit
+    abstract Quit: unit -> unit
 
     /// Reload the contents of the ITextView discarding any changes
-    abstract Reload : textView : ITextView -> bool
+    abstract Reload: textView: ITextView -> bool
 
     /// Run the specified command with the given arguments and return the textual
     /// output
-    abstract RunCommand : file : string -> arguments : string -> vimHost : IVimData -> string
+    abstract RunCommand: file: string -> arguments: string -> vimHost: IVimData -> string
 
     /// Run the Visual studio command in the context of the given ITextView
-    abstract RunHostCommand : textView : ITextView -> commandName : string -> argument : string -> unit
+    abstract RunHostCommand: textView: ITextView -> commandName: string -> argument: string -> unit
 
     /// Save the provided ITextBuffer instance
-    abstract Save : textBuffer : ITextBuffer -> bool 
+    abstract Save: textBuffer: ITextBuffer -> bool 
 
     /// Save the current document as a new file with the specified name
-    abstract SaveTextAs : text : string -> filePath : string -> bool 
+    abstract SaveTextAs: text: string -> filePath: string -> bool 
 
     /// Should the selection be kept after running the given host command?  In general 
     /// VsVim will clear the selection after a host command because that is the vim
     /// behavior.  Certain host commands exist to set selection though and clearing that
     /// isn't desirable
-    abstract ShouldKeepSelectionAfterHostCommand : command : string -> argument : string -> bool 
+    abstract ShouldKeepSelectionAfterHostCommand: command: string -> argument: string -> bool 
 
     /// Called by Vim when it encounters a new ITextView and needs to know if it should 
     /// create an IVimBuffer for it
-    abstract ShouldCreateVimBuffer : textView : ITextView -> bool
+    abstract ShouldCreateVimBuffer: textView: ITextView -> bool
 
     /// Called by Vim when it is loading vimrc files.  This gives the host the chance to
     /// filter out vimrc files it doesn't want to consider
-    abstract ShouldIncludeRcFile : vimRcPath : VimRcPath -> bool
+    abstract ShouldIncludeRcFile: vimRcPath: VimRcPath -> bool
 
     /// Split the views horizontally
-    abstract SplitViewHorizontally : ITextView -> unit
+    abstract SplitViewHorizontally: ITextView -> unit
 
     /// Split the views horizontally
-    abstract SplitViewVertically : ITextView -> unit
+    abstract SplitViewVertically: ITextView -> unit
 
     /// Called when IVim is fully created.  This callback gives the host the oppurtunity
     /// to customize various aspects of vim including IVimGlobalSettings, IVimData, etc ...
-    abstract VimCreated : vim : IVim -> unit
+    abstract VimCreated: vim: IVim -> unit
 
     /// Called when VsVim attempts to load the user _vimrc file.  If the load succeeded 
     /// then the resulting settings are passed into the method.  If the load failed it is 
     /// the defaults.  Either way, they are the default settings used for new buffers
-    abstract VimRcLoaded : vimRcState : VimRcState -> localSettings : IVimLocalSettings -> windowSettings : IVimWindowSettings -> unit
+    abstract VimRcLoaded: vimRcState: VimRcState -> localSettings: IVimLocalSettings -> windowSettings: IVimWindowSettings -> unit
 
     /// Allow the host to custom process the insert command.  Hosts often have
     /// special non-vim semantics for certain types of edits (Enter for 
     /// example).  This override allows them to do this processing
-    abstract TryCustomProcess : textView : ITextView -> command : InsertCommand -> bool
+    abstract TryCustomProcess: textView: ITextView -> command: InsertCommand -> bool
 
     /// Raised when the visibility of an ITextView changes
     [<CLIEvent>]
-    abstract IsVisibleChanged : IDelegateEvent<System.EventHandler<TextViewEventArgs>>
+    abstract IsVisibleChanged: IDelegateEvent<System.EventHandler<TextViewEventArgs>>
 
     /// Raised when the active ITextView changes
     [<CLIEvent>]
-    abstract ActiveTextViewChanged : IDelegateEvent<System.EventHandler<TextViewChangedEventArgs>>
+    abstract ActiveTextViewChanged: IDelegateEvent<System.EventHandler<TextViewChangedEventArgs>>
 
 /// Core parts of an IVimBuffer.  Used for components which make up an IVimBuffer but
 /// need the same data provided by IVimBuffer.
 and IVimBufferData =
 
     /// The current directory for this particular window
-    abstract CurrentDirectory : string option with get, set
+    abstract CurrentDirectory: string option with get, set
 
     /// This is the caret point at the start of the most recent visual mode session. It's
     /// the actual location of the caret vs. the anchor point.
-    abstract VisualCaretStartPoint : ITrackingPoint option with get, set
+    abstract VisualCaretStartPoint: ITrackingPoint option with get, set
 
     /// This is the anchor point for the visual mode selection.  It is different than the anchor
     /// point in ITextSelection.  The ITextSelection anchor point is always the start or end
     /// of the visual selection.  While the anchor point for visual mode selection may be in 
     /// the middle (in say line wise mode)
-    abstract VisualAnchorPoint : ITrackingPoint option with get, set
+    abstract VisualAnchorPoint: ITrackingPoint option with get, set
 
     /// The IJumpList associated with the IVimBuffer
-    abstract JumpList : IJumpList
+    abstract JumpList: IJumpList
 
     /// The ITextView associated with the IVimBuffer
-    abstract TextView : ITextView
+    abstract TextView: ITextView
 
     /// The ITextBuffer associated with the IVimBuffer
-    abstract TextBuffer : ITextBuffer
+    abstract TextBuffer: ITextBuffer
 
     /// The IStatusUtil associated with the IVimBuffer
-    abstract StatusUtil : IStatusUtil
+    abstract StatusUtil: IStatusUtil
 
     /// The IUndoRedOperations associated with the IVimBuffer
-    abstract UndoRedoOperations : IUndoRedoOperations
+    abstract UndoRedoOperations: IUndoRedoOperations
 
     /// The IVimTextBuffer associated with the IVimBuffer
-    abstract VimTextBuffer : IVimTextBuffer
+    abstract VimTextBuffer: IVimTextBuffer
 
     /// The IVimWindowSettings associated with the ITextView 
-    abstract WindowSettings : IVimWindowSettings
+    abstract WindowSettings: IVimWindowSettings
 
     /// The IWordUtil associated with the IVimBuffer
-    abstract WordUtil : IWordUtil
+    abstract WordUtil: IWordUtil
 
     /// The IVimLocalSettings associated with the ITextBuffer
-    abstract LocalSettings : IVimLocalSettings
+    abstract LocalSettings: IVimLocalSettings
 
-    abstract Vim : IVim
+    abstract Vim: IVim
 
 /// Vim instance.  Global for a group of buffers
 and IVim =
 
     /// Buffer actively processing input.  This has no relation to the IVimBuffer
     /// which has focus 
-    abstract ActiveBuffer : IVimBuffer option
+    abstract ActiveBuffer: IVimBuffer option
 
     /// The IStatusUtil for the active IVimBuffer.  If there is currently no active IVimBuffer
     /// then a silent one will be returned 
-    abstract ActiveStatusUtil : IStatusUtil
+    abstract ActiveStatusUtil: IStatusUtil
 
     /// Whether or not the vimrc file should be autoloaded before the first IVimBuffer
     /// is created
-    abstract AutoLoadVimRc : bool with get, set
+    abstract AutoLoadVimRc: bool with get, set
 
     /// Whether or not saved data like macros shuold be autoloaded before the first IVimBuffer 
     // is created
-    abstract AutoLoadSessionData : bool with get, set
+    abstract AutoLoadSessionData: bool with get, set
 
     /// Get the set of tracked IVimBuffer instances
-    abstract VimBuffers : IVimBuffer list
+    abstract VimBuffers: IVimBuffer list
 
     /// Get the IVimBuffer which currently has KeyBoard focus
-    abstract FocusedBuffer : IVimBuffer option
+    abstract FocusedBuffer: IVimBuffer option
 
     /// Is Vim currently disabled 
-    abstract IsDisabled : bool with get, set
+    abstract IsDisabled: bool with get, set
 
     /// In the middle of a bulk operation such as a macro replay or repeat last command
-    abstract InBulkOperation : bool
+    abstract InBulkOperation: bool
 
     /// IKeyMap for this IVim instance
-    abstract KeyMap : IKeyMap
+    abstract KeyMap: IKeyMap
 
     /// IMacroRecorder for the IVim instance
-    abstract MacroRecorder : IMacroRecorder
+    abstract MacroRecorder: IMacroRecorder
 
     /// IMarkMap for the IVim instance
-    abstract MarkMap : IMarkMap
+    abstract MarkMap: IMarkMap
 
     /// IRegisterMap for the IVim instance
-    abstract RegisterMap : IRegisterMap
+    abstract RegisterMap: IRegisterMap
 
     /// ISearchService for this IVim instance
-    abstract SearchService : ISearchService
+    abstract SearchService: ISearchService
 
     /// IGlobalSettings for this IVim instance
-    abstract GlobalSettings : IVimGlobalSettings
+    abstract GlobalSettings: IVimGlobalSettings
 
     /// The variable map for this IVim instance
-    abstract VariableMap : VariableMap
+    abstract VariableMap: VariableMap
 
-    abstract VimData : IVimData 
+    abstract VimData: IVimData 
 
-    abstract VimHost : IVimHost
+    abstract VimHost: IVimHost
 
     /// The state of the VimRc file
-    abstract VimRcState : VimRcState
+    abstract VimRcState: VimRcState
 
     /// Create an IVimBuffer for the given ITextView
-    abstract CreateVimBuffer : textView: ITextView -> IVimBuffer
+    abstract CreateVimBuffer: textView: ITextView -> IVimBuffer
 
     /// Create an IVimTextBuffer for the given ITextBuffer
-    abstract CreateVimTextBuffer : textBuffer: ITextBuffer -> IVimTextBuffer
+    abstract CreateVimTextBuffer: textBuffer: ITextBuffer -> IVimTextBuffer
 
     /// Close all IVimBuffer instances in the system
-    abstract CloseAllVimBuffers : unit -> unit
+    abstract CloseAllVimBuffers: unit -> unit
 
     /// Get the IVimInterpreter for the specified IVimBuffer
-    abstract GetVimInterpreter : vimBuffer : IVimBuffer -> IVimInterpreter
+    abstract GetVimInterpreter: vimBuffer: IVimBuffer -> IVimInterpreter
 
     /// Get or create an IVimBuffer for the given ITextView
-    abstract GetOrCreateVimBuffer : textView: ITextView -> IVimBuffer
+    abstract GetOrCreateVimBuffer: textView: ITextView -> IVimBuffer
 
     /// Get or create an IVimTextBuffer for the given ITextBuffer
-    abstract GetOrCreateVimTextBuffer : textBuffer: ITextBuffer -> IVimTextBuffer
+    abstract GetOrCreateVimTextBuffer: textBuffer: ITextBuffer -> IVimTextBuffer
 
     /// Load the VimRc file.  If the file was previously loaded a new load will be 
     /// attempted.  Returns true if a VimRc was actually loaded.
-    abstract LoadVimRc : unit -> VimRcState
+    abstract LoadVimRc: unit -> VimRcState
 
     /// Load the saved data file. 
-    abstract LoadSessionData : unit -> unit
+    abstract LoadSessionData: unit -> unit
 
     /// Save out the current session data.
-    abstract SaveSessionData : unit -> unit
+    abstract SaveSessionData: unit -> unit
 
     /// Remove the IVimBuffer associated with the given view.  This will not actually close
     /// the IVimBuffer but instead just removes it's association with the given view
-    abstract RemoveVimBuffer : ITextView -> bool
+    abstract RemoveVimBuffer: ITextView -> bool
 
     /// Get the IVimBuffer associated with the given ITextView
-    abstract TryGetVimBuffer : textView : ITextView * [<Out>] vimBuffer : IVimBuffer byref -> bool
+    abstract TryGetVimBuffer: textView: ITextView * [<Out>] vimBuffer: IVimBuffer byref -> bool
 
     /// Get the IVimTextBuffer associated with the given ITextBuffer
-    abstract TryGetVimTextBuffer : textBuffer : ITextBuffer * [<Out>] vimTextBuffer : IVimTextBuffer byref -> bool
+    abstract TryGetVimTextBuffer: textBuffer: ITextBuffer * [<Out>] vimTextBuffer: IVimTextBuffer byref -> bool
 
     /// This implements a cached version of IVimHost::ShouldCreateVimBuffer.  Code should prefer 
     /// this method wherever possible 
-    abstract ShouldCreateVimBuffer : textView : ITextView -> bool
+    abstract ShouldCreateVimBuffer: textView: ITextView -> bool
 
     /// Get or create an IVimBuffer for the given ITextView.  The creation of the IVimBuffer will
     /// only occur if the host returns true from IVimHost::ShouldCreateVimBuffer.  
@@ -4340,12 +4340,12 @@ and IVim =
     /// ITagger implementations will be called long before the host has a chance to create the 
     /// IVimBuffer instance.  This method removes the ordering concerns and maintains control of 
     /// creation in the IVimHost
-    abstract TryGetOrCreateVimBufferForHost : textView : ITextView * [<Out>] vimBuffer : IVimBuffer byref -> bool
+    abstract TryGetOrCreateVimBufferForHost: textView: ITextView * [<Out>] vimBuffer: IVimBuffer byref -> bool
 
 and SwitchModeKindEventArgs
     (
-        _modeKind : ModeKind,
-        _modeArgument : ModeArgument
+        _modeKind: ModeKind,
+        _modeArgument: ModeArgument
     ) =
     inherit System.EventArgs()
 
@@ -4355,8 +4355,8 @@ and SwitchModeKindEventArgs
 
 and SwitchModeEventArgs 
     (
-        _previousMode : IMode,
-        _currentMode : IMode
+        _previousMode: IMode,
+        _currentMode: IMode
     ) = 
 
     inherit System.EventArgs()
@@ -4371,217 +4371,217 @@ and SwitchModeEventArgs
 and IMarkMap =
 
     /// The set of active global marks
-    abstract GlobalMarks : (Letter * VirtualSnapshotPoint) seq
+    abstract GlobalMarks: (Letter * VirtualSnapshotPoint) seq
 
     /// Get the mark for the given char for the IVimTextBuffer
-    abstract GetMark : mark : Mark -> vimBufferData : IVimBufferData -> VirtualSnapshotPoint option
+    abstract GetMark: mark: Mark -> vimBufferData: IVimBufferData -> VirtualSnapshotPoint option
 
     /// Get the current value of the specified global mark
-    abstract GetGlobalMark : letter : Letter -> VirtualSnapshotPoint option
+    abstract GetGlobalMark: letter: Letter -> VirtualSnapshotPoint option
 
     /// Set the global mark to the given line and column in the provided IVimTextBuffer
-    abstract SetGlobalMark : letter: Letter -> vimtextBuffer : IVimTextBuffer -> line : int -> column : int -> unit
+    abstract SetGlobalMark: letter: Letter -> vimtextBuffer: IVimTextBuffer -> line: int -> column: int -> unit
 
     /// Set the mark for the given char for the IVimTextBuffer
-    abstract SetMark : mark : Mark -> vimBufferData : IVimBufferData -> line : int -> column : int -> bool
+    abstract SetMark: mark: Mark -> vimBufferData: IVimBufferData -> line: int -> column: int -> bool
 
     /// Set the last exited position before the window is closed
-    abstract SetLastExitedPosition : bufferName : string -> line : int -> column : int -> bool
+    abstract SetLastExitedPosition: bufferName: string -> line: int -> column: int -> bool
 
     /// Remove the specified mark and return whether or not a mark was actually
     /// removed
-    abstract RemoveGlobalMark : letter : Letter -> bool
+    abstract RemoveGlobalMark: letter: Letter -> bool
 
     /// Delete all of the global marks 
-    abstract Clear : unit -> unit
+    abstract Clear: unit -> unit
 
 /// This is the interface which represents the parts of a vim buffer which are shared amongst all
 /// of it's views
 and IVimTextBuffer = 
 
     /// The associated ITextBuffer instance
-    abstract TextBuffer : ITextBuffer
+    abstract TextBuffer: ITextBuffer
 
     /// The associated IVimGlobalSettings instance
-    abstract GlobalSettings : IVimGlobalSettings
+    abstract GlobalSettings: IVimGlobalSettings
 
     /// The 'start' point of the current insert session.  This is relevant for settings like 
     /// 'backspace'
-    abstract InsertStartPoint : SnapshotPoint option with get, set
+    abstract InsertStartPoint: SnapshotPoint option with get, set
 
     /// True when 'softtabstop' setting should be considered during backspace operations in insert
     /// mode
-    abstract IsSoftTabStopValidForBackspace : bool with get, set
+    abstract IsSoftTabStopValidForBackspace: bool with get, set
 
     /// The point the caret occupied when Insert mode was exited 
-    abstract LastInsertExitPoint : SnapshotPoint option with get, set
+    abstract LastInsertExitPoint: SnapshotPoint option with get, set
 
     /// The last VisualSpan selection for the IVimTextBuffer.  This is a combination of a VisualSpan
     /// and the SnapshotPoint within the span where the caret should be positioned
-    abstract LastVisualSelection : VisualSelection option with get, set
+    abstract LastVisualSelection: VisualSelection option with get, set
 
     /// The point the caret occupied when the last edit occurred
-    abstract LastEditPoint : SnapshotPoint option with get, set
+    abstract LastEditPoint: SnapshotPoint option with get, set
 
     /// The set of active local marks in the ITextBuffer
-    abstract LocalMarks : (LocalMark * VirtualSnapshotPoint) seq
+    abstract LocalMarks: (LocalMark * VirtualSnapshotPoint) seq
 
     /// The associated IVimLocalSettings instance
-    abstract LocalSettings : IVimLocalSettings
+    abstract LocalSettings: IVimLocalSettings
 
     /// ModeKind of the current mode of the IVimTextBuffer.  It may seem odd at first to put ModeKind
     /// at this level but it is indeed shared amongst all views.  This can be demonstrated by opening
     /// the same file in multiple tabs, switch to insert in one and then move to the other via the
     /// mouse and noting it is also in Insert mode.  Actual IMode values are ITextView specific though
     /// and only live at the ITextView level
-    abstract ModeKind : ModeKind
+    abstract ModeKind: ModeKind
 
     /// Name of the buffer.  Used for items like Marks
-    abstract Name : string
+    abstract Name: string
 
     /// The IUndoRedoOperations associated with the IVimTextBuffer
-    abstract UndoRedoOperations : IUndoRedoOperations
+    abstract UndoRedoOperations: IUndoRedoOperations
 
     /// The associated IVim instance
-    abstract Vim : IVim
+    abstract Vim: IVim
 
     /// The ITextStructureNavigator for word values in the ITextBuffer
-    abstract WordNavigator : ITextStructureNavigator
+    abstract WordNavigator: ITextStructureNavigator
 
     /// Clear out all of the cached information in the IVimTextBuffer.  It will reset to it's startup
     /// state 
-    abstract Clear : unit -> unit
+    abstract Clear: unit -> unit
 
     /// Get the local mark value 
-    abstract GetLocalMark : localMark : LocalMark -> VirtualSnapshotPoint option
+    abstract GetLocalMark: localMark: LocalMark -> VirtualSnapshotPoint option
 
     /// Set the local mark value to the specified line and column.  Returns false if the given 
     /// mark cannot be set
-    abstract SetLocalMark : localMark : LocalMark -> line : int -> column : int -> bool
+    abstract SetLocalMark: localMark: LocalMark -> line: int -> column: int -> bool
 
     /// Remove the specified local mark.  Returns whether a mark was actually removed
-    abstract RemoveLocalMark : localMark : LocalMark -> bool
+    abstract RemoveLocalMark: localMark: LocalMark -> bool
 
     /// Switch the current mode to the provided value
-    abstract SwitchMode : ModeKind -> ModeArgument -> unit
+    abstract SwitchMode: ModeKind -> ModeArgument -> unit
 
     /// Raised when the mode is switched.  Returns the old and new mode 
     [<CLIEvent>]
-    abstract SwitchedMode : IDelegateEvent<System.EventHandler<SwitchModeKindEventArgs>>
+    abstract SwitchedMode: IDelegateEvent<System.EventHandler<SwitchModeKindEventArgs>>
 
 /// Main interface for the Vim editor engine so to speak. 
 and IVimBuffer =
 
     /// Sequence of available Modes
-    abstract AllModes : seq<IMode>
+    abstract AllModes: seq<IMode>
 
     /// Buffered KeyInput list.  When a key remapping has multiple source elements the input 
     /// is buffered until it is completed or the ambiguity is removed.  
-    abstract BufferedKeyInputs : KeyInput list
+    abstract BufferedKeyInputs: KeyInput list
 
     /// The current directory for this particular window
-    abstract CurrentDirectory : string option with get, set
+    abstract CurrentDirectory: string option with get, set
 
     /// The ICommandUtil for this IVimBuffer
-    abstract CommandUtil : ICommandUtil
+    abstract CommandUtil: ICommandUtil
 
     /// Global settings for the buffer
-    abstract GlobalSettings : IVimGlobalSettings
+    abstract GlobalSettings: IVimGlobalSettings
 
     /// IIncrementalSearch instance associated with this IVimBuffer
-    abstract IncrementalSearch : IIncrementalSearch
+    abstract IncrementalSearch: IIncrementalSearch
 
     /// Whether or not the IVimBuffer is currently processing a KeyInput value
-    abstract IsProcessingInput : bool
+    abstract IsProcessingInput: bool
 
     /// Whether or not the IVimBuffer is currently switching modes
-    abstract IsSwitchingMode : bool
+    abstract IsSwitchingMode: bool
 
     /// Is this IVimBuffer instance closed
-    abstract IsClosed : bool
+    abstract IsClosed: bool
 
     /// Jump list
-    abstract JumpList : IJumpList
+    abstract JumpList: IJumpList
 
     /// Local settings for the buffer
-    abstract LocalSettings : IVimLocalSettings
+    abstract LocalSettings: IVimLocalSettings
 
     /// Associated IMarkMap
-    abstract MarkMap : IMarkMap
+    abstract MarkMap: IMarkMap
 
     /// Current mode of the buffer
-    abstract Mode : IMode
+    abstract Mode: IMode
 
     /// ModeKind of the current IMode in the buffer
-    abstract ModeKind : ModeKind
+    abstract ModeKind: ModeKind
 
     /// Name of the buffer.  Used for items like Marks
-    abstract Name : string
+    abstract Name: string
 
     /// If we are in the middle of processing a "one time command" (<c-o>) then this will
     /// hold the ModeKind which will be switched back to after it's completed
-    abstract InOneTimeCommand : ModeKind option
+    abstract InOneTimeCommand: ModeKind option
 
     /// Register map for IVim.  Global to all IVimBuffer instances but provided here
     /// for convenience
-    abstract RegisterMap : IRegisterMap
+    abstract RegisterMap: IRegisterMap
 
     /// Underlying ITextBuffer Vim is operating under
-    abstract TextBuffer : ITextBuffer
+    abstract TextBuffer: ITextBuffer
 
     /// Current ITextSnapshot of the ITextBuffer
-    abstract TextSnapshot : ITextSnapshot
+    abstract TextSnapshot: ITextSnapshot
 
     /// View of the file
-    abstract TextView : ITextView
+    abstract TextView: ITextView
 
     /// The IMotionUtil associated with this IVimBuffer instance
-    abstract MotionUtil : IMotionUtil
+    abstract MotionUtil: IMotionUtil
 
     /// The IUndoRedoOperations associated with this IVimBuffer instance
-    abstract UndoRedoOperations : IUndoRedoOperations
+    abstract UndoRedoOperations: IUndoRedoOperations
 
     /// Owning IVim instance
-    abstract Vim : IVim
+    abstract Vim: IVim
 
     /// Associated IVimTextBuffer
-    abstract VimTextBuffer : IVimTextBuffer
+    abstract VimTextBuffer: IVimTextBuffer
 
     /// VimBufferData for the given IVimBuffer
-    abstract VimBufferData : IVimBufferData
+    abstract VimBufferData: IVimBufferData
 
     /// The ITextStructureNavigator for word values in the buffer
-    abstract WordNavigator : ITextStructureNavigator
+    abstract WordNavigator: ITextStructureNavigator
 
     /// Associated IVimWindowSettings
-    abstract WindowSettings : IVimWindowSettings
+    abstract WindowSettings: IVimWindowSettings
 
     /// Associated IVimData instance
-    abstract VimData : IVimData
+    abstract VimData: IVimData
 
     /// INormalMode instance for normal mode
-    abstract NormalMode : INormalMode
+    abstract NormalMode: INormalMode
 
     /// ICommandMode instance for command mode
-    abstract CommandMode : ICommandMode 
+    abstract CommandMode: ICommandMode 
 
     /// IDisabledMode instance for disabled mode
-    abstract DisabledMode : IDisabledMode
+    abstract DisabledMode: IDisabledMode
 
     /// IVisualMode for visual character mode
-    abstract VisualCharacterMode : IVisualMode
+    abstract VisualCharacterMode: IVisualMode
 
     /// IVisualMode for visual line mode
-    abstract VisualLineMode : IVisualMode
+    abstract VisualLineMode: IVisualMode
 
     /// IVisualMode for visual block mode
-    abstract VisualBlockMode : IVisualMode
+    abstract VisualBlockMode: IVisualMode
 
     /// IInsertMode instance for insert mode
-    abstract InsertMode : IInsertMode
+    abstract InsertMode: IInsertMode
 
     /// IInsertMode instance for replace mode
-    abstract ReplaceMode : IInsertMode
+    abstract ReplaceMode: IInsertMode
 
     /// ISelectMode instance for character mode
     abstract SelectCharacterMode: ISelectMode
@@ -4593,26 +4593,26 @@ and IVimBuffer =
     abstract SelectBlockMode: ISelectMode
 
     /// ISubstituteConfirmDoe instance for substitute confirm mode
-    abstract SubstituteConfirmMode : ISubstituteConfirmMode
+    abstract SubstituteConfirmMode: ISubstituteConfirmMode
 
     /// IMode instance for external edits
-    abstract ExternalEditMode : IMode
+    abstract ExternalEditMode: IMode
 
     /// Get the register of the given name
-    abstract GetRegister : RegisterName -> Register
+    abstract GetRegister: RegisterName -> Register
 
     /// Get the specified Mode
-    abstract GetMode : ModeKind -> IMode
+    abstract GetMode: ModeKind -> IMode
 
     /// Get the KeyInput value produced by this KeyInput in the current state of the
     /// IVimBuffer.  This will consider any buffered KeyInput values.
-    abstract GetKeyInputMapping : keyInput : KeyInput -> KeyMappingResult
+    abstract GetKeyInputMapping: keyInput: KeyInput -> KeyMappingResult
 
     /// Process the KeyInput and return whether or not the input was completely handled
-    abstract Process : KeyInput -> ProcessResult
+    abstract Process: KeyInput -> ProcessResult
 
     /// Process all of the buffered KeyInput values.
-    abstract ProcessBufferedKeyInputs : unit -> unit
+    abstract ProcessBufferedKeyInputs: unit -> unit
 
     /// Can the passed in KeyInput be processed by the current state of IVimBuffer.  The
     /// provided KeyInput will participate in remapping based on the current mode
@@ -4625,31 +4625,31 @@ and IVimBuffer =
     /// This is very similar to CanProcess except it will return false for any KeyInput
     /// which would be processed as a direct insert.  In other words commands like 'a',
     /// 'b' when handled by insert / replace mode
-    abstract CanProcessAsCommand : KeyInput -> bool
+    abstract CanProcessAsCommand: KeyInput -> bool
 
     /// Switch the current mode to the provided value
-    abstract SwitchMode : ModeKind -> ModeArgument -> IMode
+    abstract SwitchMode: ModeKind -> ModeArgument -> IMode
 
     /// Switch the buffer back to the previous mode which is returned
-    abstract SwitchPreviousMode : unit -> IMode
+    abstract SwitchPreviousMode: unit -> IMode
 
     /// Add a processed KeyInput value.  This is a way for a host which is intercepting 
     /// KeyInput and custom processing it to still participate in items like Macro 
     /// recording.  The provided value will not go through any remapping
-    abstract SimulateProcessed : KeyInput -> unit
+    abstract SimulateProcessed: KeyInput -> unit
 
     /// Called when the view is closed and the IVimBuffer should uninstall itself
     /// and it's modes
-    abstract Close : unit -> unit
+    abstract Close: unit -> unit
     
     /// Raised when the mode is switched.  Returns the old and new mode 
     [<CLIEvent>]
-    abstract SwitchedMode : IDelegateEvent<System.EventHandler<SwitchModeEventArgs>>
+    abstract SwitchedMode: IDelegateEvent<System.EventHandler<SwitchModeEventArgs>>
 
     /// Raised when a KeyInput is received by the buffer.  This will be raised for the 
     /// KeyInput which was received and does not consider any mappings
     [<CLIEvent>]
-    abstract KeyInputStart : IDelegateEvent<System.EventHandler<KeyInputStartEventArgs>>
+    abstract KeyInputStart: IDelegateEvent<System.EventHandler<KeyInputStartEventArgs>>
 
     /// This is raised just before the IVimBuffer attempts to process a KeyInput 
     /// value.  This will not necessarily be the KeyInput which was raised in KeyInputStart
@@ -4660,7 +4660,7 @@ and IVimBuffer =
     /// processed by the IVimBuffer.  It will instead immediately move to the 
     /// KeyInputProcessed event
     [<CLIEvent>]
-    abstract KeyInputProcessing : IDelegateEvent<System.EventHandler<KeyInputStartEventArgs>>
+    abstract KeyInputProcessing: IDelegateEvent<System.EventHandler<KeyInputStartEventArgs>>
 
     /// Raised when a key is processed.  This is raised when the KeyInput is actually
     /// processed by Vim, not when it is received.  
@@ -4670,38 +4670,38 @@ and IVimBuffer =
     /// mapping contains more than one key.  In this case the input is buffered until the 
     /// second key is read and then the inputs are processed
     [<CLIEvent>]
-    abstract KeyInputProcessed : IDelegateEvent<System.EventHandler<KeyInputProcessedEventArgs>>
+    abstract KeyInputProcessed: IDelegateEvent<System.EventHandler<KeyInputProcessedEventArgs>>
 
     /// Raised when a key is received but not immediately processed.  Occurs when a
     /// key remapping has more than one source key strokes
     [<CLIEvent>]
-    abstract KeyInputBuffered : IDelegateEvent<System.EventHandler<KeyInputSetEventArgs>>
+    abstract KeyInputBuffered: IDelegateEvent<System.EventHandler<KeyInputSetEventArgs>>
 
     /// Raised when a KeyInput is completed processing within the IVimBuffer.  This happens 
     /// if the KeyInput is buffered or processed.  This will be raised for the KeyInput which
     /// was initially considered (came from KeyInputStart).  It won't consider any mappings
     [<CLIEvent>]
-    abstract KeyInputEnd : IDelegateEvent<System.EventHandler<KeyInputEventArgs>>
+    abstract KeyInputEnd: IDelegateEvent<System.EventHandler<KeyInputEventArgs>>
 
     /// Raised when a warning is encountered
     [<CLIEvent>]
-    abstract WarningMessage : IDelegateEvent<System.EventHandler<StringEventArgs>>
+    abstract WarningMessage: IDelegateEvent<System.EventHandler<StringEventArgs>>
 
     /// Raised when an error is encountered
     [<CLIEvent>]
-    abstract ErrorMessage : IDelegateEvent<System.EventHandler<StringEventArgs>>
+    abstract ErrorMessage: IDelegateEvent<System.EventHandler<StringEventArgs>>
 
     /// Raised when a status message is encountered
     [<CLIEvent>]
-    abstract StatusMessage : IDelegateEvent<System.EventHandler<StringEventArgs>>
+    abstract StatusMessage: IDelegateEvent<System.EventHandler<StringEventArgs>>
 
     /// Raised when the IVimBuffer is being closed
     [<CLIEvent>]
-    abstract Closing : IDelegateEvent<System.EventHandler>
+    abstract Closing: IDelegateEvent<System.EventHandler>
 
     /// Raised when the IVimBuffer is closed
     [<CLIEvent>]
-    abstract Closed : IDelegateEvent<System.EventHandler>
+    abstract Closed: IDelegateEvent<System.EventHandler>
 
     inherit IPropertyOwner
 
@@ -4709,46 +4709,46 @@ and IVimBuffer =
 and IMode =
 
     /// Associated IVimTextBuffer
-    abstract VimTextBuffer : IVimTextBuffer 
+    abstract VimTextBuffer: IVimTextBuffer 
 
     /// What type of Mode is this
-    abstract ModeKind : ModeKind
+    abstract ModeKind: ModeKind
 
     /// Sequence of commands handled by the Mode.  
-    abstract CommandNames : seq<KeyInputSet>
+    abstract CommandNames: seq<KeyInputSet>
 
     /// Can the mode process this particular KeyIput at the current time
-    abstract CanProcess : KeyInput -> bool
+    abstract CanProcess: KeyInput -> bool
 
     /// Process the given KeyInput
-    abstract Process : KeyInput -> ProcessResult
+    abstract Process: KeyInput -> ProcessResult
 
     /// Called when the mode is entered
-    abstract OnEnter : ModeArgument -> unit
+    abstract OnEnter: ModeArgument -> unit
 
     /// Called when the mode is left
-    abstract OnLeave : unit -> unit
+    abstract OnLeave: unit -> unit
 
     /// Called when the owning IVimBuffer is closed so that the mode can free up 
     /// any resources including event handlers
-    abstract OnClose : unit -> unit
+    abstract OnClose: unit -> unit
 
 and INormalMode =
 
     /// Buffered input for the current command
-    abstract Command : string 
+    abstract Command: string 
 
     /// The ICommandRunner implementation associated with NormalMode
-    abstract CommandRunner : ICommandRunner 
+    abstract CommandRunner: ICommandRunner 
 
     /// Mode keys need to be remapped with currently
-    abstract KeyRemapMode : KeyRemapMode
+    abstract KeyRemapMode: KeyRemapMode
 
     /// Is normal mode in the middle of a count operation
-    abstract InCount : bool
+    abstract InCount: bool
 
     /// Is normal mode in the middle of a character replace operation
-    abstract InReplace : bool
+    abstract InReplace: bool
 
     inherit IMode
 
@@ -4756,85 +4756,85 @@ and INormalMode =
 and IInsertMode =
 
     /// The active IWordCompletionSession if one is active
-    abstract ActiveWordCompletionSession : IWordCompletionSession option
+    abstract ActiveWordCompletionSession: IWordCompletionSession option
 
     /// Is insert mode currently in a paste operation
-    abstract IsInPaste : bool
+    abstract IsInPaste: bool
 
     /// Is this KeyInput value considered to be a direct insert command in the current
     /// state of the IVimBuffer.  This does not apply to commands which edit the buffer
     /// like 'CTRL-D' but instead commands like 'a', 'b' which directly edit the 
     /// ITextBuffer
-    abstract IsDirectInsert : KeyInput -> bool
+    abstract IsDirectInsert: KeyInput -> bool
 
     /// Raised when a command is successfully run
     [<CLIEvent>]
-    abstract CommandRan : IDelegateEvent<System.EventHandler<CommandRunDataEventArgs>>
+    abstract CommandRan: IDelegateEvent<System.EventHandler<CommandRunDataEventArgs>>
 
     inherit IMode
 
 and ICommandMode = 
 
     /// Buffered input for the current command
-    abstract Command : string with get, set
+    abstract Command: string with get, set
 
     /// Is command mode currently waiting for a register paste operation to complete
-    abstract InPasteWait : bool
+    abstract InPasteWait: bool
 
     /// Run the specified command
-    abstract RunCommand : string -> unit
+    abstract RunCommand: string -> unit
 
     /// Raised when the command string is changed
     [<CLIEvent>]
-    abstract CommandChanged : IDelegateEvent<System.EventHandler>
+    abstract CommandChanged: IDelegateEvent<System.EventHandler>
 
     inherit IMode
 
 and IVisualMode = 
 
     /// The ICommandRunner implementation associated with NormalMode
-    abstract CommandRunner : ICommandRunner 
+    abstract CommandRunner: ICommandRunner 
 
     /// Mode keys need to be remapped with currently
-    abstract KeyRemapMode : KeyRemapMode 
+    abstract KeyRemapMode: KeyRemapMode 
 
     /// Is visual mode in the middle of a count operation
-    abstract InCount : bool
+    abstract InCount: bool
 
     /// The current Visual Selection
-    abstract VisualSelection : VisualSelection
+    abstract VisualSelection: VisualSelection
 
     /// Asks Visual Mode to reset what it perceives to be the original selection.  Instead it 
     /// views the current selection as the original selection for entering the mode
-    abstract SyncSelection : unit -> unit
+    abstract SyncSelection: unit -> unit
 
     inherit IMode 
     
 and IDisabledMode =
     
     /// Help message to display 
-    abstract HelpMessage : string 
+    abstract HelpMessage: string 
 
     inherit IMode
 
 and ISelectMode = 
 
     /// Sync the selection with the current state
-    abstract SyncSelection : unit -> unit
+    abstract SyncSelection: unit -> unit
 
     inherit IMode
 
 and ISubstituteConfirmMode =
 
     /// The SnapshotSpan of the current matching piece of text
-    abstract CurrentMatch : SnapshotSpan option
+    abstract CurrentMatch: SnapshotSpan option
 
     /// The string which will replace the current match
-    abstract CurrentSubstitute : string option
+    abstract CurrentSubstitute: string option
 
     /// Raised when the current match changes
     [<CLIEvent>]
-    abstract CurrentMatchChanged : IEvent<SnapshotSpan option> 
+    abstract CurrentMatchChanged: IEvent<SnapshotSpan option> 
 
     inherit IMode 
 
@@ -4873,12 +4873,12 @@ type IProtectedOperations =
     /// Get an Action delegate which invokes the original action and handles any
     /// thrown Exceptions by passing them off the the available IExtensionErrorHandler
     /// values
-    abstract member GetProtectedAction : action : Action -> Action
+    abstract member GetProtectedAction: action: Action -> Action
 
     /// Get an EventHandler delegate which invokes the original action and handles any
     /// thrown Exceptions by passing them off the the available IExtensionErrorHandler
     /// values
-    abstract member GetProtectedEventHandler : eventHandler : EventHandler -> EventHandler
+    abstract member GetProtectedEventHandler: eventHandler: EventHandler -> EventHandler
 
     /// Report an Exception to the IExtensionErrorHandlers
-    abstract member Report : ex : Exception -> unit
+    abstract member Report: ex: Exception -> unit

--- a/Src/VimCore/CoreInternalInterfaces.fs
+++ b/Src/VimCore/CoreInternalInterfaces.fs
@@ -8,55 +8,55 @@ open Vim.Interpreter
 
 type internal IVimBufferInternal =
 
-    abstract TextView : ITextView
+    abstract TextView: ITextView
 
-    abstract RaiseErrorMessage : string -> unit
+    abstract RaiseErrorMessage: string -> unit
 
-    abstract RaiseWarningMessage : string -> unit
+    abstract RaiseWarningMessage: string -> unit
 
-    abstract RaiseStatusMessage : string -> unit
+    abstract RaiseStatusMessage: string -> unit
 
 /// Factory for getting IStatusUtil instances.  This is an importable MEF component
 type internal IStatusUtilFactory =
 
     /// Gets an empty instance which doesn't actually raise any messages
-    abstract EmptyStatusUtil : IStatusUtil
+    abstract EmptyStatusUtil: IStatusUtil
 
     /// Get the IStatusUtil instance for the given ITextBuffer.  This will propagate 
     /// to IStatusUtil in connected ITextView values.
-    abstract GetStatusUtilForBuffer : textBuffer : ITextBuffer -> IStatusUtil
+    abstract GetStatusUtilForBuffer: textBuffer: ITextBuffer -> IStatusUtil
 
     /// Get the IStatusUtil instance for the given ITextView.  
-    abstract GetStatusUtilForView : textView : ITextView -> IStatusUtil
+    abstract GetStatusUtilForView: textView: ITextView -> IStatusUtil
 
     /// Complete the initialization for the IStatusUtil associated with the given 
     /// ITextView.
-    abstract InitializeVimBuffer : vimBuffer : IVimBufferInternal -> unit
+    abstract InitializeVimBuffer: vimBuffer: IVimBufferInternal -> unit
 
 /// Bulk operations include repeat and macro commands.  This inteface is used to notify the 
 /// system that a bulk operation is begining / ending
 type internal IBulkOperations =
 
     /// True when in the middle of a bulk operation
-    abstract InBulkOperation : bool
+    abstract InBulkOperation: bool
 
     /// Called at the start of a bulk operation.  The disposing of the returned IDisposable
     /// instance represents the conclusion of the bulk operation
-    abstract BeginBulkOperation : unit -> System.IDisposable
+    abstract BeginBulkOperation: unit -> System.IDisposable
 
 type internal IVimBufferFactory =
 
     /// Create an IVimTextBuffer for the given ITextView
-    abstract CreateVimTextBuffer : textBuffer : ITextBuffer -> vim : IVim -> IVimTextBuffer
+    abstract CreateVimTextBuffer: textBuffer: ITextBuffer -> vim: IVim -> IVimTextBuffer
 
     /// Create a VimBufferData value for the given values
-    abstract CreateVimBufferData : vimTextBuffer : IVimTextBuffer -> textView : ITextView -> IVimBufferData
+    abstract CreateVimBufferData: vimTextBuffer: IVimTextBuffer -> textView: ITextView -> IVimBufferData
 
     /// Create an IVimBuffer for the given parameters
-    abstract CreateVimBuffer : vimBufferData : IVimBufferData -> IVimBuffer
+    abstract CreateVimBuffer: vimBufferData: IVimBufferData -> IVimBuffer
 
 type internal IVimInterpreterFactory = 
 
     /// Create a IVimInterpreter for the given IVimBuffer.  
-    abstract CreateVimInterpreter : vimBuffer : IVimBuffer -> fileSystem : IFileSystem -> IVimInterpreter
+    abstract CreateVimInterpreter: vimBuffer: IVimBuffer -> fileSystem: IFileSystem -> IVimInterpreter
 

--- a/Src/VimCore/CoreTypes.fs
+++ b/Src/VimCore/CoreTypes.fs
@@ -83,9 +83,9 @@ type SubstituteFlags =
     | PrintLastWithList = 0x1000
 
 type SubstituteData = {
-    SearchPattern : string
-    Substitute : string
-    Flags : SubstituteFlags
+    SearchPattern: string
+    Substitute: string
+    Flags: SubstituteFlags
 }
 
 /// Represents the different type of operations that are available for Motions

--- a/Src/VimCore/CountCapture.fs
+++ b/Src/VimCore/CountCapture.fs
@@ -7,10 +7,10 @@ open Microsoft.VisualStudio.Text.Editor;
 module internal CountCapture =
 
     /// Get a count value starting with the provided KeyInput
-    let GetCount keyRemapMode (keyInput : KeyInput) = 
-        let charToInt (c : char) = c.ToString() |> System.Int32.Parse
+    let GetCount keyRemapMode (keyInput: KeyInput) = 
+        let charToInt (c: char) = c.ToString() |> System.Int32.Parse
 
-        let rec nextFunc number (keyInput : KeyInput) =
+        let rec nextFunc number (keyInput: KeyInput) =
             match keyInput.IsDigit with
             | true ->
                 let digit = charToInt keyInput.Char

--- a/Src/VimCore/DisabledMode.fs
+++ b/Src/VimCore/DisabledMode.fs
@@ -2,7 +2,7 @@
 
 namespace Vim
 
-type internal DisabledMode(_vimBufferData : IVimBufferData) =
+type internal DisabledMode(_vimBufferData: IVimBufferData) =
 
     let _localSettings = _vimBufferData.LocalSettings
     let _globalSettings = _localSettings.GlobalSettings

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -18,37 +18,37 @@ open System.Linq
 /// This module exists purely to break type dependency issues created below.  
 module internal EditorCoreUtil =
 
-    let IsEndPoint (point : SnapshotPoint) = 
+    let IsEndPoint (point: SnapshotPoint) = 
         point.Position = point.Snapshot.Length
 
-    let AddOneOrCurrent (point : SnapshotPoint) =
+    let AddOneOrCurrent (point: SnapshotPoint) =
         if IsEndPoint point then
             point
         else
             point.Add(1)
 
-    let SubtractOneOrCurrent (point : SnapshotPoint) = 
+    let SubtractOneOrCurrent (point: SnapshotPoint) = 
         if point.Position = 0 then
             point
         else
             point.Subtract(1)
 
-    let GetCharacterWidth (point : SnapshotPoint) tabStop = 
+    let GetCharacterWidth (point: SnapshotPoint) tabStop = 
         if IsEndPoint point then 
             0
         else
             let c = point.GetChar()
             CharUtil.GetCharacterWidth c tabStop
 
-    let IsInsideLineBreak (point : SnapshotPoint) (line : ITextSnapshotLine) = 
+    let IsInsideLineBreak (point: SnapshotPoint) (line: ITextSnapshotLine) = 
         point.Position >= line.End.Position && not (IsEndPoint point)
 
 module TrackingSpanUtil =
 
-    let Create (span : SnapshotSpan) spanTrackingMode =
+    let Create (span: SnapshotSpan) spanTrackingMode =
         span.Snapshot.CreateTrackingSpan(span.Span, spanTrackingMode)
 
-    let GetSpan (snapshot : ITextSnapshot) (span : ITrackingSpan) =
+    let GetSpan (snapshot: ITextSnapshot) (span: ITrackingSpan) =
         try 
             span.GetSpan(snapshot) |> Some
         with
@@ -56,10 +56,10 @@ module TrackingSpanUtil =
 
 module PropertyCollectionUtil = 
 
-    let ContainsKey (key : obj)  (propertyCollection : PropertyCollection) = propertyCollection.ContainsProperty(key)
+    let ContainsKey (key: obj)  (propertyCollection: PropertyCollection) = propertyCollection.ContainsProperty(key)
 
     /// Get the property value for the givne key
-    let GetValue<'T> (key : obj) (propertyCollection : PropertyCollection) = 
+    let GetValue<'T> (key: obj) (propertyCollection: PropertyCollection) = 
         try
             let succeeded, value = propertyCollection.TryGetProperty<'T>(key)
             if succeeded then
@@ -79,8 +79,8 @@ module PropertyCollectionUtil =
 [<DebuggerDisplay("{ToString()}")>]
 type LineRange
     (
-        _startLine : int,
-        _count : int
+        _startLine: int,
+        _count: int
     ) = 
 
     member x.StartLineNumber = _startLine
@@ -93,11 +93,11 @@ type LineRange
 
     member x.ContainsLineNumber lineNumber = lineNumber >= _startLine && lineNumber <= x.LastLineNumber
 
-    member x.Contains (lineRange : LineRange) = 
+    member x.Contains (lineRange: LineRange) = 
         x.StartLineNumber <= lineRange.StartLineNumber &&
         x.LastLineNumber >= lineRange.LastLineNumber
 
-    member x.Intersects (lineRange : LineRange) = 
+    member x.Intersects (lineRange: LineRange) = 
         x.ContainsLineNumber(lineRange.StartLineNumber) ||
         x.ContainsLineNumber(lineRange.LastLineNumber) ||
         x.LastLineNumber + 1 = lineRange.StartLineNumber ||
@@ -105,17 +105,17 @@ type LineRange
 
     override x.ToString() = sprintf "[%d - %d]" x.StartLineNumber x.LastLineNumber
 
-    static member op_Equality(this : LineRange, other) = this = other;
-    static member op_Inequality(this : LineRange, other) = this <> other;
+    static member op_Equality(this: LineRange, other) = this = other;
+    static member op_Inequality(this: LineRange, other) = this <> other;
 
-    static member CreateFromBounds (startLineNumber : int) (lastLineNumber : int) = 
+    static member CreateFromBounds (startLineNumber: int) (lastLineNumber: int) = 
         if (lastLineNumber < startLineNumber) then
             raise (new ArgumentOutOfRangeException("lastLineNumber", "Must be greater than startLineNmuber"))
 
         let count = (lastLineNumber - startLineNumber) + 1;
         new LineRange(startLineNumber, count)
 
-    static member CreateOverarching (left : LineRange) (right : LineRange) =
+    static member CreateOverarching (left: LineRange) (right: LineRange) =
         let startLineNumber =  min left.StartLineNumber right.StartLineNumber
         let lastLineNumber = max left.LastLineNumber right.LastLineNumber
         LineRange.CreateFromBounds startLineNumber lastLineNumber
@@ -128,9 +128,9 @@ type LineRange
 [<DebuggerDisplay("{ToString()}")>]
 type SnapshotLineRange  =
 
-    val private _snapshot : ITextSnapshot
-    val private _startLine : int
-    val private _count : int
+    val private _snapshot: ITextSnapshot
+    val private _startLine: int
+    val private _count: int
 
     member x.Snapshot = x._snapshot
 
@@ -162,7 +162,7 @@ type SnapshotLineRange  =
         let last = x.LastLineNumber
         seq { for i = start to last do yield snapshot.GetLineFromLineNumber(i) }
 
-    new (snapshot : ITextSnapshot, startLine : int, count : int) =
+    new (snapshot: ITextSnapshot, startLine: int, count: int) =
         if startLine >= snapshot.LineCount then
             raise (new ArgumentException("startLine", "Invalid Line Number"))
 
@@ -175,19 +175,19 @@ type SnapshotLineRange  =
 
     member x.GetTextIncludingLineBreak() = x.ExtentIncludingLineBreak.GetText()
 
-    static member op_Equality(left : SnapshotLineRange, right) = left = right
+    static member op_Equality(left: SnapshotLineRange, right) = left = right
 
-    static member op_Inequality(left : SnapshotLineRange, right) = left <> right
+    static member op_Inequality(left: SnapshotLineRange, right) = left <> right
 
     override x.ToString() = sprintf "[%d - %d] %O" x.StartLineNumber x.LastLineNumber x.Snapshot
 
     /// Create for the entire ITextSnapshot
-    static member CreateForExtent (snapshot : ITextSnapshot) = new SnapshotLineRange(snapshot, 0, snapshot.LineCount)
+    static member CreateForExtent (snapshot: ITextSnapshot) = new SnapshotLineRange(snapshot, 0, snapshot.LineCount)
 
     /// Create for a single ITextSnapshotLine
-    static member CreateForLine (snapshotLine : ITextSnapshotLine) = new SnapshotLineRange(snapshotLine.Snapshot, snapshotLine.LineNumber, 1)
+    static member CreateForLine (snapshotLine: ITextSnapshotLine) = new SnapshotLineRange(snapshotLine.Snapshot, snapshotLine.LineNumber, 1)
 
-    static member CreateForSpan (span : SnapshotSpan) =
+    static member CreateForSpan (span: SnapshotSpan) =
         let startLine = span.Start.GetContainingLine()
         // TODO use GetLastLine
         let lastLine = 
@@ -198,13 +198,13 @@ type SnapshotLineRange  =
     /// Create a range for the provided ITextSnapshotLine and with at most count 
     /// length.  If count pushes the range past the end of the buffer then the 
     /// span will go to the end of the buffer
-    static member CreateForLineAndMaxCount (snapshotLine : ITextSnapshotLine) (count : int) = 
+    static member CreateForLineAndMaxCount (snapshotLine: ITextSnapshotLine) (count: int) = 
         let maxCount = (snapshotLine.Snapshot.LineCount - snapshotLine.LineNumber)
         let count = Math.Min(count, maxCount)
         new SnapshotLineRange(snapshotLine.Snapshot, snapshotLine.LineNumber, count)
 
     /// Create a SnapshotLineRange which includes the 2 lines
-    static member CreateForLineRange (startLine : ITextSnapshotLine) (lastLine : ITextSnapshotLine) =
+    static member CreateForLineRange (startLine: ITextSnapshotLine) (lastLine: ITextSnapshotLine) =
         Contract.Requires(startLine.Snapshot = lastLine.Snapshot)
         let count = (lastLine.LineNumber - startLine.LineNumber) + 1
         new SnapshotLineRange(startLine.Snapshot, startLine.LineNumber, count)
@@ -212,7 +212,7 @@ type SnapshotLineRange  =
     /// <summary>
     /// Create a SnapshotLineRange which includes the 2 lines
     /// </summary>
-    static member CreateForLineNumberRange (snapshot : ITextSnapshot) (startLine : int) (lastLine : int) : Nullable<SnapshotLineRange> =
+    static member CreateForLineNumberRange (snapshot: ITextSnapshot) (startLine: int) (lastLine: int): Nullable<SnapshotLineRange> =
         Contract.Requires(startLine <= lastLine)
         if (startLine >= snapshot.LineCount || lastLine >= snapshot.LineCount) then
             Nullable<SnapshotLineRange>()
@@ -231,11 +231,11 @@ type SnapshotLineRange  =
 [<NoComparison>]
 type SnapshotColumn 
     (
-        _snapshotLine : ITextSnapshotLine,
-        _column : int
+        _snapshotLine: ITextSnapshotLine,
+        _column: int
     ) =
 
-    new (point : SnapshotPoint) = 
+    new (point: SnapshotPoint) = 
         let line = point.GetContainingLine()
         let column = point.Position - line.Start.Position
         SnapshotColumn(line, column)
@@ -279,24 +279,24 @@ type SnapshotColumn
 [<DebuggerDisplay("{ToString()}")>]
 type SnapshotOverlapPoint =
 
-    val private _point : SnapshotPoint
+    val private _point: SnapshotPoint
 
     /// The number of spaces into the point where this overlap point occurs
-    val private _beforeSpaces : int
+    val private _beforeSpaces: int
 
     /// The number of spaces the point occupies in the editor. 
     ///
     /// An interesting case to consider here is tabs.  They will not always occupy 
     /// 'tabstop' spaces.  It can occupy less if there is a character in front of the 
     /// tab which occurs on a 'tabstop' boundary. 
-    val private _totalSpaces : int
+    val private _totalSpaces: int
 
     /// !!!Do not call this directly!!!
     ///
     /// This constructor is meant for internal usage only.  If friend types existed this would employ
     /// a friend type to protect it.  It's far too easy to get the 'totalSpaces' parameter incorrect.  Instead
     /// go through a supported API for creating them
-    internal new (point : SnapshotPoint, beforeSpaces : int, totalSpaces : int) = 
+    internal new (point: SnapshotPoint, beforeSpaces: int, totalSpaces: int) = 
         if totalSpaces < 0 then
             invalidArg "totalSpaces" "totalSpaces must be positive"
         { _point = point; _beforeSpaces = beforeSpaces; _totalSpaces = totalSpaces }
@@ -307,7 +307,7 @@ type SnapshotOverlapPoint =
     ///
     /// TODO: This API is fundamentally incorrect because it treats all points as a one space item
     /// even if the underlying character is spaces wide.  
-    new (point : SnapshotPoint) =
+    new (point: SnapshotPoint) =
         let width = 
             if EditorCoreUtil.IsEndPoint point then
                 0
@@ -341,15 +341,15 @@ type SnapshotOverlapPoint =
 [<DebuggerDisplay("{ToString()}")>] 
 type SnapshotOverlapSpan = 
 
-    val private _start : SnapshotOverlapPoint
-    val private _end : SnapshotOverlapPoint 
+    val private _start: SnapshotOverlapPoint
+    val private _end: SnapshotOverlapPoint 
 
-    new (startPoint : SnapshotOverlapPoint, endPoint : SnapshotOverlapPoint) = 
+    new (startPoint: SnapshotOverlapPoint, endPoint: SnapshotOverlapPoint) = 
         if startPoint.Point.Position + startPoint.SpacesBefore > endPoint.Point.Position + endPoint.SpacesBefore then
             invalidArg "endPoint" "End cannot be before the start"
         { _start = startPoint; _end = endPoint }
 
-    new (span : SnapshotSpan) =
+    new (span: SnapshotSpan) =
         let startPoint = SnapshotOverlapPoint(span.Start)
         let endPoint = SnapshotOverlapPoint(span.End)
         { _start = startPoint; _end = endPoint }
@@ -486,7 +486,7 @@ module SnapshotUtil =
         span.Start < tss.Length && span.End <= tss.Length
 
     /// Is the last line in the ITextSnapshot empty
-    let IsLastLineEmpty (snapshot : ITextSnapshot) = 
+    let IsLastLineEmpty (snapshot: ITextSnapshot) = 
         let endPoint = GetEndPoint snapshot
         let line = endPoint.GetContainingLine()
         line.Length = 0
@@ -548,7 +548,7 @@ module SnapshotUtil =
                 snapshotLine.Start.Add(column) |> Some
 
     /// Get the point from the specified position
-    let GetPoint (snapshot : ITextSnapshot) position = SnapshotPoint(snapshot, position)
+    let GetPoint (snapshot: ITextSnapshot) position = SnapshotPoint(snapshot, position)
 
 /// Contains operations to help fudge the Editor APIs to be more F# friendly.  Does not
 /// include any Vim specific logic
@@ -606,7 +606,7 @@ module SnapshotSpanUtil =
     /// Get the end line in the SnapshotSpan.  Remember that End is not a part of the Span
     /// but instead the first point after the Span.  This is important when the Span is 
     /// ITextSnapshotLine.ExtentIncludingLineBreak as it is in Visual Mode
-    let GetLastLine (span : SnapshotSpan) = 
+    let GetLastLine (span: SnapshotSpan) = 
         if span.Length > 0 then span.End.Subtract(1).GetContainingLine()
         else GetStartLine(span)
 
@@ -745,7 +745,7 @@ module SnapshotSpanUtil =
     /// Given a NonEmptyCollection<SnapshotSpan> return the SnapshotSpan which is the overarching span that
     /// encompasses all of the SnapshotSpan values in the collection.  The Start will be the minimum start of 
     /// all of the SnapshotSpan values and the End will be the maximum
-    let GetOverarchingSpan (col : NonEmptyCollection<SnapshotSpan>) =
+    let GetOverarchingSpan (col: NonEmptyCollection<SnapshotSpan>) =
         let startPoint = col |> Seq.map (fun span -> span.Start) |> Seq.minBy (fun p -> p.Position)
         let endPoint = col |> Seq.map (fun span -> span.End) |> Seq.maxBy (fun p -> p.Position)
         SnapshotSpan(startPoint, endPoint)
@@ -757,10 +757,10 @@ module SnapshotSpanUtil =
     let CreateEmpty point = SnapshotSpan(point, 0)
 
     /// Create a span from the given point with the specified length
-    let CreateWithLength (startPoint : SnapshotPoint) (length : int) = SnapshotSpan(startPoint, length)
+    let CreateWithLength (startPoint: SnapshotPoint) (length: int) = SnapshotSpan(startPoint, length)
 
     /// Create a span which is the overarching span of the two provided SnapshotSpan values
-    let CreateOverarching (leftSpan : SnapshotSpan) (rightSpan : SnapshotSpan) = 
+    let CreateOverarching (leftSpan: SnapshotSpan) (rightSpan: SnapshotSpan) = 
         Contract.Requires (leftSpan.Snapshot = rightSpan.Snapshot)
         let snapshot = leftSpan.Snapshot
         let startPoint = 
@@ -798,7 +798,7 @@ module NormalizedSnapshotSpanCollectionUtil =
         SnapshotSpan(first.Start,last.End) 
 
     /// Get the first item 
-    let TryGetFirst (col : NormalizedSnapshotSpanCollection) = if col.Count = 0 then None else Some (col.[0])
+    let TryGetFirst (col: NormalizedSnapshotSpanCollection) = if col.Count = 0 then None else Some (col.[0])
 
     let OfSeq (s:SnapshotSpan seq) = new NormalizedSnapshotSpanCollection(s)
 
@@ -814,13 +814,13 @@ module VirtualSnapshotSpanUtil =
 module SnapshotLineUtil =
 
     /// ITextSnapshot the ITextSnapshotLine is associated with
-    let GetSnapshot (line : ITextSnapshotLine) = line.Snapshot
+    let GetSnapshot (line: ITextSnapshotLine) = line.Snapshot
 
     /// Length of the line
-    let GetLength (line : ITextSnapshotLine) = line.Length
+    let GetLength (line: ITextSnapshotLine) = line.Length
 
     /// Length of the line including the line break
-    let GetLengthIncludingLineBreak (line : ITextSnapshotLine) = line.LengthIncludingLineBreak
+    let GetLengthIncludingLineBreak (line: ITextSnapshotLine) = line.LengthIncludingLineBreak
 
     /// Get the length of the line break
     let GetLineBreakLength (line:ITextSnapshotLine) = line.LengthIncludingLineBreak - line.Length
@@ -899,10 +899,10 @@ module SnapshotLineUtil =
         span.GetText()
 
     /// Get the text of the ITextSnapshotLine 
-    let GetText (line : ITextSnapshotLine) = line.GetText()
+    let GetText (line: ITextSnapshotLine) = line.GetText()
 
     /// Get the text of the ITextSnapshotLine including the line break
-    let GetTextIncludingLineBreak (line : ITextSnapshotLine) = line.GetTextIncludingLineBreak()
+    let GetTextIncludingLineBreak (line: ITextSnapshotLine) = line.GetTextIncludingLineBreak()
 
     /// Get the last point which is included in this line not including the line 
     /// break.  Can be None if this is a 0 length line 
@@ -917,16 +917,16 @@ module SnapshotLineUtil =
         | None -> line.Start
 
     /// Is this the last included point on the ITextSnapshotLine
-    let IsLastPoint (line : ITextSnapshotLine) point = 
+    let IsLastPoint (line: ITextSnapshotLine) point = 
         if line.Length = 0 then point = line.Start
         else point.Position + 1 = line.End.Position
 
     /// Is this the last point on the line including the line break
-    let IsLastPointIncludingLineBreak (line : ITextSnapshotLine) (point : SnapshotPoint) = 
+    let IsLastPointIncludingLineBreak (line: ITextSnapshotLine) (point: SnapshotPoint) = 
         point.Position + 1 = line.EndIncludingLineBreak.Position
 
     /// Is this the last line in the ITextBuffer
-    let IsLastLine (line : ITextSnapshotLine) = 
+    let IsLastLine (line: ITextSnapshotLine) = 
         let snapshot = line.Snapshot
         snapshot.LineCount - 1 = line.LineNumber
 
@@ -953,7 +953,7 @@ module SnapshotLineUtil =
         |> SeqUtil.tryHeadOnly
 
     // Checks if the point is the first non blank character of the line
-    let IsFirstNonBlank (point : SnapshotPoint) =
+    let IsFirstNonBlank (point: SnapshotPoint) =
         point.GetContainingLine()
         |> GetFirstNonBlank = Some(point)
 
@@ -974,7 +974,7 @@ module SnapshotLineUtil =
     /// Get the SnapshotSpan for the given column in length within the extent of the
     /// line.  If the column or length exceeds the length of the line then an
     /// End will be used in it's place
-    let GetSpanInLine (line : ITextSnapshotLine) column length =
+    let GetSpanInLine (line: ITextSnapshotLine) column length =
         let startPoint = 
             if column >= line.Length then
                 line.End
@@ -990,13 +990,13 @@ module SnapshotLineUtil =
 
     /// Get a SnapshotPoint representing the nth characters into the line or the 
     /// End point of the line.  This is done using positioning 
-    let GetColumnOrEnd column (line : ITextSnapshotLine) = 
+    let GetColumnOrEnd column (line: ITextSnapshotLine) = 
         if line.Start.Position + column >= line.End.Position then line.End
         else line.Start.Add(column)
 
     /// Get a SnapshotPoint representing 'offset' characters into the line or it's
     /// line break or the EndIncludingLineBreak of the line
-    let GetColumnOrEndIncludingLineBreak column (line : ITextSnapshotLine) = 
+    let GetColumnOrEndIncludingLineBreak column (line: ITextSnapshotLine) = 
         if line.Start.Position + column >= line.EndIncludingLineBreak.Position then line.EndIncludingLineBreak
         else line.Start.Add(column)
 
@@ -1011,7 +1011,7 @@ module SnapshotLineUtil =
 
         let mutable point = line.Start
         let mutable spaces = 0 
-        let mutable value : SnapshotOverlapPoint option = None
+        let mutable value: SnapshotOverlapPoint option = None
 
         if point = endPoint then
             value <- Some (SnapshotOverlapPoint(point, 0, 0))
@@ -1054,7 +1054,7 @@ module SnapshotLineUtil =
     /// Get the count of spaces to get to the specified absolute column offset.  This will count
     /// tabs as counting for 'tabstop' spaces.  Note though that tabs which don't occur on a 'tabstop'
     /// boundary only count for the number of spaces to get to the next tabstop boundary
-    let GetSpacesToColumn (line : ITextSnapshotLine) column tabStop = 
+    let GetSpacesToColumn (line: ITextSnapshotLine) column tabStop = 
         let mutable spaces = 0
         let mutable current = SnapshotColumn(line.Start)
         let maxColumn = min column line.Length
@@ -1398,11 +1398,11 @@ module SnapshotPointUtil =
 
         /// Get the relative column in 'direction' using predicate 'isEnd'
         /// to stop the motion
-        let GetRelativeColumn direction (isEnd : SnapshotPoint -> bool) =
+        let GetRelativeColumn direction (isEnd: SnapshotPoint -> bool) =
 
             /// Adjust 'column' backward or forward if it is in the
             /// middle of a line break
-            let AdjustLineBreak (column : SnapshotColumn) =
+            let AdjustLineBreak (column: SnapshotColumn) =
                 if column.Column <= column.Line.Length then
                     column
                 else if direction = -1 then
@@ -1500,11 +1500,11 @@ module VirtualSnapshotPointUtil =
 module SnapshotLineRangeUtil = 
 
     /// Create a range for the entire ItextSnapshot
-    let CreateForSnapshot (snapshot : ITextSnapshot) = 
+    let CreateForSnapshot (snapshot: ITextSnapshot) = 
         SnapshotLineRange.CreateForExtent snapshot
 
     /// Create a range for the provided ITextSnapshotLine
-    let CreateForLine (line : ITextSnapshotLine) =
+    let CreateForLine (line: ITextSnapshotLine) =
         SnapshotLineRange.CreateForLine line
 
     /// Create a range for the provided ITextSnapshotLine and with count length
@@ -1541,7 +1541,7 @@ module SnapshotLineRangeUtil =
         CreateForLineAndMaxCount line count
 
     /// Create a line range for the provided start and end line 
-    let CreateForLineRange (startLine : ITextSnapshotLine) (endLine : ITextSnapshotLine) = 
+    let CreateForLineRange (startLine: ITextSnapshotLine) (endLine: ITextSnapshotLine) = 
         SnapshotLineRange.CreateForLineRange startLine endLine
 
     /// Create a line range for the provided start and end line 
@@ -1554,7 +1554,7 @@ module BufferGraphUtil =
 
     /// Map the point up to the given ITextSnapshot.  Returns None if the mapping is not 
     /// possible
-    let MapPointUpToSnapshot (bufferGraph : IBufferGraph) point snapshot trackingMode affinity =
+    let MapPointUpToSnapshot (bufferGraph: IBufferGraph) point snapshot trackingMode affinity =
         try
             bufferGraph.MapUpToSnapshot(point, trackingMode, affinity, snapshot)
             |> OptionUtil.ofNullable
@@ -1564,12 +1564,12 @@ module BufferGraphUtil =
 
     /// Map the point up to the given ITextSnapshot.  Returns None if the mapping is not 
     /// possible
-    let MapPointUpToSnapshotStandard (bufferGraph : IBufferGraph) point snapshot =
+    let MapPointUpToSnapshotStandard (bufferGraph: IBufferGraph) point snapshot =
         MapPointUpToSnapshot bufferGraph point snapshot PointTrackingMode.Negative PositionAffinity.Predecessor
 
     /// Map the point down to the given ITextSnapshot.  Returns None if the mapping is not 
     /// possible
-    let MapPointDownToSnapshot (bufferGraph : IBufferGraph) point snapshot trackingMode affinity =
+    let MapPointDownToSnapshot (bufferGraph: IBufferGraph) point snapshot trackingMode affinity =
         try
             bufferGraph.MapDownToSnapshot(point, trackingMode, snapshot, affinity)
             |> OptionUtil.ofNullable
@@ -1579,12 +1579,12 @@ module BufferGraphUtil =
 
     /// Map the point down to the given ITextSnapshot.  Returns None if the mapping is not 
     /// possible
-    let MapPointDownToSnapshotStandard (bufferGraph : IBufferGraph) point snapshot =
+    let MapPointDownToSnapshotStandard (bufferGraph: IBufferGraph) point snapshot =
         MapPointDownToSnapshot bufferGraph point snapshot PointTrackingMode.Negative PositionAffinity.Predecessor
 
     /// Map the SnapshotSpan up to the given ITextSnapshot.  Returns None if the mapping is
     /// not possible
-    let MapSpanUpToSnapshot (bufferGraph : IBufferGraph) span trackingMode snapshot =
+    let MapSpanUpToSnapshot (bufferGraph: IBufferGraph) span trackingMode snapshot =
         try
             bufferGraph.MapUpToSnapshot(span, trackingMode, snapshot) |> Some
         with
@@ -1593,7 +1593,7 @@ module BufferGraphUtil =
 
     /// Map the SnapshotSpan down to the given ITextSnapshot.  Returns None if the mapping is
     /// not possible
-    let MapSpanDownToSnapshot (bufferGraph : IBufferGraph) span trackingMode snapshot =
+    let MapSpanDownToSnapshot (bufferGraph: IBufferGraph) span trackingMode snapshot =
         try
             bufferGraph.MapDownToSnapshot(span, trackingMode, snapshot) |> Some
         with
@@ -1602,7 +1602,7 @@ module BufferGraphUtil =
 
     /// Map the SnapshotSpan down to the given ITextSnapshot by the Start and End points
     /// instead of by the mapped Spans
-    let MapSpanDownToSingle (bufferGraph : IBufferGraph) (span : SnapshotSpan) snapshot = 
+    let MapSpanDownToSingle (bufferGraph: IBufferGraph) (span: SnapshotSpan) snapshot = 
         let startPoint = MapPointDownToSnapshot bufferGraph span.Start snapshot PointTrackingMode.Negative PositionAffinity.Predecessor
         let endPoint = MapPointDownToSnapshot bufferGraph span.End snapshot PointTrackingMode.Positive PositionAffinity.Successor
         match startPoint, endPoint with
@@ -1616,13 +1616,13 @@ module BufferGraphUtil =
 type SnapshotData = {
 
     /// SnapshotPoint for the Caret
-    CaretPoint : SnapshotPoint
+    CaretPoint: SnapshotPoint
 
     /// ITextSnapshotLine on which the caret resides
-    CaretLine : ITextSnapshotLine
+    CaretLine: ITextSnapshotLine
 
     /// The current ITextSnapshot on which this data is based
-    CurrentSnapshot : ITextSnapshot
+    CurrentSnapshot: ITextSnapshot
 }
 
 [<System.Flags>]
@@ -1635,7 +1635,7 @@ type MoveCaretFlags =
 module EditorOptionsUtil =
 
     /// Get the option value if it exists
-    let GetOptionValue (opts : IEditorOptions) (key : EditorOptionKey<'a>) =
+    let GetOptionValue (opts: IEditorOptions) (key: EditorOptionKey<'a>) =
         try
             if opts.IsOptionDefined(key, false) then 
                 opts.GetOptionValue(key) |> Some
@@ -1650,12 +1650,12 @@ module EditorOptionsUtil =
         | Some value -> value
         | None -> defaultValue
 
-    let SetOptionValue (opts : IEditorOptions) (key : EditorOptionKey<'a>) value =
+    let SetOptionValue (opts: IEditorOptions) (key: EditorOptionKey<'a>) value =
         opts.SetOptionValue(key, value)
 
 module ProjectionBufferUtil =
 
-    let GetSourceBuffersRecursive (projectionBuffer : IProjectionBuffer) =
+    let GetSourceBuffersRecursive (projectionBuffer: IProjectionBuffer) =
         let toVisit = new Queue<IProjectionBuffer>()
         toVisit.Enqueue projectionBuffer
 
@@ -1676,14 +1676,14 @@ module TextBufferUtil =
     /// Delete the specified span and return the latest ITextSnapshot after the
     /// entire delete operation completes vs. the one which is returned for 
     /// the specific delete operation
-    let DeleteAndGetLatest (textBuffer : ITextBuffer) (deleteSpan : Span) = 
+    let DeleteAndGetLatest (textBuffer: ITextBuffer) (deleteSpan: Span) = 
         textBuffer.Delete(deleteSpan) |> ignore
         textBuffer.CurrentSnapshot
 
     /// Any ITextBuffer instance is possibly an IProjectionBuffer (which is a text buffer composed 
     /// of parts of other ITextBuffers).  This will return all of the real ITextBuffer buffers 
     /// composing the provided ITextBuffer
-    let GetSourceBuffersRecursive (textBuffer : ITextBuffer) =
+    let GetSourceBuffersRecursive (textBuffer: ITextBuffer) =
         match textBuffer with
         | :? IProjectionBuffer as p -> ProjectionBufferUtil.GetSourceBuffersRecursive p
         | _ -> Seq.singleton textBuffer
@@ -1693,7 +1693,7 @@ module TextEditUtil =
     /// Apply the change and return the latest ITextSnapshot after the edit
     /// operation completes vs. the one which is returned for this specific
     /// edit operation.
-    let ApplyAndGetLatest (textEdit : ITextEdit) = 
+    let ApplyAndGetLatest (textEdit: ITextEdit) = 
         textEdit.Apply() |> ignore
         textEdit.Snapshot.TextBuffer.CurrentSnapshot
 
@@ -1701,13 +1701,13 @@ module TextEditUtil =
 /// include any Vim specific logic
 module TextViewUtil =
 
-    let GetSnapshot (textView : ITextView) = textView.TextSnapshot
+    let GetSnapshot (textView: ITextView) = textView.TextSnapshot
 
-    let GetCaret (textView : ITextView) = textView.Caret
+    let GetCaret (textView: ITextView) = textView.Caret
 
-    let GetCaretPoint (textView : ITextView) = textView.Caret.Position.BufferPosition
+    let GetCaretPoint (textView: ITextView) = textView.Caret.Position.BufferPosition
 
-    let GetCaretVirtualPoint (textView : ITextView) = textView.Caret.Position.VirtualBufferPosition
+    let GetCaretVirtualPoint (textView: ITextView) = textView.Caret.Position.VirtualBufferPosition
 
     let GetCaretLine textView = GetCaretPoint textView |> SnapshotPointUtil.GetContainingLine
 
@@ -1723,7 +1723,7 @@ module TextViewUtil =
     ///
     /// Be aware when using GetTextViewLineContainingYCoordinate, may need to add the
     /// _textView.ViewportTop to the y coordinate
-    let GetTextViewLines (textView : ITextView) =
+    let GetTextViewLines (textView: ITextView) =
         try
             let textViewLines = textView.TextViewLines
             if textViewLines <> null then Some textViewLines
@@ -1740,7 +1740,7 @@ module TextViewUtil =
         | Some textViewLines -> textViewLines.Count
 
     /// Return the overarching SnapshotLineRange for the visible lines in the ITextView
-    let GetVisibleSnapshotLineRange (textView : ITextView) =
+    let GetVisibleSnapshotLineRange (textView: ITextView) =
         if textView.InLayout then
             None
         else 
@@ -1751,14 +1751,14 @@ module TextViewUtil =
             SnapshotLineRange.CreateForLineNumberRange textView.TextSnapshot startLine lastLine |> NullableUtil.ToOption
 
     /// Returns a sequence of ITextSnapshotLine values representing the visible lines in the buffer
-    let GetVisibleSnapshotLines (textView : ITextView) =
+    let GetVisibleSnapshotLines (textView: ITextView) =
         match GetVisibleSnapshotLineRange textView with
         | Some lineRange -> lineRange.Lines
         | None -> Seq.empty
 
     /// Returns the overarching SnapshotLineRange for the visible lines in the ITextView on the
     /// Visual snapshot.
-    let GetVisibleVisualSnapshotLineRange (textView : ITextView) = 
+    let GetVisibleVisualSnapshotLineRange (textView: ITextView) = 
         match GetVisibleSnapshotLineRange textView with
         | None -> NullableUtil.CreateNull<SnapshotLineRange>()
         | Some range ->
@@ -1772,7 +1772,7 @@ module TextViewUtil =
 
     /// Returns a sequence of ITextSnapshotLine values representing the visible lines in the buffer
     /// on the Visual snapshot
-    let GetVisibleVisualSnapshotLines (textView : ITextView) =
+    let GetVisibleVisualSnapshotLines (textView: ITextView) =
         match GetVisibleVisualSnapshotLineRange textView with
         | NullableUtil.HasValue lineRange -> lineRange.Lines
         | NullableUtil.Null -> Seq.empty
@@ -1783,7 +1783,7 @@ module TextViewUtil =
         caret.EnsureVisible()
 
     /// Clear out the selection
-    let ClearSelection (textView : ITextView) =
+    let ClearSelection (textView: ITextView) =
         textView.Selection.Clear()
 
     let private MoveCaretToCommon textView flags = 
@@ -1794,7 +1794,7 @@ module TextViewUtil =
             EnsureCaretOnScreen textView
 
     /// Move the caret to the given point
-    let MoveCaretToPointRaw textView (point : SnapshotPoint) flags = 
+    let MoveCaretToPointRaw textView (point: SnapshotPoint) flags = 
         let caret = GetCaret textView
         caret.MoveTo(point) |> ignore
         MoveCaretToCommon textView flags
@@ -1805,7 +1805,7 @@ module TextViewUtil =
         MoveCaretToPointRaw textView point MoveCaretFlags.All
 
     /// Move the caret to the given point and ensure it is on screen.  Will not expand any outlining regions
-    let MoveCaretToVirtualPointRaw textView (point : VirtualSnapshotPoint) flags = 
+    let MoveCaretToVirtualPointRaw textView (point: VirtualSnapshotPoint) flags = 
         let caret = GetCaret textView
         caret.MoveTo(point) |> ignore
         MoveCaretToCommon textView flags
@@ -1816,7 +1816,7 @@ module TextViewUtil =
         MoveCaretToVirtualPointRaw textView point MoveCaretFlags.All
 
     /// Move the caret to the given point and ensure it is on screen.  Will not expand any outlining regions
-    let MoveCaretToPositionRaw textView (position : int) flags = 
+    let MoveCaretToPositionRaw textView (position: int) flags = 
         let snapshot = GetSnapshot textView
         let point = SnapshotPoint(snapshot, position)
         MoveCaretToPointRaw textView point flags
@@ -1828,7 +1828,7 @@ module TextViewUtil =
 
     /// Get the SnapshotData value for the edit buffer.  Unlike the SnapshotData for the Visual Buffer this 
     /// can always be retrieved because the caret point is presented in terms of the edit buffer
-    let GetEditSnapshotData (textView : ITextView) = 
+    let GetEditSnapshotData (textView: ITextView) = 
         let caretPoint = GetCaretPoint textView
         let caretLine = SnapshotPointUtil.GetContainingLine caretPoint
         { 
@@ -1839,7 +1839,7 @@ module TextViewUtil =
     /// Get the SnapshotData value for the visual buffer.  Can return None if the information is not mappable
     /// to the visual buffer.  Really this shouldn't ever happen unless the IProjectionBuffer was incorrectly
     /// hooked up though
-    let GetVisualSnapshotData (textView : ITextView) = 
+    let GetVisualSnapshotData (textView: ITextView) = 
 
         // Get the visual buffer information
         let visualBuffer = textView.TextViewModel.VisualBuffer
@@ -1877,7 +1877,7 @@ module TextViewUtil =
         | None -> GetEditSnapshotData textView
 
     /// Is word wrap enabled for this ITextView
-    let IsWordWrapEnabled (textView : ITextView) = 
+    let IsWordWrapEnabled (textView: ITextView) = 
         let editorOptions = textView.Options
         match EditorOptionsUtil.GetOptionValue editorOptions DefaultTextViewOptions.WordWrapStyleId with
         | None -> false
@@ -1887,7 +1887,7 @@ module TextSelectionUtil =
 
     /// Returns the SnapshotSpan which represents the total of the selection.  This is a SnapshotSpan of the left
     /// most and right most point point in any of the selected spans 
-    let GetOverarchingSelectedSpan (selection : ITextSelection) = 
+    let GetOverarchingSelectedSpan (selection: ITextSelection) = 
         if selection.IsEmpty then 
             None
         else
@@ -1900,13 +1900,13 @@ module TextSelectionUtil =
 
 module TrackingPointUtil =
 
-    let GetPoint (snapshot : ITextSnapshot) (point : ITrackingPoint) =
+    let GetPoint (snapshot: ITextSnapshot) (point: ITrackingPoint) =
         try
             point.GetPoint(snapshot) |> Some
         with
             | :? System.ArgumentException -> None
 
-    let GetPointInSnapshot point mode (newSnapshot : ITextSnapshot) =
+    let GetPointInSnapshot point mode (newSnapshot: ITextSnapshot) =
         let oldSnapshot = SnapshotPointUtil.GetSnapshot point
         if oldSnapshot.Version.VersionNumber = newSnapshot.Version.VersionNumber then
             Some point
@@ -1959,17 +1959,17 @@ type EditSpan =
 module EditUtil = 
 
     /// NewLine to use for the ITextBuffer
-    let NewLine (options : IEditorOptions) = DefaultOptionExtensions.GetNewLineCharacter options
+    let NewLine (options: IEditorOptions) = DefaultOptionExtensions.GetNewLineCharacter options
 
     /// Get the text for a tab character based on the given options
-    let GetTabText (options : IEditorOptions) = 
+    let GetTabText (options: IEditorOptions) = 
         if DefaultOptionExtensions.IsConvertTabsToSpacesEnabled options then
             StringUtil.RepeatChar (DefaultOptionExtensions.GetTabSize options) ' '
         else
             "\t"
 
     /// Get the length of the line break at the given index 
-    let GetLineBreakLength (str : string) index =
+    let GetLineBreakLength (str: string) index =
         match str.Chars(index) with
         | '\r' ->
             if index + 1 < str.Length && '\n' = str.Chars(index + 1) then
@@ -1987,7 +1987,7 @@ module EditUtil =
             else 0
 
     /// Get the length of the line break at the end of the string
-    let GetLineBreakLengthAtEnd (str : string) =
+    let GetLineBreakLengthAtEnd (str: string) =
         if System.String.IsNullOrEmpty str then 
             0
         else
@@ -1998,7 +1998,7 @@ module EditUtil =
                 GetLineBreakLength str index
 
     /// Get the count of new lines in the string
-    let GetLineBreakCount (str : string) =
+    let GetLineBreakCount (str: string) =
         let rec inner index count =
             if index >= str.Length then
                 count
@@ -2013,7 +2013,7 @@ module EditUtil =
 
     /// Get the indentation level given the context line (the line above the line which is 
     /// being indented)
-    let GetAutoIndent (contextLine : ITextSnapshotLine) =
+    let GetAutoIndent (contextLine: ITextSnapshotLine) =
         contextLine 
         |> SnapshotLineUtil.GetIndentPoint 
         |> SnapshotPointUtil.GetColumn 
@@ -2022,7 +2022,7 @@ module EditUtil =
     let EndsWithNewLine value = 0 <> GetLineBreakLengthAtEnd value
 
     /// Does this text have a new line character inside of it?
-    let HasNewLine (text : string) = 
+    let HasNewLine (text: string) = 
         { 0 .. (text.Length - 1) }
         |> SeqUtil.any (fun index -> GetLineBreakLength text index > 0)
 
@@ -2051,7 +2051,7 @@ module EditUtil =
                 value.Substring(0, value.Length - length)
 
     /// Normalize the new line values in the string to the specified value
-    let NormalizeNewLines (text : string) (newLine : string) = 
+    let NormalizeNewLines (text: string) (newLine: string) = 
         let builder = System.Text.StringBuilder()
         let rec inner index = 
             if index >= text.Length then
@@ -2072,17 +2072,17 @@ module EditUtil =
 type TextLine = {
 
     /// The text of the line
-    Text : string
+    Text: string
 
     /// The string for the new line 
-    NewLine : string
+    NewLine: string
 
 } with
 
     member x.HasNewLine = x.NewLine.Length = 0
 
     /// Create a string back from the provided TextLine values
-    static member CreateString (textLines : TextLine seq) = 
+    static member CreateString (textLines: TextLine seq) = 
         let builder = System.Text.StringBuilder()
         for textLine in textLines do
             builder.AppendString textLine.Text
@@ -2092,7 +2092,7 @@ type TextLine = {
     /// Break a string representation into a series of TextNode values.  This will 
     /// always return at least a single value for even an empty string so we use 
     /// a NonEmptyCollection
-    static member GetTextLines (fullText : string) = 
+    static member GetTextLines (fullText: string) = 
 
         // Get the next new line item from the given index
         let rec getNextNewLine index = 
@@ -2133,15 +2133,15 @@ type TextLine = {
             let firstLine, index = getForIndex 0 |> Option.get
     
             // Now calculate the rest 
-            let rest : TextLine list = Seq.unfold getForIndex index |> List.ofSeq
+            let rest: TextLine list = Seq.unfold getForIndex index |> List.ofSeq
 
             NonEmptyCollection(firstLine, rest)
 
 module SnapshotColumnUtil =
 
-    let GetPoint (column : SnapshotColumn) = column.Point
+    let GetPoint (column: SnapshotColumn) = column.Point
 
-    let GetLine (column : SnapshotColumn) = column.Line
+    let GetLine (column: SnapshotColumn) = column.Line
     
     /// Get the columns from the given point in a forward motion 
     let private GetColumnsCore path includeLineBreak point = 
@@ -2149,8 +2149,8 @@ module SnapshotColumnUtil =
         let startLineNumber = SnapshotPointUtil.GetLineNumber point
         let filter = 
             match path with 
-            | SearchPath.Forward -> fun (c : SnapshotColumn) -> c.Point.Position >= point.Position
-            | SearchPath.Backward -> fun (c : SnapshotColumn) -> c.Point.Position <= point.Position
+            | SearchPath.Forward -> fun (c: SnapshotColumn) -> c.Point.Position >= point.Position
+            | SearchPath.Backward -> fun (c: SnapshotColumn) -> c.Point.Position <= point.Position
 
         SnapshotUtil.GetLines snapshot startLineNumber path
         |> Seq.collect (fun line -> 
@@ -2172,7 +2172,7 @@ module internal ITextEditExtensions =
 
         /// Delete the overlapped span from the ITextBuffer.  If there is any overlap then the
         /// remaining spaces will be filed with ' ' 
-        member x.Delete (overlapSpan : SnapshotOverlapSpan) = 
+        member x.Delete (overlapSpan: SnapshotOverlapSpan) = 
             let pre = overlapSpan.Start.SpacesBefore
             let post = 
                 if overlapSpan.HasOverlapEnd then

--- a/Src/VimCore/ExternalEdit.fs
+++ b/Src/VimCore/ExternalEdit.fs
@@ -2,7 +2,7 @@
 
 namespace Vim
 
-type internal ExternalEditMode(_vimBufferData : IVimBufferData) =
+type internal ExternalEditMode(_vimBufferData: IVimBufferData) =
     
     interface IMode with 
         member x.VimTextBuffer = _vimBufferData.VimTextBuffer

--- a/Src/VimCore/FSharpExtensions.fs
+++ b/Src/VimCore/FSharpExtensions.fs
@@ -36,7 +36,7 @@ module public FSharpOption =
         | null -> None
         | _ -> Some value
 
-    let CreateForNullable (value : System.Nullable<'T>) =
+    let CreateForNullable (value: System.Nullable<'T>) =
         if value.HasValue then Some value.Value
         else None
 
@@ -44,31 +44,31 @@ module public FSharpOption =
 type public FSharpFuncUtil = 
 
     [<Extension>] 
-    static member ToFSharpFunc<'a> (func : System.Func<'a>) = fun () -> func.Invoke()
+    static member ToFSharpFunc<'a> (func: System.Func<'a>) = fun () -> func.Invoke()
 
     [<Extension>] 
-    static member ToFSharpFunc<'a,'b> (func : System.Converter<'a,'b>) = fun x -> func.Invoke(x)
+    static member ToFSharpFunc<'a,'b> (func: System.Converter<'a,'b>) = fun x -> func.Invoke(x)
 
     [<Extension>] 
-    static member ToFSharpFunc<'a,'b> (func : System.Func<'a,'b>) = fun x -> func.Invoke(x)
+    static member ToFSharpFunc<'a,'b> (func: System.Func<'a,'b>) = fun x -> func.Invoke(x)
 
     [<Extension>] 
-    static member ToFSharpFunc<'a,'b,'c> (func : System.Func<'a,'b,'c>) = fun x y -> func.Invoke(x,y)
+    static member ToFSharpFunc<'a,'b,'c> (func: System.Func<'a,'b,'c>) = fun x y -> func.Invoke(x,y)
 
     [<Extension>] 
-    static member ToFSharpFunc<'a,'b,'c,'d> (func : System.Func<'a,'b,'c,'d>) = fun x y z -> func.Invoke(x,y,z)
+    static member ToFSharpFunc<'a,'b,'c,'d> (func: System.Func<'a,'b,'c,'d>) = fun x y z -> func.Invoke(x,y,z)
 
     [<Extension>] 
-    static member ToFSharpFunc<'a> (func : System.Action) = fun () -> func.Invoke()
+    static member ToFSharpFunc<'a> (func: System.Action) = fun () -> func.Invoke()
 
     [<Extension>] 
-    static member ToFSharpFunc<'a> (func : System.Action<'a>) = fun x -> func.Invoke(x)
+    static member ToFSharpFunc<'a> (func: System.Action<'a>) = fun x -> func.Invoke(x)
 
-    static member Create<'a,'b> (func : System.Func<'a,'b>) = FSharpFuncUtil.ToFSharpFunc func
+    static member Create<'a,'b> (func: System.Func<'a,'b>) = FSharpFuncUtil.ToFSharpFunc func
 
-    static member Create<'a,'b,'c> (func : System.Func<'a,'b,'c>) = FSharpFuncUtil.ToFSharpFunc func
+    static member Create<'a,'b,'c> (func: System.Func<'a,'b,'c>) = FSharpFuncUtil.ToFSharpFunc func
 
-    static member Create<'a,'b,'c,'d> (func : System.Func<'a,'b,'c,'d>) = FSharpFuncUtil.ToFSharpFunc func
+    static member Create<'a,'b,'c,'d> (func: System.Func<'a,'b,'c,'d>) = FSharpFuncUtil.ToFSharpFunc func
 
 [<Extension>]
 module public CollectionExtensions =
@@ -86,10 +86,10 @@ module public CollectionExtensions =
         historyList
 
     [<Extension>] 
-    let ToReadOnlyCollectionShallow (list : List<'T>) = ReadOnlyCollection<'T>(list)
+    let ToReadOnlyCollectionShallow (list: List<'T>) = ReadOnlyCollection<'T>(list)
 
     [<Extension>]
-    let ToReadOnlyCollection (e : 'T seq) = 
+    let ToReadOnlyCollection (e: 'T seq) = 
         let list = List<'T>(e)
         ReadOnlyCollection<'T>(list)
 
@@ -98,7 +98,7 @@ module public EditorExtensions =
     open System.Runtime.InteropServices
 
     [<Extension>]
-    let TryGetPropertySafe<'T> propertyCollection (key : obj) ([<Out>] value : byref<'T>) =
+    let TryGetPropertySafe<'T> propertyCollection (key: obj) ([<Out>] value: byref<'T>) =
         match PropertyCollectionUtil.GetValue<'T> key propertyCollection with
         | Some v ->
             value <- v

--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -20,11 +20,11 @@ type Contract =
         if not test then
             raise (System.Exception("Contract failed"))
 
-    static member GetInvalidEnumException<'T> (value : 'T) : System.Exception =
+    static member GetInvalidEnumException<'T> (value: 'T): System.Exception =
         let msg = sprintf "The value %O is not a valid member of type %O" value typedefof<'T>
         System.Exception(msg)
 
-    static member FailEnumValue<'T> (value : 'T) : unit = 
+    static member FailEnumValue<'T> (value: 'T): unit = 
         raise (Contract.GetInvalidEnumException value)
 
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Method ||| AttributeTargets.Interface)>]
@@ -37,7 +37,7 @@ type internal StandardEvent<'T when 'T :> System.EventArgs>() =
 
     member x.Publish = _event.Publish
 
-    member x.Trigger (sender : obj) (args : 'T) = 
+    member x.Trigger (sender: obj) (args: 'T) = 
         let argsArray = [| sender; args :> obj |]
         _event.Trigger(argsArray)
 
@@ -47,12 +47,12 @@ type internal StandardEvent() =
 
     member x.Publish = _event.Publish
 
-    member x.Trigger (sender : obj) =
+    member x.Trigger (sender: obj) =
         let argsArray = [| sender; System.EventArgs.Empty :> obj |]
         _event.Trigger(argsArray)
 
 type internal DisposableBag() = 
-    let mutable _toDispose : System.IDisposable list = List.empty
+    let mutable _toDispose: System.IDisposable list = List.empty
     member x.DisposeAll () = 
         _toDispose |> List.iter (fun x -> x.Dispose()) 
         _toDispose <- List.empty
@@ -60,19 +60,19 @@ type internal DisposableBag() =
 
 module internal NullableUtil = 
 
-    let (|HasValue|Null|) (x : System.Nullable<_>) =
+    let (|HasValue|Null|) (x: System.Nullable<_>) =
         if x.HasValue then
             HasValue (x.Value)
         else
             Null 
 
-    let Create (x : 'T) =
+    let Create (x: 'T) =
         System.Nullable<'T>(x)
 
-    let CreateNull<'T when 'T : (new : unit -> 'T) and 'T : struct and 'T :> System.ValueType> () =
+    let CreateNull<'T when 'T: (new: unit -> 'T) and 'T: struct and 'T :> System.ValueType> () =
         System.Nullable<'T>()
 
-    let ToOption (x : System.Nullable<_>) =
+    let ToOption (x: System.Nullable<_>) =
         if x.HasValue then
             Some x.Value
         else
@@ -80,8 +80,8 @@ module internal NullableUtil =
 
 [<AbstractClass>]
 type internal ToggleHandler() =
-    abstract Add : unit -> unit
-    abstract Remove : unit -> unit
+    abstract Add: unit -> unit
+    abstract Remove: unit -> unit
    
     static member Create<'T> (source:System.IObservable<'T>) (func: 'T -> unit) = ToggleHandler<'T>(source,func)
     static member Empty = 
@@ -91,10 +91,10 @@ type internal ToggleHandler() =
 
 and internal ToggleHandler<'T> 
     ( 
-        _source : System.IObservable<'T>,
-        _func : 'T -> unit) =  
+        _source: System.IObservable<'T>,
+        _func: 'T -> unit) =  
     inherit ToggleHandler()
-    let mutable _handler : System.IDisposable option = None
+    let mutable _handler: System.IDisposable option = None
     override x.Add() = 
         match _handler with
         | Some(_) -> failwith "Already subscribed"
@@ -107,7 +107,7 @@ and internal ToggleHandler<'T>
         | None -> ()
 
 /// F# friendly typed wrapper around the WeakReference class 
-type internal WeakReference<'T>( _weak : System.WeakReference ) =
+type internal WeakReference<'T>( _weak: System.WeakReference ) =
     member x.Target = 
         let v = _weak.Target
         if v = null then
@@ -118,7 +118,7 @@ type internal WeakReference<'T>( _weak : System.WeakReference ) =
 
 module internal WeakReferenceUtil =
 
-    let Create<'T> (value : 'T) = 
+    let Create<'T> (value: 'T) = 
         let weakReference = System.WeakReference(value)
         WeakReference<'T>(weakReference)
 
@@ -202,7 +202,7 @@ module internal SeqUtil =
             Some (head,tail)
 
     /// Try and get the head of the sequence
-    let tryHeadOnly (sequence : 'a seq) = 
+    let tryHeadOnly (sequence: 'a seq) = 
         use e = sequence.GetEnumerator()
         if e.MoveNext() then
             Some e.Current
@@ -298,7 +298,7 @@ module internal SeqUtil =
         }
 
     /// Filters the list removing all of the first tuple arguments which are None
-    let filterToSome2 (sequence : ('a option * 'b) seq) =
+    let filterToSome2 (sequence: ('a option * 'b) seq) =
         seq { 
             for cur in sequence do
                 let first,second = cur
@@ -342,7 +342,7 @@ module internal SeqUtil =
 
     /// Same functionality as Seq.tryFind except it allows you to pass along a 
     /// state value along 
-    let tryFind initialState predicate (sequence : 'a seq) =
+    let tryFind initialState predicate (sequence: 'a seq) =
         use e = sequence.GetEnumerator()
         let rec inner state = 
             match predicate e.Current state with
@@ -364,7 +364,7 @@ module internal MapUtil =
 
 module internal GenericListUtil = 
 
-    let OfSeq (col : 'T seq) = System.Collections.Generic.List<'T>(col)
+    let OfSeq (col: 'T seq) = System.Collections.Generic.List<'T>(col)
 
 [<RequireQualifiedAccess>]
 type internal CharComparer =
@@ -384,7 +384,7 @@ type internal CharComparer =
                 let right = System.Char.ToLower right
                 left = right
 
-    member x.Compare (left : char) (right : char) = 
+    member x.Compare (left: char) (right: char) = 
         if left = right then
             0
         else
@@ -396,7 +396,7 @@ type internal CharComparer =
                 let right = System.Char.ToLower right
                 left.CompareTo(right)
 
-    member x.GetHashCode (c : char) = 
+    member x.GetHashCode (c: char) = 
         let c = 
             match x with
             | Exact -> c
@@ -410,18 +410,18 @@ type internal CharComparer =
 [<CustomEquality>]
 type internal CharSpan 
     (
-        _value : string, 
-        _index : int,
-        _length : int,
-        _comparer : CharComparer
+        _value: string, 
+        _index: int,
+        _length: int,
+        _comparer: CharComparer
     ) = 
 
-    new (value : string, comparer : CharComparer) = 
+    new (value: string, comparer: CharComparer) = 
         CharSpan(value, 0, value.Length, comparer)
 
     member x.Length = _length
 
-    member x.CharAt index : char = 
+    member x.CharAt index: char = 
         let index = _index + index
         _value.[index]
 
@@ -435,7 +435,7 @@ type internal CharSpan
         | CharComparer.Exact -> System.StringComparer.Ordinal
         | CharComparer.IgnoreCase -> System.StringComparer.OrdinalIgnoreCase
 
-    member x.CompareTo (other : CharSpan) = 
+    member x.CompareTo (other: CharSpan) = 
         let diff = x.Length - other.Length
         if diff <> 0 then
             diff
@@ -453,7 +453,7 @@ type internal CharSpan
     member x.GetSubSpan index length = 
         CharSpan(_value, index + _index, length, _comparer)
 
-    member x.IndexOf (c : char) = 
+    member x.IndexOf (c: char) = 
         let mutable index = 0
         let mutable found = -1
         while index < x.Length && found < 0 do
@@ -498,7 +498,7 @@ type internal CharSpan
     interface System.IEquatable<CharSpan> with
         member x.Equals other = 0 = x.CompareTo other
 
-    static member FromBounds (str : string) (startIndex : int) (endIndex : int) charComparer =
+    static member FromBounds (str: string) (startIndex: int) (endIndex: int) charComparer =
         let length = endIndex - startIndex
         CharSpan(str, startIndex, length, charComparer)
 
@@ -528,7 +528,7 @@ module internal CharUtil =
     let ToLower x = System.Char.ToLower(x)
     let ToUpper x = System.Char.ToUpper(x)
     let ChangeCase x = if IsUpper x then ToLower x else ToUpper x
-    let ChangeRot13 (x : char) = 
+    let ChangeRot13 (x: char) = 
         let isUpper = IsUpper x 
         let x = ToLower x
         let index = int x - int 'a'
@@ -547,7 +547,7 @@ module internal CharUtil =
         left = right
 
     /// Get the Char value for the given ASCII code
-    let OfAsciiValue (value : byte) =
+    let OfAsciiValue (value: byte) =
         let asciiArray = [| value |]
         let charArray = System.Text.Encoding.ASCII.GetChars(asciiArray)
         if charArray.Length > 0 then
@@ -680,45 +680,45 @@ module internal CharCodes =
 module internal StringBuilderExtensions =
 
     type StringBuilder with
-        member x.AppendChar (c : char) = 
+        member x.AppendChar (c: char) = 
             x.Append(c) |> ignore
 
-        member x.AppendCharCount (c : char) (count : int) = 
+        member x.AppendCharCount (c: char) (count: int) = 
             x.Append(c, count) |> ignore
 
-        member x.AppendString (str : string) =
+        member x.AppendString (str: string) =
             x.Append(str) |> ignore
             
-        member x.AppendStringCount (str : string) (count : int) =
+        member x.AppendStringCount (str: string) (count: int) =
             for i = 0 to count - 1 do
                 x.Append(str) |> ignore
 
-        member x.AppendNumber (number : int) =
+        member x.AppendNumber (number: int) =
             x.Append(number) |> ignore
 
-        member x.AppendCharSpan (charSpan : CharSpan) =
+        member x.AppendCharSpan (charSpan: CharSpan) =
             let mutable i = 0
             while i < charSpan.Length do 
                 let c = charSpan.CharAt i
                 x.AppendChar c
                 i <- i + 1
 
-        member x.AppendSubstring (str : string) (start : int) (length : int) =
+        member x.AppendSubstring (str: string) (start: int) (length: int) =
             let charSpan = CharSpan(str, start, length, CharComparer.Exact)
             x.AppendCharSpan charSpan
 
 module internal CollectionExtensions = 
 
     type System.Collections.Generic.Stack<'T> with
-        member x.PushRange (col : 'T seq) = 
+        member x.PushRange (col: 'T seq) = 
             col |> Seq.iter (fun item -> x.Push(item))
 
     type System.Collections.Generic.Queue<'T> with
-        member x.EnqueueRange (col : 'T seq) = 
+        member x.EnqueueRange (col: 'T seq) = 
             col |> Seq.iter (fun item -> x.Enqueue(item))
 
     type System.Collections.Generic.Dictionary<'TKey, 'TValue> with
-        member x.TryGetValueEx (key : 'TKey) = 
+        member x.TryGetValueEx (key: 'TKey) = 
             let found, value = x.TryGetValue key
             if found then
                 Some value
@@ -728,7 +728,7 @@ module internal CollectionExtensions =
 module internal OptionUtil =
 
     /// Collapse an option of an option to just an option
-    let collapse<'a> (opt : 'a option option) =
+    let collapse<'a> (opt: 'a option option) =
         match opt with
         | None -> None
         | Some opt -> opt
@@ -779,7 +779,7 @@ module internal OptionUtil =
         | None -> defaultValue
 
     /// Convert the Nullable<T> to an Option<T>
-    let ofNullable (value : System.Nullable<'T>) =
+    let ofNullable (value: System.Nullable<'T>) =
         if value.HasValue then
             Some value.Value
         else
@@ -793,8 +793,8 @@ module internal OptionUtil =
 /// operations
 type NonEmptyCollection<'T> 
     (
-        _head : 'T,
-        _rest : 'T list
+        _head: 'T,
+        _rest: 'T list
     ) = 
 
     /// Number of items in the collection
@@ -823,7 +823,7 @@ type NonEmptyCollection<'T>
 module NonEmptyCollectionUtil =
 
     /// Appends a list to the NonEmptyCollection
-    let Append values (col : NonEmptyCollection<'T>) =
+    let Append values (col: NonEmptyCollection<'T>) =
         let rest = col.Rest @ values
         NonEmptyCollection(col.Head, rest)
 
@@ -834,25 +834,25 @@ module NonEmptyCollectionUtil =
         | Some (head, rest) -> NonEmptyCollection(head, rest |> List.ofSeq) |> Some
 
     /// Maps the elements in the NonEmptyCollection using the specified function
-    let Map mapFunc (col : NonEmptyCollection<'T>) = 
+    let Map mapFunc (col: NonEmptyCollection<'T>) = 
         let head = mapFunc col.Head
         let rest = List.map mapFunc col.Rest
         NonEmptyCollection<_>(head, rest)
 
 module internal ReadOnlyCollectionUtil = 
 
-    let Single (item : 'T) = 
+    let Single (item: 'T) = 
         let list = System.Collections.Generic.List<'T>()
         list.Add(item)
         ReadOnlyCollection<'T>(list)
 
-    let OfSeq (collection : 'T seq) = 
+    let OfSeq (collection: 'T seq) = 
         let list = System.Collections.Generic.List<'T>(collection)
         ReadOnlyCollection<'T>(list)
 
 module internal HashSetUtil = 
 
-    let OfSeq (collection : 'T seq) = System.Collections.Generic.HashSet<'T>(collection)
+    let OfSeq (collection: 'T seq) = System.Collections.Generic.HashSet<'T>(collection)
 
 module internal SystemUtil =
 
@@ -874,7 +874,7 @@ module internal SystemUtil =
     /// The IO.Path.Combine API has a lot of "features" which basically prevents it
     /// from being a reliable API.  The most notable is that if you pass it c:
     /// instead of c:\ it will silently fail.
-    let CombinePath (path1 : string) (path2 : string) = 
+    let CombinePath (path1: string) (path2: string) = 
 
         // Work around the c: problem by adding a trailing slash to a drive specification
         let path1 = 
@@ -912,7 +912,7 @@ module internal SystemUtil =
 
     /// Whether text starts with a leading tilde and is followed by either
     // nothing else or a directory separator
-    let StartsWithTilde (text : string) =
+    let StartsWithTilde (text: string) =
         if text.StartsWith("~") then
             if text.Length = 1 then
                 true
@@ -933,7 +933,7 @@ module internal SystemUtil =
     /// "$HOMEDRIVE$HOMEPATH" if those variables are defined
     let ResolvePath text =
 
-        let processMatch (regexMatch : Match) =
+        let processMatch (regexMatch: Match) =
             let token = regexMatch.Value
             if token.StartsWith("$") then
                 let variable = token.Substring(1)

--- a/Src/VimCore/FileSystem.fs
+++ b/Src/VimCore/FileSystem.fs
@@ -26,7 +26,7 @@ type internal FileSystem() =
     /// an exception occurred during processing and if not the lines that were read
     /// Read all of the lines from the file at the given path.  If this fails None
     /// will be returned
-    member x.ReadAllLinesCore (streamReader : StreamReader) =
+    member x.ReadAllLinesCore (streamReader: StreamReader) =
         let list = List<string>()
         let mutable line = streamReader.ReadLine()
         while line <> null do
@@ -38,19 +38,19 @@ type internal FileSystem() =
     /// This will attempt to read the path using first the encoding dictated by the BOM and 
     /// if there is no BOM it will try UTF8.  If either encoding encounters errors trying to
     /// process the file then this function will also fail
-    member x.ReadAllLinesBomAndUtf8 (path : string) = 
+    member x.ReadAllLinesBomAndUtf8 (path: string) = 
         let encoding = UTF8Encoding(false, true)
         use streamReader = new StreamReader(path, encoding, true)
         x.ReadAllLinesCore streamReader
 
     /// Read the lines with the Latin1 encoding.  
-    member x.ReadAllLinesLatin1 (path : string) = 
+    member x.ReadAllLinesLatin1 (path: string) = 
         let encoding = Encoding.GetEncoding("Latin1")
         use streamReader = new StreamReader(path, encoding, false)
         x.ReadAllLinesCore streamReader
 
     /// Forced utf8 encoding
-    member x.ReadAllLinesUtf8 (path : string) = 
+    member x.ReadAllLinesUtf8 (path: string) = 
         let encoding = Encoding.UTF8
         use streamReader = new StreamReader(path, encoding, false)
         x.ReadAllLinesCore streamReader
@@ -74,7 +74,7 @@ type internal FileSystem() =
                 x.ReadAllLinesUtf8;
             |]
 
-        let mutable lines : List<string> option = None
+        let mutable lines: List<string> option = None
         let mutable i = 0
         while i < all.Length && Option.isNone lines do
             try
@@ -172,7 +172,7 @@ type internal FileSystem() =
         with 
             _ -> None
 
-    member x.Write filePath (stream : Stream) = 
+    member x.Write filePath (stream: Stream) = 
         try
             use fileStream = File.Open(filePath, FileMode.Create, FileAccess.Write)
             stream.CopyTo(fileStream)

--- a/Src/VimCore/FoldManager.fs
+++ b/Src/VimCore/FoldManager.fs
@@ -21,11 +21,11 @@ open System.Linq;
 [<Sealed>]
 type internal FoldData
     (
-        _textBuffer : ITextBuffer
+        _textBuffer: ITextBuffer
     ) =
 
     let _foldsUpdated = StandardEvent()
-    let mutable _folds : ITrackingSpan list = List.empty
+    let mutable _folds: ITrackingSpan list = List.empty
 
     /// Get the SnapshotSpan values which represent folded regions in the ITextView which
     /// were created by vim
@@ -37,7 +37,7 @@ type internal FoldData
         |> Seq.sortBy (fun span -> span.Start.Position)
 
     /// Create a fold over the given line range
-    member x.CreateFold (range : SnapshotLineRange) = 
+    member x.CreateFold (range: SnapshotLineRange) = 
         if range.Count > 1 then
 
             // Note we only use the Extent of the range and do not include the line break.  If
@@ -50,7 +50,7 @@ type internal FoldData
             _foldsUpdated.Trigger x
 
     /// Delete the fold which corresponds to the given SnapshotPoint
-    member x.DeleteFold (point : SnapshotPoint) = 
+    member x.DeleteFold (point: SnapshotPoint) = 
         let snapshot = _textBuffer.CurrentSnapshot
         let data = 
             _folds
@@ -68,7 +68,7 @@ type internal FoldData
         ret
 
     /// Delete all folds which intersect the given SnapshotSpan
-    member x.DeleteAllFolds (span : SnapshotSpan) =
+    member x.DeleteAllFolds (span: SnapshotSpan) =
         _folds <-
             _folds
             |> Seq.map (TrackingSpanUtil.GetSpan _textBuffer.CurrentSnapshot)
@@ -89,10 +89,10 @@ type internal FoldData
 
 type internal FoldManager 
     (
-        _textView : ITextView,
-        _foldData : IFoldData,
-        _statusUtil : IStatusUtil,
-        _outliningManager : IOutliningManager option
+        _textView: ITextView,
+        _foldData: IFoldData,
+        _statusUtil: IStatusUtil,
+        _outliningManager: IOutliningManager option
     ) =
 
     member x.CaretPoint = TextViewUtil.GetCaretPoint _textView
@@ -123,7 +123,7 @@ type internal FoldManager
             |> Seq.iter (fun region -> outliningManager.TryCollapse(region) |> ignore))
 
     /// Close all folds which intersect with the given SnapshotSpan
-    member x.CloseAllFolds (span : SnapshotSpan) =
+    member x.CloseAllFolds (span: SnapshotSpan) =
         x.DoWithOutliningManager (fun outliningManager -> 
             // Get the collapsed regions and map them to SnapshotSpan values in this buffer.  Then
             // order them by most start and then length
@@ -132,7 +132,7 @@ type internal FoldManager
             |> Seq.iter (fun region -> outliningManager.TryCollapse(region) |> ignore))
 
     /// Create a fold over the given line range
-    member x.CreateFold (range : SnapshotLineRange) = 
+    member x.CreateFold (range: SnapshotLineRange) = 
         _foldData.CreateFold range
         if range.Count > 1 then
 
@@ -150,7 +150,7 @@ type internal FoldManager
     /// Do the given operation with the IOutliningManager.  If there is no IOutliningManager
     /// associated with this ITextView then no action will occur and an error message will
     /// be raised to the user
-    member x.DoWithOutliningManager (action : IOutliningManager -> unit) = 
+    member x.DoWithOutliningManager (action: IOutliningManager -> unit) = 
         match _outliningManager with
         | None -> _statusUtil.OnWarning Resources.Internal_FoldsNotSupported
         | Some outliningManager -> action outliningManager
@@ -180,7 +180,7 @@ type internal FoldManager
             |> Seq.iter (fun region -> outliningManager.Expand(region) |> ignore))
 
     /// Open all folds which intersect the given SnapshotSpan value
-    member x.OpenAllFolds (span : SnapshotSpan) =
+    member x.OpenAllFolds (span: SnapshotSpan) =
         x.DoWithOutliningManager (fun outliningManager -> 
 
             outliningManager.GetCollapsedRegions(span)
@@ -201,7 +201,7 @@ type internal FoldManager
              x.CloseFold point count)
 
     /// Toggle the fold which corresponds to the given SnapshotPoint
-    member x.ToggleAllFolds (span : SnapshotSpan) =
+    member x.ToggleAllFolds (span: SnapshotSpan) =
         x.DoWithOutliningManager (fun outliningManager -> 
            let currentRegions = outliningManager.GetAllRegions(span)
                                    |> List.ofSeq
@@ -228,8 +228,8 @@ type internal FoldManager
 type FoldManagerFactory
     [<ImportingConstructor>]
     (
-        _statusUtilFactory : IStatusUtilFactory,
-        _outliningManagerService : IOutliningManagerService
+        _statusUtilFactory: IStatusUtilFactory,
+        _outliningManagerService: IOutliningManagerService
     ) =
 
     /// Use an object instance as a key.  Makes it harder for components to ignore this
@@ -238,10 +238,10 @@ type FoldManagerFactory
 
     let _managerKey = new System.Object()
 
-    member x.GetFoldData (textBuffer : ITextBuffer) = 
+    member x.GetFoldData (textBuffer: ITextBuffer) = 
         textBuffer.Properties.GetOrCreateSingletonProperty(_dataKey, (fun unused -> FoldData(textBuffer)))
 
-    member x.GetFoldManager (textView : ITextView) = 
+    member x.GetFoldManager (textView: ITextView) = 
         textView.Properties.GetOrCreateSingletonProperty(_managerKey, (fun unused ->
             let outliningManager = 
                 let outliningManager = _outliningManagerService.GetOutliningManager textView

--- a/Src/VimCore/HistoryUtil.fs
+++ b/Src/VimCore/HistoryUtil.fs
@@ -24,10 +24,10 @@ type HistoryCommand =
 
 type internal HistorySession<'TData, 'TResult>
     (
-        _historyClient : IHistoryClient<'TData, 'TResult>,
-        _initialClientData : 'TData,
-        _command : string,
-        _buffer : IVimBuffer option
+        _historyClient: IHistoryClient<'TData, 'TResult>,
+        _initialClientData: 'TData,
+        _command: string,
+        _buffer: IVimBuffer option
     ) =
 
     let _registerMap = _historyClient.RegisterMap
@@ -120,7 +120,7 @@ type internal HistorySession<'TData, 'TResult>
             x.CreateBindResult()
 
     /// Run a history scroll at the specified index
-    member x.DoHistoryScroll (historyList : string list) index =
+    member x.DoHistoryScroll (historyList: string list) index =
         if index < 0 || index >= historyList.Length then
             // Make sure we are searching at a valid index
             _historyClient.Beep()

--- a/Src/VimCore/HistoryUtil.fsi
+++ b/Src/VimCore/HistoryUtil.fsi
@@ -9,4 +9,4 @@ type internal HistoryUtil =
     static member CreateHistorySession<'TData, 'TResult> : IHistoryClient<'TData, 'TResult> -> 'TData -> string -> IVimBuffer option -> IHistorySession<'TData, 'TResult>
 
     /// The set of KeyInput values which history considers to be a valid command
-    static member CommandNames : KeyInput list
+    static member CommandNames: KeyInput list

--- a/Src/VimCore/IncrementalSearch.fs
+++ b/Src/VimCore/IncrementalSearch.fs
@@ -9,10 +9,10 @@ open NullableUtil
 type IncrementalSearchData = { 
 
     /// Most recent result of the search
-    SearchResult : SearchResult
+    SearchResult: SearchResult
 
     /// Most recent search text being usde
-    SearchText : string
+    SearchText: string
 
 } with 
 
@@ -28,9 +28,9 @@ type IncrementalSearchData = {
 
 type internal IncrementalSearchSession
     (
-        _key : obj,
-        _historySession : IHistorySession<ITrackingPoint, SearchResult>,
-        _incrementalSearchData : IncrementalSearchData
+        _key: obj,
+        _historySession: IHistorySession<ITrackingPoint, SearchResult>,
+        _incrementalSearchData: IncrementalSearchData
     ) =
 
     let mutable _incrementalSearchData = _incrementalSearchData
@@ -45,8 +45,8 @@ type internal IncrementalSearchSession
 
 type internal IncrementalSearch
     (
-        _vimBufferData : IVimBufferData,
-        _operations : ICommonOperations
+        _vimBufferData: IVimBufferData,
+        _operations: ICommonOperations
     ) =
 
     let _vimData = _vimBufferData.Vim.VimData
@@ -57,7 +57,7 @@ type internal IncrementalSearch
     let _globalSettings = _localSettings.GlobalSettings
     let _textView = _operations.TextView
     let _searchService = _vimBufferData.Vim.SearchService
-    let mutable _incrementalSearchSession : IncrementalSearchSession option = None
+    let mutable _incrementalSearchSession: IncrementalSearchSession option = None
     let _currentSearchUpdated = StandardEvent<SearchResultEventArgs>()
     let _currentSearchCompleted = StandardEvent<SearchResultEventArgs>()
     let _currentSearchCancelled = StandardEvent<SearchDataEventArgs>()
@@ -129,8 +129,8 @@ type internal IncrementalSearch
                 member this.RemapMode = x.RemapMode
                 member this.Beep() = _operations.Beep()
                 member this.ProcessCommand data command = runActive (fun session -> x.RunSearch session data command) data
-                member this.Completed (data : ITrackingPoint) _ = runActive (fun session -> x.RunCompleted session data) IncrementalSearchData.Default.SearchResult
-                member this.Cancelled (data : ITrackingPoint) = runActive (fun session -> x.RunCancelled session) ()
+                member this.Completed (data: ITrackingPoint) _ = runActive (fun session -> x.RunCompleted session data) IncrementalSearchData.Default.SearchResult
+                member this.Cancelled (data: ITrackingPoint) = runActive (fun session -> x.RunCancelled session) ()
             }
 
         let historySession = HistoryUtil.CreateHistorySession historyClient startPoint StringUtil.Empty None
@@ -148,7 +148,7 @@ type internal IncrementalSearch
         if _globalSettings.IncrementalSearch then
              _operations.EnsureAtCaret ViewFlags.Standard
 
-    member x.RunSearch incrementalSearchSession (startPoint : ITrackingPoint) rawPattern =
+    member x.RunSearch incrementalSearchSession (startPoint: ITrackingPoint) rawPattern =
         let incrementalSearchData = x.RunSearchCore incrementalSearchSession startPoint rawPattern
         incrementalSearchSession.IncrementalSearchData <- incrementalSearchData
         let args = SearchResultEventArgs(incrementalSearchData.SearchResult)
@@ -157,7 +157,7 @@ type internal IncrementalSearch
 
     /// Run the search for the specified text.  This will do the search, update the caret 
     /// position and raise events
-    member x.RunSearchCore incrementalSearchSession (startPoint : ITrackingPoint) rawPattern =
+    member x.RunSearchCore incrementalSearchSession (startPoint: ITrackingPoint) rawPattern =
 
         // Get the SearchResult value for the new text
         let incrementalSearchData = incrementalSearchSession.IncrementalSearchData

--- a/Src/VimCore/IncrementalSearch.fsi
+++ b/Src/VimCore/IncrementalSearch.fsi
@@ -7,7 +7,7 @@ open Microsoft.VisualStudio.Text.Editor
 open Microsoft.VisualStudio.Text.Outlining
 
 type internal IncrementalSearch =
-    new : IVimBufferData * ICommonOperations -> IncrementalSearch
+    new: IVimBufferData * ICommonOperations -> IncrementalSearch
 
     interface IIncrementalSearch
 

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -25,9 +25,9 @@ type internal BackspaceCommand =
 /// This type houses the functionality for many of the insert mode commands
 type internal InsertUtil
     (
-        _vimBufferData : IVimBufferData,
-        _motionUtil : IMotionUtil,
-        _operations : ICommonOperations
+        _vimBufferData: IVimBufferData,
+        _motionUtil: IMotionUtil,
+        _operations: ICommonOperations
     ) =
 
     let _textView = _vimBufferData.TextView
@@ -40,7 +40,7 @@ type internal InsertUtil
     let _wordUtil = _vimBufferData.WordUtil
     let _vimHost = _vimBufferData.Vim.VimHost
     let _vimTextBuffer = _vimBufferData.VimTextBuffer
-    let mutable _combinedEditStartPoint : ITrackingPoint option = None
+    let mutable _combinedEditStartPoint: ITrackingPoint option = None
 
     /// The SnapshotPoint for the caret
     member x.CaretPoint = TextViewUtil.GetCaretPoint _textView
@@ -68,13 +68,13 @@ type internal InsertUtil
 
     /// Run the specified action with a wrapped undo transaction.  This is often necessary when
     /// an edit command manipulates the caret
-    member x.EditWithUndoTransaction<'T> (name : string) (action : unit -> 'T) : 'T = 
+    member x.EditWithUndoTransaction<'T> (name: string) (action: unit -> 'T): 'T = 
         _undoRedoOperations.EditWithUndoTransaction name _textView action
 
     /// Apply the TextChange to the given ITextEdit at the specified position.  This will
     /// return the position of the edit after the operation completes.  None is returned
     /// if the edit cannot be completed 
-    member x.ApplyTextChangeCore (textEdit : ITextEdit) (position : int) (bounds : Span) (textChange : TextChange) addNewLines =
+    member x.ApplyTextChangeCore (textEdit: ITextEdit) (position: int) (bounds: Span) (textChange: TextChange) addNewLines =
 
         let textChange = textChange.Reduce
 
@@ -158,7 +158,7 @@ type internal InsertUtil
         | None -> textEdit.Cancel()
 
     /// Apply the given TextChange to the specified BlockSpan 
-    member x.ApplyBlockInsert (text : string) startLineNumber spaces height = 
+    member x.ApplyBlockInsert (text: string) startLineNumber spaces height = 
 
         // Don't edit past the end of the ITextBuffer 
         let height = 
@@ -301,7 +301,7 @@ type internal InsertUtil
             CommandResult.Error
 
     /// Do a replacement under the caret of the specified char
-    member x.Replace (c : char) =
+    member x.Replace (c: char) =
         // Typically we have the overwrite option set for all of replace mode so this
         // is a redundant check.  But during repeat we only see the commands and not
         // the mode changes so we need to check here
@@ -316,7 +316,7 @@ type internal InsertUtil
             if not oldValue then
                 EditorOptionsUtil.SetOptionValue _editorOptions DefaultTextViewOptions.OverwriteModeId false
 
-    member x.Replace (s : string) =
+    member x.Replace (s: string) =
         // overwrite does not seem to be respected, just using delete instead
         x.DeleteRight(s.Length - 1) |> ignore
         x.Insert s
@@ -501,7 +501,7 @@ type internal InsertUtil
                 x.ApplyTextChange textChange addNewLines)
 
     /// Repeat the edits for the other lines in the block span.
-    member x.RepeatBlock (insertCommand : InsertCommand) (blockSpan : BlockSpan) =
+    member x.RepeatBlock (insertCommand: InsertCommand) (blockSpan: BlockSpan) =
 
         // Unfortunately the ITextEdit implementation doesn't properly reduce the changes that are
         // applied to it.  For example if you add 2 characters, delete them and then insert text
@@ -568,7 +568,7 @@ type internal InsertUtil
     /// Shift the caret line one 'shiftwidth' in a direction.  This is
     /// different than both normal and visual mode shifts because it will
     /// round the blanks to a 'shiftwidth' before indenting
-    member x.ShiftLine (direction : int) =
+    member x.ShiftLine (direction: int) =
 
         // Get the current indent and whether the line is blank
         let indentSpan = SnapshotLineUtil.GetIndentSpan x.CaretLine
@@ -715,7 +715,7 @@ type internal InsertUtil
 
     // A backspace over line (Ctrl-U)  and word (Ctrl-W) which begins to the right of the insert start
     // point has a max delete of the start point itself.  Do the minimization here
-    member x.AdjustBackspaceDeletePointForStartPoint (deletePoint : SnapshotPoint) =
+    member x.AdjustBackspaceDeletePointForStartPoint (deletePoint: SnapshotPoint) =
         match _vimBufferData.VimTextBuffer.InsertStartPoint with
         | None -> deletePoint
         | Some startPoint ->

--- a/Src/VimCore/InsertUtil.fsi
+++ b/Src/VimCore/InsertUtil.fsi
@@ -6,7 +6,7 @@ open Microsoft.VisualStudio.Text.Outlining
 
 type internal InsertUtil =
 
-    new : IVimBufferData * IMotionUtil * ICommonOperations -> InsertUtil
+    new: IVimBufferData * IMotionUtil * ICommonOperations -> InsertUtil
 
     interface IInsertUtil
 

--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -17,8 +17,8 @@ type NameScope =
     | Vim
 
 type VariableName = { 
-    NameScope : NameScope
-    Name : string 
+    NameScope: NameScope
+    Name: string 
 }
 
 [<RequireQualifiedAccess>]
@@ -160,23 +160,23 @@ type AutoCommandGroup =
     | Named of string 
 
 type AutoCommand = {
-    Group : AutoCommandGroup
+    Group: AutoCommandGroup
 
-    EventKind : EventKind
+    EventKind: EventKind
 
-    LineCommandText : string
+    LineCommandText: string
 
-    Pattern : string
+    Pattern: string
 }    
 
 type AutoCommandDefinition = { 
-    Group : AutoCommandGroup
+    Group: AutoCommandGroup
 
-    EventKinds : EventKind list
+    EventKinds: EventKind list
 
-    LineCommandText : string
+    LineCommandText: string
 
-    Patterns : string list
+    Patterns: string list
 }
 
 /// A single line specifier in a range 
@@ -325,34 +325,34 @@ type BinaryKind =
 
 /// Data for the :call command
 type CallInfo = {
-    Name : string
-    Arguments : string
-    LineRange : LineRangeSpecifier
-    IsScriptLocal : bool
+    Name: string
+    Arguments: string
+    LineRange: LineRangeSpecifier
+    IsScriptLocal: bool
 }
 
 type FunctionDefinition = {
 
     /// Name of the function
-    Name : string
+    Name: string
 
     /// Arguments to the function
-    Parameters : string list
+    Parameters: string list
 
     /// Is the function responsible for its ranges
-    IsRange : bool
+    IsRange: bool
 
     /// Is the function supposed to abort on the first error
-    IsAbort : bool
+    IsAbort: bool
 
     /// Is the function intended to be invoked from a dictionary
-    IsDictionary : bool
+    IsDictionary: bool
 
     /// Is this a forced definition of the function
-    IsForced : bool
+    IsForced: bool
 
     /// Is this a script local function (begins with s:)
-    IsScriptLocal : bool
+    IsScriptLocal: bool
 }
 
 /// Represents the values or the '+cmd' which can occur on commands like :edit
@@ -366,10 +366,10 @@ type CommandOption =
 and Function = {
 
     /// The definition of the function 
-    Definition : FunctionDefinition
+    Definition: FunctionDefinition
 
     // Line commands that compose the function
-    LineCommands : LineCommand list
+    LineCommands: LineCommand list
 }
 
 /// The ConditionalBlock type is used to represent if / else if / else blocks
@@ -379,10 +379,10 @@ and ConditionalBlock = {
     /// The conditional which must be true in order for the LineCommand list
     /// to be executed.  If there is no condition then the LineCommand list 
     /// is unconditionally executed
-    Conditional : Expression option
+    Conditional: Expression option
 
     /// The LineCommand values that make up this conditional block
-    LineCommands : LineCommand list
+    LineCommands: LineCommand list
 
 }
 
@@ -726,17 +726,17 @@ type IVimInterpreter =
 
     /// Get the ITextSnapshotLine for the provided LineSpecifier if it's 
     /// applicable
-    abstract GetLine : lineSpecifier : LineSpecifier -> ITextSnapshotLine option
+    abstract GetLine: lineSpecifier: LineSpecifier -> ITextSnapshotLine option
 
     /// Get the specified LineRange in the IVimBuffer
-    abstract GetLineRange : lineRange : LineRangeSpecifier -> SnapshotLineRange option
+    abstract GetLineRange: lineRange: LineRangeSpecifier -> SnapshotLineRange option
 
     /// Run the LineCommand
-    abstract RunLineCommand : lineCommand : LineCommand -> unit
+    abstract RunLineCommand: lineCommand: LineCommand -> unit
 
     /// Run the Expression
-    abstract RunExpression : expression : Expression -> VariableValue
+    abstract RunExpression: expression: Expression -> VariableValue
 
     /// Run the given script 
-    abstract RunScript : lines : string[] -> unit
+    abstract RunScript: lines: string[] -> unit
 

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -18,7 +18,7 @@ type DefaultLineRange =
 [<Class>]
 type VariableValueUtil
     (
-        _statusUtil : IStatusUtil
+        _statusUtil: IStatusUtil
     ) =
 
     member x.ConvertToNumber value = 
@@ -55,12 +55,12 @@ type VariableValueUtil
 [<Class>]
 type BuiltinFunctionCaller
     (
-        _variableMap : Dictionary<string, VariableValue>
+        _variableMap: Dictionary<string, VariableValue>
     ) =
-    member x.Call (func : BuiltinFunctionCall) =
+    member x.Call (func: BuiltinFunctionCall) =
         match func with
         | BuiltinFunctionCall.Escape(escapeIn, escapeWhat) ->
-            let escapeChar (c : char) =
+            let escapeChar (c: char) =
                 let character = c.ToString()
                 if escapeWhat.Contains character then sprintf @"\%s" character else character
             Seq.map escapeChar escapeIn
@@ -86,11 +86,11 @@ type BuiltinFunctionCaller
 [<Class>]
 type VimScriptFunctionCaller
     (
-        _builtinCaller : BuiltinFunctionCaller,
-        _statusUtil : IStatusUtil
+        _builtinCaller: BuiltinFunctionCaller,
+        _statusUtil: IStatusUtil
     ) =
     let _getValue = VariableValueUtil(_statusUtil)
-    member x.Call (name : VariableName) (args : VariableValue list) =
+    member x.Call (name: VariableName) (args: VariableValue list) =
         let tooManyArgs() =
             sprintf "Too many arguments for function: %s" name.Name |> _statusUtil.OnError
             VariableValue.Error
@@ -134,11 +134,11 @@ type VimScriptFunctionCaller
 [<Class>]
 type ExpressionInterpreter
     (
-        _statusUtil : IStatusUtil,
-        _localSettings : IVimSettings,
-        _windowSettings : IVimSettings,
-        _variableMap : Dictionary<string, VariableValue>,
-        _registerMap : IRegisterMap
+        _statusUtil: IStatusUtil,
+        _localSettings: IVimSettings,
+        _windowSettings: IVimSettings,
+        _variableMap: Dictionary<string, VariableValue>,
+        _registerMap: IRegisterMap
     ) =
     let _builtinCaller = BuiltinFunctionCaller(_variableMap)
     let _functionCaller = VimScriptFunctionCaller(_builtinCaller, _statusUtil)
@@ -174,7 +174,7 @@ type ExpressionInterpreter
         (_registerMap.GetRegister name).StringValue |> VariableValue.String
 
     /// Get the value of the specified expression 
-    member x.RunExpression (expr : Expression) : VariableValue =
+    member x.RunExpression (expr: Expression): VariableValue =
         let runExpression expressions = [for expr in expressions -> x.RunExpression expr]
         match expr with
         | Expression.ConstantValue value -> value
@@ -189,13 +189,13 @@ type ExpressionInterpreter
         | Expression.List expressions -> runExpression expressions |> VariableValue.List 
 
     /// Run the binary expression
-    member x.RunBinaryExpression binaryKind (leftExpr : Expression) (rightExpr : Expression) = 
+    member x.RunBinaryExpression binaryKind (leftExpr: Expression) (rightExpr: Expression) = 
 
         let notSupported() =
             _statusUtil.OnError "Binary operation not supported at this time"
             VariableValue.Error
 
-        let runAdd (leftValue : VariableValue) (rightValue : VariableValue) = 
+        let runAdd (leftValue: VariableValue) (rightValue: VariableValue) = 
             if leftValue.VariableType = VariableType.List && rightValue.VariableType = VariableType.List then
                 // it's a list concatenation
                 notSupported()
@@ -206,7 +206,7 @@ type ExpressionInterpreter
                 | Some left, Some right -> left + right |> VariableValue.Number
                 | _ -> VariableValue.Error
 
-        let runConcat (leftValue : VariableValue) (rightValue : VariableValue) =
+        let runConcat (leftValue: VariableValue) (rightValue: VariableValue) =
             let leftString = _getValue.ConvertToString leftValue
             let rightString = _getValue.ConvertToString rightValue
             match leftString, rightString with
@@ -228,11 +228,11 @@ type ExpressionInterpreter
 [<Class>]
 type VimInterpreter
     (
-        _vimBuffer : IVimBuffer,
-        _commonOperations : ICommonOperations,
-        _foldManager : IFoldManager,
-        _fileSystem : IFileSystem,
-        _bufferTrackingService : IBufferTrackingService
+        _vimBuffer: IVimBuffer,
+        _commonOperations: ICommonOperations,
+        _foldManager: IFoldManager,
+        _fileSystem: IFileSystem,
+        _bufferTrackingService: IBufferTrackingService
     ) =
 
     let _vimBufferData = _vimBuffer.VimBufferData
@@ -282,13 +282,13 @@ type VimInterpreter
     member x.CurrentSnapshot = _textBuffer.CurrentSnapshot
 
     /// Execute the external command and return the lines of output
-    member x.ExecuteCommand (command : string) : string[] option = 
+    member x.ExecuteCommand (command: string): string[] option = 
         // TODO: Implement
         None
 
     /// Resolve the given path.  In the case the path contains illegal characters it 
     /// will be returned unaltered. 
-    member x.ResolveVimPath (path : string) =
+    member x.ResolveVimPath (path: string) =
         try
             SystemUtil.ResolveVimPath _vimData.CurrentDirectory path
         with
@@ -296,15 +296,15 @@ type VimInterpreter
 
     /// Get a tuple of the ITextSnapshotLine specified by the given LineSpecifier and the 
     /// corresponding vim line number
-    member x.GetLineAndVimLineNumberCore lineSpecifier (currentLine : ITextSnapshotLine) = 
+    member x.GetLineAndVimLineNumberCore lineSpecifier (currentLine: ITextSnapshotLine) = 
 
         // To convert from a VS line number to a vim line number, simply add 1
-        let getLineAndNumber (line : ITextSnapshotLine) = (line, line.LineNumber + 1)
+        let getLineAndNumber (line: ITextSnapshotLine) = (line, line.LineNumber + 1)
 
         // Get the ITextSnapshotLine specified by lineSpecifier and then apply the
         // given adjustment to the number.  Can fail if the line number adjustment
         // is invalid
-        let getAdjustment adjustment (line : ITextSnapshotLine) = 
+        let getAdjustment adjustment (line: ITextSnapshotLine) = 
             let vimLine = line.LineNumber + 1 + adjustment
             let number = Util.VimLineToTssLine vimLine
 
@@ -434,7 +434,7 @@ type VimInterpreter
     member x.GetCountOrDefault count = Util.CountOrDefault count
 
     /// Add the specified auto command to the list 
-    member x.RunAddAutoCommand (autoCommandDefinition : AutoCommandDefinition) = 
+    member x.RunAddAutoCommand (autoCommandDefinition: AutoCommandDefinition) = 
         let builder = System.Collections.Generic.List<AutoCommand>()
         for eventKind in autoCommandDefinition.EventKinds do
             for pattern in autoCommandDefinition.Patterns do
@@ -465,7 +465,7 @@ type VimInterpreter
             _globalSettings.Selection <- "inclusive"
         | _ -> _statusUtil.OnError (Resources.Interpreter_InvalidArgument model)
 
-    member x.RunCall (callInfo : CallInfo) = 
+    member x.RunCall (callInfo: CallInfo) = 
         _statusUtil.OnError (Resources.Interpreter_CallNotSupported callInfo.Name)
 
     /// Change the directory to the given value
@@ -621,7 +621,7 @@ type VimInterpreter
         |> Seq.map (fun localMark -> Mark.LocalMark localMark)
         |> Seq.iter x.RunDeleteMarkCore
 
-    member x.RunFunction (func : Function) = 
+    member x.RunFunction (func: Function) = 
         _statusUtil.OnError Resources.Interpreter_FunctionNotSupported
 
     /// Display the given map modes
@@ -652,7 +652,7 @@ type VimInterpreter
                 | KeyRemapMode.Insert -> "i"
 
         // Get the printable format for the KeyInputSet 
-        let getKeyInputSetLine (keyInputSet : KeyInputSet) = 
+        let getKeyInputSetLine (keyInputSet: KeyInputSet) = 
 
             keyInputSet.KeyInputs |> Seq.map KeyNotationUtil.GetDisplayName |> String.concat ""
 
@@ -680,7 +680,7 @@ type VimInterpreter
 
         // The value when display shouldn't contain any new lines.  They are expressed as instead
         // ^J which is the key-notation for <NL>
-        let normalizeDisplayString (data : string) = data.Replace(System.Environment.NewLine, "^J")
+        let normalizeDisplayString (data: string) = data.Replace(System.Environment.NewLine, "^J")
 
         let displayNames = 
             match nameList with
@@ -713,7 +713,7 @@ type VimInterpreter
         let lines = Seq.append (Seq.singleton Resources.CommandMode_RegisterBanner) lines
         _statusUtil.OnStatusLong lines
 
-    member x.RunDisplayLets (names : VariableName list) = 
+    member x.RunDisplayLets (names: VariableName list) = 
         let list = List<string>()
         for name in names do
             let found, value = _variableMap.TryGetValue name.Name
@@ -727,11 +727,11 @@ type VimInterpreter
         _statusUtil.OnStatusLong list
 
     /// Display the specified marks
-    member x.RunDisplayMarks (marks : Mark list) = 
+    member x.RunDisplayMarks (marks: Mark list) = 
         if not (List.isEmpty marks) then
             _statusUtil.OnError (Resources.Interpreter_OptionNotSupported "Specific marks")
         else
-            let printMark (ident : char) (point : VirtualSnapshotPoint) =
+            let printMark (ident: char) (point: VirtualSnapshotPoint) =
                 let textLine = point.Position.GetContainingLine()
                 let lineNum = textLine.LineNumber + 1
                 let column = point.Position.Position - textLine.Start.Position
@@ -1014,8 +1014,8 @@ type VimInterpreter
         _statusUtil.OnStatusLong(output)
 
     /// Run the if command
-    member x.RunIf (conditionalBlockList : ConditionalBlock list)  =
-        let shouldRun (conditionalBlock : ConditionalBlock) =
+    member x.RunIf (conditionalBlockList: ConditionalBlock list)  =
+        let shouldRun (conditionalBlock: ConditionalBlock) =
             match conditionalBlock.Conditional with
             | None -> true
             | Some expr -> 
@@ -1049,7 +1049,7 @@ type VimInterpreter
         _commonOperations.MoveCaretToPoint point (ViewFlags.Standard &&& (~~~ViewFlags.TextExpanded))
 
     /// Run the let command
-    member x.RunLet (name : VariableName) expr =
+    member x.RunLet (name: VariableName) expr =
         // TODO: At this point we are treating all variables as if they were global.  Need to 
         // take into account the NameScope at this level too
         match x.RunExpression expr with
@@ -1057,8 +1057,8 @@ type VimInterpreter
         | value -> _variableMap.[name.Name] <- value
 
     /// Run the let command for registers
-    member x.RunLetRegister (name : RegisterName) expr =
-        let setRegister (value : string) =
+    member x.RunLetRegister (name: RegisterName) expr =
+        let setRegister (value: string) =
             let registerValue = RegisterValue(value, OperationKind.CharacterWise)
             _commonOperations.SetRegisterValue (Some name) RegisterOperation.Yank registerValue
         match _exprInterpreter.GetExpressionAsString expr with
@@ -1188,7 +1188,7 @@ type VimInterpreter
                 _commonOperations.CloseWindowUnlessDirty())
 
     /// Run the core parts of the read command
-    member x.RunReadCore (lineRange : SnapshotLineRange) (lines : string[]) = 
+    member x.RunReadCore (lineRange: SnapshotLineRange) (lines: string[]) = 
         let point = lineRange.EndIncludingLineBreak
         let lineBreak = _commonOperations.GetNewLineText point
         let text = 
@@ -1226,8 +1226,8 @@ type VimInterpreter
         _commonOperations.Redo 1
 
     /// Remove the auto commands which match the specified definition
-    member x.RemoveAutoCommands (autoCommandDefinition : AutoCommandDefinition) = 
-        let isMatch (autoCommand : AutoCommand) = 
+    member x.RemoveAutoCommands (autoCommandDefinition: AutoCommandDefinition) = 
+        let isMatch (autoCommand: AutoCommand) = 
             
             if autoCommand.Group = autoCommandDefinition.Group then
                 let isPatternMatch = Seq.exists (fun p -> autoCommand.Pattern = p) autoCommandDefinition.Patterns
@@ -1266,7 +1266,7 @@ type VimInterpreter
             let spans = 
     
                 // Find the next position which has a space or tab value 
-                let rec nextPoint (point : SnapshotPoint) = 
+                let rec nextPoint (point: SnapshotPoint) = 
                     if point.Position >= lineRange.End.Position then
                         None
                     elif SnapshotPointUtil.IsBlank point then
@@ -1338,7 +1338,7 @@ type VimInterpreter
     member x.RunSet setArguments =
 
         // Get the setting for the specified name
-        let withSetting name msg (func : Setting -> IVimSettings -> unit) =
+        let withSetting name msg (func: Setting -> IVimSettings -> unit) =
             match _localSettings.GetSetting name with
             | None -> 
                 match _windowSettings.GetSetting name with
@@ -1463,7 +1463,7 @@ type VimInterpreter
                 | SetArgument.UseSetting name -> useSetting name)
 
     /// Run the specified shell command
-    member x.RunShellCommand (command : string) =
+    member x.RunShellCommand (command: string) =
 
         // Actuall run the command
         let doRun command = 
@@ -1549,7 +1549,7 @@ type VimInterpreter
 
         // Called to initialize the data and move to a confirm style substitution.  Have to find the first match
         // before passing off to confirm
-        let setupConfirmSubstitute (range : SnapshotLineRange) (data : SubstituteData) =
+        let setupConfirmSubstitute (range: SnapshotLineRange) (data: SubstituteData) =
             let regex = VimRegexFactory.CreateForSubstituteFlags data.SearchPattern _globalSettings data.Flags
             match regex with
             | None -> 
@@ -1779,10 +1779,10 @@ type VimInterpreter
         | LineCommand.WriteAll hasBang -> x.RunWriteAll hasBang
         | LineCommand.Yank (lineRange, registerName, count) -> x.RunYank registerName lineRange count
 
-    member x.RunWithLineRange lineRangeSpecifier (func : SnapshotLineRange -> unit) = 
+    member x.RunWithLineRange lineRangeSpecifier (func: SnapshotLineRange -> unit) = 
         x.RunWithLineRangeOrDefault lineRangeSpecifier DefaultLineRange.None func
 
-    member x.RunWithLineRangeOrDefault (lineRangeSpecifier : LineRangeSpecifier) defaultLineRange (func : SnapshotLineRange -> unit) = 
+    member x.RunWithLineRangeOrDefault (lineRangeSpecifier: LineRangeSpecifier) defaultLineRange (func: SnapshotLineRange -> unit) = 
         match x.GetLineRangeOrDefault lineRangeSpecifier defaultLineRange with
         | None -> _statusUtil.OnError Resources.Range_Invalid
         | Some lineRange -> func lineRange
@@ -1805,12 +1805,12 @@ type VimInterpreter
 type VimInterpreterFactory
     [<ImportingConstructor>]
     (
-        _commonOperationsFactory : ICommonOperationsFactory,
-        _foldManagerFactory : IFoldManagerFactory,
-        _bufferTrackingService : IBufferTrackingService
+        _commonOperationsFactory: ICommonOperationsFactory,
+        _foldManagerFactory: IFoldManagerFactory,
+        _bufferTrackingService: IBufferTrackingService
     ) = 
 
-    member x.CreateVimInterpreter (vimBuffer : IVimBuffer) fileSystem =
+    member x.CreateVimInterpreter (vimBuffer: IVimBuffer) fileSystem =
         let commonOperations = _commonOperationsFactory.GetCommonOperations vimBuffer.VimBufferData
         let foldManager = _foldManagerFactory.GetFoldManager vimBuffer.TextView
         let interpreter = VimInterpreter(vimBuffer, commonOperations, foldManager, fileSystem, _bufferTrackingService)

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -17,49 +17,49 @@ type ParseResult<'T> =
 
     with 
 
-    member x.Map (mapFunc : 'T -> ParseResult<'U>) =
+    member x.Map (mapFunc: 'T -> ParseResult<'U>) =
         match x with
         | ParseResult.Failed msg -> ParseResult.Failed msg
         | ParseResult.Succeeded value -> mapFunc value
 
 module ParseResultUtil =
 
-    let Map (parseResult : ParseResult<'T>) mapFunc = 
+    let Map (parseResult: ParseResult<'T>) mapFunc = 
         parseResult.Map mapFunc
 
-    let ConvertToLineCommand (parseResult : ParseResult<LineCommand>) =
+    let ConvertToLineCommand (parseResult: ParseResult<LineCommand>) =
         match parseResult with
         | ParseResult.Failed msg -> LineCommand.ParseError msg
         | ParseResult.Succeeded lineCommand -> lineCommand
 
 type ParseResultBuilder
     (
-        _errorMessage : string
+        _errorMessage: string
     ) = 
 
     new () = ParseResultBuilder(Resources.Parser_Error)
 
     /// Bind a ParseResult value
-    member x.Bind (parseResult : ParseResult<'T>, (rest : 'T -> ParseResult<'U>)) = 
+    member x.Bind (parseResult: ParseResult<'T>, (rest: 'T -> ParseResult<'U>)) = 
         match parseResult with
         | ParseResult.Failed msg -> ParseResult.Failed msg
         | ParseResult.Succeeded value -> rest value
 
     /// Bind an option value
-    member x.Bind (parseValue : 'T option, (rest : 'T -> ParseResult<'U>)) = 
+    member x.Bind (parseValue: 'T option, (rest: 'T -> ParseResult<'U>)) = 
         match parseValue with
         | None -> ParseResult.Failed _errorMessage
         | Some value -> rest value
 
-    member x.Return (value : 'T) =
+    member x.Return (value: 'T) =
         ParseResult.Succeeded value
 
-    member x.Return (parseResult : ParseResult<'T>) =
+    member x.Return (parseResult: ParseResult<'T>) =
         match parseResult with
         | ParseResult.Failed msg -> ParseResult.Failed msg
         | ParseResult.Succeeded value -> ParseResult.Succeeded value
 
-    member x.Return (msg : string) = 
+    member x.Return (msg: string) = 
         ParseResult.Failed msg
 
     member x.ReturnFrom value = 
@@ -70,32 +70,32 @@ type ParseResultBuilder
 
 type LineCommandBuilder
     (
-        _errorMessage : string
+        _errorMessage: string
     ) = 
 
     new () = LineCommandBuilder(Resources.Parser_Error)
 
     /// Bind a ParseResult value
-    member x.Bind (parseResult : ParseResult<'T>, rest) = 
+    member x.Bind (parseResult: ParseResult<'T>, rest) = 
         match parseResult with
         | ParseResult.Failed msg -> LineCommand.ParseError msg
         | ParseResult.Succeeded value -> rest value
 
     /// Bind an option value
-    member x.Bind (parseValue : 'T option, rest) = 
+    member x.Bind (parseValue: 'T option, rest) = 
         match parseValue with
         | None -> LineCommand.ParseError _errorMessage
         | Some value -> rest value
 
-    member x.Return (value : LineCommand) =
+    member x.Return (value: LineCommand) =
         value
 
-    member x.Return (parseResult : ParseResult<LineCommand>) =
+    member x.Return (parseResult: ParseResult<LineCommand>) =
         match parseResult with
         | ParseResult.Failed msg -> LineCommand.ParseError msg
         | ParseResult.Succeeded lineCommand -> lineCommand
 
-    member x.Return (msg : string) = 
+    member x.Return (msg: string) = 
         LineCommand.ParseError msg
 
     member x.ReturnFrom value = 
@@ -107,8 +107,8 @@ type LineCommandBuilder
 [<Sealed>]
 type Parser
     (
-        _globalSettings : IVimGlobalSettings,
-        _vimData : IVimData
+        _globalSettings: IVimGlobalSettings,
+        _vimData: IVimData
     ) = 
 
     let _parseResultBuilder = ParseResultBuilder()
@@ -351,7 +351,7 @@ type Parser
         x.ParseTokenSequence [| "s"; ":" |]
 
     /// Reset the parser to the given set of input lines.  
-    member x.Reset (lines : string[]) = 
+    member x.Reset (lines: string[]) = 
         _lines <- 
             if lines.Length = 0 then
                 [|""|]
@@ -422,7 +422,7 @@ type Parser
     member x.TryExpand name =
 
         // Is 'name' an abbreviation of the given command name and abbreviation
-        let isAbbreviation (fullName : string) (abbreviation : string) = 
+        let isAbbreviation (fullName: string) (abbreviation: string) = 
             if name = fullName then
                 true
             else 
@@ -604,7 +604,7 @@ type Parser
             None
 
     /// Parse out the '++opt' parameter to some commands.
-    member x.ParseFileOptions () : FileOption list =
+    member x.ParseFileOptions (): FileOption list =
 
         // TODO: Need to implement parsing out FileOption list
         List.empty
@@ -678,7 +678,7 @@ type Parser
             | _ -> false)
         let flagString = OptionUtil.getOrDefault "" flagString
 
-        let mutable parseResult : ParseResult<SubstituteFlags> option = None
+        let mutable parseResult: ParseResult<SubstituteFlags> option = None
         let mutable flags = 
             if _globalSettings.GlobalDefault then SubstituteFlags.ReplaceAll
             else SubstituteFlags.None
@@ -757,7 +757,7 @@ type Parser
             x.SkipBlanks()
 
             let rec inner rest = 
-                let isNotBlankOrComma (token : Token) =
+                let isNotBlankOrComma (token: Token) =
                     match token.TokenKind with
                     | TokenKind.Blank -> false
                     | TokenKind.Character ',' -> false
@@ -779,7 +779,7 @@ type Parser
         let parseEventKindList () = 
 
             // Parse out an EventKind value from the specified event name 
-            let parseEventKind (word : string) = 
+            let parseEventKind (word: string) = 
                 let word = word.ToLower()
                 Map.tryFind word s_NameToEventKindMap
             
@@ -959,7 +959,7 @@ type Parser
 
             // Parse out the range of marks.  Anything from the start to end character
             // inclusive 
-            let parseRange (startChar : char) (endChar : char) =
+            let parseRange (startChar: char) (endChar: char) =
                 for i = int startChar to int endChar do
                     let c = char i 
                     match Mark.OfChar c with
@@ -1114,7 +1114,7 @@ type Parser
     /// when there was an error parsing out the function header.  Even when there is an error we 
     /// still must parse out the statements inside of it.  If we don't then a simple parsing error
     /// on a function header can lead to all of the statements inside it being executed promptly
-    member x.ParseFunction (functionDefinition : FunctionDefinition option) = 
+    member x.ParseFunction (functionDefinition: FunctionDefinition option) = 
 
         // Parse out the lines in the function.  If any of the lines inside the function register as a 
         // parse error we still need to continue parsing the function (even though it should ultimately
@@ -1303,7 +1303,7 @@ type Parser
 
     /// Parse out any valid range node.  This will consider % and any other 
     /// range expression
-    member x.ParseLineRange () : LineRangeSpecifier =
+    member x.ParseLineRange (): LineRangeSpecifier =
         if _tokenizer.CurrentChar = '%' then
             _tokenizer.MoveNextToken()
             LineRangeSpecifier.EntireBuffer
@@ -1990,7 +1990,7 @@ type Parser
     /// Parse out the :display and :registers command.  Just takes a single argument 
     /// which is the register name
     member x.ParseDisplayRegisters () = 
-        let mutable nameList : RegisterName list = List.Empty
+        let mutable nameList: RegisterName list = List.Empty
         let mutable more = true
         while more do
             x.SkipBlanks()
@@ -2012,7 +2012,7 @@ type Parser
         | TokenKind.Word word ->
 
             _tokenizer.MoveNextToken()
-            let mutable message : string option = None
+            let mutable message: string option = None
             let list = System.Collections.Generic.List<Mark>()
             for c in word do
                 match Mark.OfChar c with
@@ -2030,7 +2030,7 @@ type Parser
     /// and :endfunc.  Instead it will return the result of the current LineCommand
     member x.ParseSingleLine() =
 
-        // Skip the white space and : at the beginning of the line
+        // Skip the white space and: at the beginning of the line
         while _tokenizer.CurrentChar = ':' || _tokenizer.CurrentTokenKind = TokenKind.Blank do
             _tokenizer.MoveNextChar()
 
@@ -2046,7 +2046,7 @@ type Parser
             | LineRangeSpecifier.None -> parseFunc()
             | _ -> LineCommand.ParseError Resources.Parser_NoRangeAllowed
 
-        let handleParseResult (lineCommand : LineCommand) =
+        let handleParseResult (lineCommand: LineCommand) =
             let lineCommand = 
                 if lineCommand.Failed then
                     // If there is already a failure don't look any deeper.
@@ -2360,7 +2360,7 @@ type Parser
         x.Reset [|rangeText|]
         x.ParseLineRange(), x.ParseRestOfLine()
 
-    member x.ParseExpression (expressionText : string) =
+    member x.ParseExpression (expressionText: string) =
         x.Reset [|expressionText|]
         x.ParseExpressionCore()
 
@@ -2380,8 +2380,8 @@ type Parser
                 
 and ConditionalParser
     (
-        _parser : Parser,
-        _initialExpr : Expression
+        _parser: Parser,
+        _initialExpr: Expression
     ) = 
 
     static let StateBeforeElse = 1
@@ -2397,7 +2397,7 @@ and ConditionalParser
 
     member x.Parse() =
 
-        let mutable error : string option = None
+        let mutable error: string option = None
         let mutable isDone = false
         while not _parser.IsDone && not isDone && Option.isNone error do
             match _parser.ParseSingleCommand() with

--- a/Src/VimCore/Interpreter_Parser.fsi
+++ b/Src/VimCore/Interpreter_Parser.fsi
@@ -12,27 +12,27 @@ type ParseResult<'T> =
 [<Class>]
 type Parser = 
 
-    new: vimData : IVimGlobalSettings * IVimData -> Parser
+    new: vimData: IVimGlobalSettings * IVimData -> Parser
 
-    new: vimData : IVimGlobalSettings * IVimData * lines : string[] -> Parser
+    new: vimData: IVimGlobalSettings * IVimData * lines: string[] -> Parser
 
-    member IsDone : bool
+    member IsDone: bool
 
     /// Parse the next complete command from the source.  Command pairs like :func and :endfunc
     /// will be returned as a single Function command.  
-    member ParseNextCommand : unit -> LineCommand
+    member ParseNextCommand: unit -> LineCommand
 
     /// Parse the next line from the source.  Command pairs like :func and :endfunc will
     /// not be returned as a single command.  Instead they will be returned as the individual
     /// items
-    member ParseNextLine : unit -> LineCommand
+    member ParseNextLine: unit -> LineCommand
 
-    member ParseRange : rangeText : string -> LineRangeSpecifier * string
+    member ParseRange: rangeText: string -> LineRangeSpecifier * string
 
-    member ParseExpression : expressionText : string -> ParseResult<Expression>
+    member ParseExpression: expressionText: string -> ParseResult<Expression>
 
-    member ParseLineCommand : commandText : string -> LineCommand
+    member ParseLineCommand: commandText: string -> LineCommand
 
-    member ParseLineCommands : lines : string[] -> LineCommand list
+    member ParseLineCommands: lines: string[] -> LineCommand list
 
 

--- a/Src/VimCore/Interpreter_Tokenizer.fs
+++ b/Src/VimCore/Interpreter_Tokenizer.fs
@@ -173,8 +173,8 @@ type internal TokenStream() =
 [<DebuggerDisplay("{ToString(),nq}")>]
 type internal Tokenizer
     (
-        _text : string,
-        _tokenizerFlags : TokenizerFlags
+        _text: string,
+        _tokenizerFlags: TokenizerFlags
     ) as this =
 
     let _tokenStream = TokenStream()
@@ -265,8 +265,8 @@ type internal Tokenizer
 
 and [<Sealed>] ResetTokenizerFlags
     (
-        _tokenizer : Tokenizer,
-        _tokenizerFlags : TokenizerFlags
+        _tokenizer: Tokenizer,
+        _tokenizerFlags: TokenizerFlags
     ) = 
 
     member x.TokenizerFlags = _tokenizerFlags

--- a/Src/VimCore/Interpreter_Tokenizer.fsi
+++ b/Src/VimCore/Interpreter_Tokenizer.fsi
@@ -23,10 +23,10 @@ type internal TokenizerFlags =
 type internal ResetTokenizerFlags = 
 
     /// The flags that will be set on reset
-    member TokenizerFlags : TokenizerFlags
+    member TokenizerFlags: TokenizerFlags
 
     /// Reset now 
-    member Reset : unit -> unit
+    member Reset: unit -> unit
 
     interface IDisposable
 
@@ -34,46 +34,46 @@ type internal ResetTokenizerFlags =
 [<Class>]
 type internal Tokenizer = 
 
-    new: text : string * tokenizerFlags : TokenizerFlags -> Tokenizer
+    new: text: string * tokenizerFlags: TokenizerFlags -> Tokenizer
 
     /// Current mark into the token stream
-    member Mark : int
+    member Mark: int
 
     /// The flags the tokenizer is parsing under
-    member TokenizerFlags : TokenizerFlags with get, set 
+    member TokenizerFlags: TokenizerFlags with get, set 
 
     /// Is it at the end of the stream
-    member IsAtEndOfLine : bool
+    member IsAtEndOfLine: bool
 
     /// Current Token 
-    member CurrentToken : Token
+    member CurrentToken: Token
 
     /// Current TokenKind
-    member CurrentTokenKind : TokenKind
+    member CurrentTokenKind: TokenKind
 
     /// Current character that the tokenizer is pointing at
-    member CurrentChar : char
+    member CurrentChar: char
 
     /// Move to the next token in the stream.  Double quotes will be treated as a 
     /// comment
-    member MoveNextToken : unit -> unit
+    member MoveNextToken: unit -> unit
 
     /// Move to the next character in the stream and reset the current token.  If the 
     /// current token is a word then this would move past the first character in the
     /// word
-    member MoveNextChar : unit -> unit
+    member MoveNextChar: unit -> unit
 
     /// Rewind the token stream to the specified mark
-    member MoveToMark : mark : int -> unit
+    member MoveToMark: mark: int -> unit
 
     /// Move to the end of the current line
-    member MoveToEndOfLine : unit -> unit
+    member MoveToEndOfLine: unit -> unit
 
     /// Change the flags on the tokenizer and return a ResetTokenizerFlags instance
     /// that will reset the flags when done 
-    member SetTokenizerFlagsScoped : tokenizerFlags : TokenizerFlags -> ResetTokenizerFlags
+    member SetTokenizerFlagsScoped: tokenizerFlags: TokenizerFlags -> ResetTokenizerFlags
 
     /// Reset the tokenizer with the specified string and flags.  It will begin parsing
     /// this text from the beginning
-    member Reset : text : string -> tokenizerFlags : TokenizerFlags -> unit
+    member Reset: text: string -> tokenizerFlags: TokenizerFlags -> unit
 

--- a/Src/VimCore/Interpreter_Tokens.fs
+++ b/Src/VimCore/Interpreter_Tokens.fs
@@ -38,10 +38,10 @@ type TokenKind =
 [<DebuggerDisplay("{ToString(),nq}")>]
 type Token
     (
-        _lineText : string,
-        _startIndex : int,
-        _length : int,
-        _tokenKind : TokenKind
+        _lineText: string,
+        _startIndex: int,
+        _length: int,
+        _tokenKind: TokenKind
     ) = 
 
     member x.TokenKind = _tokenKind

--- a/Src/VimCore/JumpList.fs
+++ b/Src/VimCore/JumpList.fs
@@ -9,8 +9,8 @@ open System.Collections.Generic
 /// window
 type internal JumpList 
     ( 
-        _textView : ITextView,
-        _bufferTrackingService : IBufferTrackingService
+        _textView: ITextView,
+        _bufferTrackingService: IBufferTrackingService
     ) =
 
     let _textBuffer = _textView.TextBuffer
@@ -25,10 +25,10 @@ type internal JumpList
     let _list = new LinkedList<ITrackingLineColumn>()
 
     /// Index into the linked list of values.  Contains a value if we are actively traversing
-    let mutable _current : (LinkedListNode<ITrackingLineColumn> * int) option = None
+    let mutable _current: (LinkedListNode<ITrackingLineColumn> * int) option = None
 
     /// Last jump from location
-    let mutable _lastJumpLocation : ITrackingLineColumn option = None
+    let mutable _lastJumpLocation: ITrackingLineColumn option = None
 
     /// Return the point for the caret before the most recent jump
     member x.LastJumpLocation = _lastJumpLocation |> OptionUtil.map2 (fun trackingLineColumn -> trackingLineColumn.VirtualPoint)
@@ -61,7 +61,7 @@ type internal JumpList
     /// Find the LinkedListNode tracking the provided line number.  Returns None if 
     /// one doesn't exist
     member x.FindNodeTrackingLine lineNumber = 
-        let rec inner (current : LinkedListNode<ITrackingLineColumn>) =
+        let rec inner (current: LinkedListNode<ITrackingLineColumn>) =
 
             let currentLineNumber = current.Value.Point |> Option.map SnapshotPointUtil.GetLineNumber
             let matches = 
@@ -145,7 +145,7 @@ type internal JumpList
             // Not traversing
             false
         | Some (current, index) ->
-            let rec inner (current : LinkedListNode<ITrackingLineColumn>) count = 
+            let rec inner (current: LinkedListNode<ITrackingLineColumn>) count = 
                 if count = 0 then current, true
                 elif current.Previous = null then current, false
                 else inner current.Previous (count - 1)
@@ -163,7 +163,7 @@ type internal JumpList
             // Not traversing
             false
         | Some (current, index) ->
-            let rec inner (current : LinkedListNode<ITrackingLineColumn>) count = 
+            let rec inner (current: LinkedListNode<ITrackingLineColumn>) count = 
                 if count = 0 then current, true
                 elif current.Next = null then current, false
                 else inner current.Next (count - 1)

--- a/Src/VimCore/KeyInput.fs
+++ b/Src/VimCore/KeyInput.fs
@@ -6,9 +6,9 @@ open System.Runtime.InteropServices
 [<Sealed>]
 type KeyInput
     (
-        _key : VimKey,
-        _modKey : VimKeyModifiers, 
-        _literal : char option 
+        _key: VimKey,
+        _modKey: VimKeyModifiers, 
+        _literal: char option 
     ) =
 
     member x.Char = _literal |> OptionUtil.getOrDefault CharUtil.MinValue
@@ -37,7 +37,7 @@ type KeyInput
     /// This is demonstratable in a couple of areas.  One simple one is using the 
     /// the CTRL-F command (scroll down).  It has the same behavior with capital 
     /// or lower case F.
-    member x.CompareTo (right : KeyInput) =
+    member x.CompareTo (right: KeyInput) =
         if obj.ReferenceEquals(right, null) then
             1
         else 
@@ -258,7 +258,7 @@ module KeyInputUtil =
             |> List.ofSeq
 
 #if DEBUG
-        let mutable debugMap : Map<char, KeyInput> = Map.empty
+        let mutable debugMap: Map<char, KeyInput> = Map.empty
         for tuple in inputs do
             let c = fst tuple
             let found = Map.tryFind c debugMap
@@ -302,9 +302,9 @@ module KeyInputUtil =
     /// Apply the modifiers to the given KeyInput and determine the result.  This will
     /// not necessarily return a KeyInput with the modifier set.  It attempts to unify 
     /// certain ambiguous combinations.
-    let ApplyKeyModifiers (keyInput : KeyInput) (targetModifiers : VimKeyModifiers) =
+    let ApplyKeyModifiers (keyInput: KeyInput) (targetModifiers: VimKeyModifiers) =
 
-        let normalizeShift (keyInput : KeyInput) =
+        let normalizeShift (keyInput: KeyInput) =
             match keyInput.RawChar with
             | None -> keyInput
             | Some c ->
@@ -342,7 +342,7 @@ module KeyInputUtil =
                     // Nothing special to do here
                     keyInput
 
-        let normalizeControl (keyInput : KeyInput) = 
+        let normalizeControl (keyInput: KeyInput) = 
             if Util.IsFlagSet keyInput.KeyModifiers VimKeyModifiers.Alt then
                 keyInput
             else
@@ -365,7 +365,7 @@ module KeyInputUtil =
                         let modifiers = Util.UnsetFlag keyInput.KeyModifiers VimKeyModifiers.Control
                         ChangeKeyModifiersDangerous keyInput modifiers
 
-        let normalizeAlt (keyInput : KeyInput) =
+        let normalizeAlt (keyInput: KeyInput) =
             match keyInput.RawChar with
             | None -> keyInput
             | Some c ->
@@ -382,7 +382,7 @@ module KeyInputUtil =
                     // Nothing special to do here
                     keyInput
 
-        let normalizeAltGr (keyInput : KeyInput) = 
+        let normalizeAltGr (keyInput: KeyInput) = 
             match keyInput.RawChar with
             | None -> keyInput
             | Some c ->
@@ -390,7 +390,7 @@ module KeyInputUtil =
                 // key mapping. So in order to let VsVim behave the same way, the modifiers should be removed. Furthermore there's 
                 // no special Alt-Gr modifier, it's rerpresented by Ctrl+Alt, so remove both of them. 
                 // This fixes the #1008 and #1390 issues.
-                let unsetflag (a : VimKeyModifiers) (b : VimKeyModifiers) : VimKeyModifiers = Util.UnsetFlag a b
+                let unsetflag (a: VimKeyModifiers) (b: VimKeyModifiers): VimKeyModifiers = Util.UnsetFlag a b
                 let unsetflags a b c = unsetflag (unsetflag a b) c
                 let modifiers = unsetflags keyInput.KeyModifiers VimKeyModifiers.Alt VimKeyModifiers.Control
                 KeyInput(keyInput.Key, modifiers, Some c)
@@ -441,7 +441,7 @@ module KeyInputUtil =
         let keyInput = ch |> CharToKeyInput 
         ApplyKeyModifiers keyInput VimKeyModifiers.Alt
 
-    let GetNonKeypadEquivalent (keyInput : KeyInput) = 
+    let GetNonKeypadEquivalent (keyInput: KeyInput) = 
 
         let apply c = 
             let keyInput = CharToKeyInput c

--- a/Src/VimCore/KeyInput.fsi
+++ b/Src/VimCore/KeyInput.fsi
@@ -10,36 +10,36 @@ type KeyInput =
 
     /// The character representation of this input.  If there is no character representation
     /// then Char.MinValue will be returend
-    member Char : char
+    member Char: char
 
     /// Returns the actual backing character in the form of an option.  Several keys 
     /// don't have corresponding char values and will return None
-    member RawChar : char option
+    member RawChar: char option
 
     /// The VimKey for this KeyInput.  
-    member Key : VimKey
+    member Key: VimKey
 
     /// The extra modifier keys applied to the VimKey value
-    member KeyModifiers : VimKeyModifiers
+    member KeyModifiers: VimKeyModifiers
 
     /// Is the character for this KeyInput a digit
-    member IsDigit : bool
+    member IsDigit: bool
 
     /// Is this an arrow key?
-    member IsArrowKey : bool 
+    member IsArrowKey: bool 
 
     /// Is this a function key
-    member IsFunctionKey : bool
+    member IsFunctionKey: bool
 
     /// Is this a mouse key
-    member IsMouseKey : bool
+    member IsMouseKey: bool
 
     /// The empty KeyInput.  Used in places where a KeyInput is required but no 
     /// good mapping exists
-    static member DefaultValue : KeyInput
+    static member DefaultValue: KeyInput
 
-    static member op_Equality : KeyInput * KeyInput -> bool
-    static member op_Inequality : KeyInput * KeyInput -> bool
+    static member op_Equality: KeyInput * KeyInput -> bool
+    static member op_Inequality: KeyInput * KeyInput -> bool
 
     interface System.IComparable
     interface System.IComparable<KeyInput>
@@ -48,51 +48,51 @@ type KeyInput =
 module KeyInputUtil = 
 
     /// The Null Key: VimKey.Null
-    val NullKey : KeyInput
+    val NullKey: KeyInput
 
     /// The LineFeed key: VimKey.LineFeed
-    val LineFeedKey : KeyInput
+    val LineFeedKey: KeyInput
 
     /// The FormFeed key: VimKey.FormFeed
-    val FormFeedKey : KeyInput
+    val FormFeedKey: KeyInput
 
     /// The Enter Key: VimKey.Enter
-    val EnterKey : KeyInput
+    val EnterKey: KeyInput
 
     /// The Escape Key: VimKey.Escape
-    val EscapeKey : KeyInput 
+    val EscapeKey: KeyInput 
 
     /// The Tab Key: VimKey.Tab
-    val TabKey : KeyInput 
+    val TabKey: KeyInput 
 
     /// The KeyInput for every VimKey in the system which is considered predefined
-    val VimKeyInputList : KeyInput list
+    val VimKeyInputList: KeyInput list
 
     /// The set of core characters as a seq
-    val VimKeyCharList : char list
+    val VimKeyCharList: char list
 
     /// Apply the modifiers to the given KeyInput and determine the result.  This will
     /// not necessarily return a KeyInput with the modifier set.  It attempts to unify 
     /// certain ambiguous combinations.
-    val ApplyKeyModifiers : keyInput : KeyInput -> modifiers : VimKeyModifiers -> KeyInput
+    val ApplyKeyModifiers: keyInput: KeyInput -> modifiers: VimKeyModifiers -> KeyInput
 
     /// Apply the modifiers to the given character
-    val ApplyKeyModifiersToChar : c : char  -> modifiers : VimKeyModifiers -> KeyInput
+    val ApplyKeyModifiersToChar: c: char  -> modifiers: VimKeyModifiers -> KeyInput
 
     /// Apply the modifiers to the given VimKey
-    val ApplyKeyModifiersToKey : vimKey : VimKey -> modifiers : VimKeyModifiers -> KeyInput
+    val ApplyKeyModifiersToKey: vimKey: VimKey -> modifiers: VimKeyModifiers -> KeyInput
 
     /// Try and convert the given char to a KeyInput value
-    val CharToKeyInput : c : char -> KeyInput
+    val CharToKeyInput: c: char -> KeyInput
 
     /// Convert the passed in char to a KeyInput with Control
-    val CharWithControlToKeyInput : c : char -> KeyInput
+    val CharWithControlToKeyInput: c: char -> KeyInput
 
     /// Convert the passed in char to a KeyInput with Alt
-    val CharWithAltToKeyInput : c : char -> KeyInput
+    val CharWithAltToKeyInput: c: char -> KeyInput
 
     /// Convert the specified VimKey code to a KeyInput 
-    val VimKeyToKeyInput : vimKey : VimKey -> KeyInput
+    val VimKeyToKeyInput: vimKey: VimKey -> KeyInput
 
     /// Change the KeyModifiers associated with this KeyInput.  Will not change the value
     /// of the underlying char.  Although it may produce a KeyInput that makes no 
@@ -101,8 +101,8 @@ module KeyInputUtil =
     ///
     /// This method should be avoided.  If you need to apply modifiers then use
     /// ApplyModifiers which uses Vim semantics when deciding how to apply the modifiers
-    val ChangeKeyModifiersDangerous : keyInput : KeyInput -> modifiers : VimKeyModifiers -> KeyInput
+    val ChangeKeyModifiersDangerous: keyInput: KeyInput -> modifiers: VimKeyModifiers -> KeyInput
 
     /// Get the alternate key for the given KeyInput if it's a key from the keypad 
-    val GetNonKeypadEquivalent : keyInput : KeyInput -> KeyInput option 
+    val GetNonKeypadEquivalent: keyInput: KeyInput -> KeyInput option 
 

--- a/Src/VimCore/KeyMap.fs
+++ b/Src/VimCore/KeyMap.fs
@@ -19,17 +19,17 @@ type RemapModeMap = Map<KeyInputSet, KeyMapping>
 /// approach because it's easy to follow and meets the specs
 type Mapper
     (
-        _keyInputSet : KeyInputSet,
-        _modeMap : RemapModeMap,
-        _globalSettings : IVimGlobalSettings,
-        _isZeroMappingEnabled : bool
+        _keyInputSet: KeyInputSet,
+        _modeMap: RemapModeMap,
+        _globalSettings: IVimGlobalSettings,
+        _isZeroMappingEnabled: bool
     ) =
 
     /// During the processing of mapping input we found a match for the inputKeySet to the 
     /// specified KeyMapping entry.  Return the KeyInputSet which this definitively mapped
     /// to (and requires no remapping) and the set of keys which still must be considered
     /// for mapping
-    member x.ProcessMapping (lhs : KeyInputSet) (keyMapping : KeyMapping) = 
+    member x.ProcessMapping (lhs: KeyInputSet) (keyMapping: KeyMapping) = 
 
         let mappedSet, remainingSet = 
             if keyMapping.AllowRemap then
@@ -72,7 +72,7 @@ type Mapper
 
         mappedSet, remainingSet
 
-    static member IsFirstKeyInputZero (keyInputSet : KeyInputSet) =
+    static member IsFirstKeyInputZero (keyInputSet: KeyInputSet) =
         match keyInputSet.FirstKeyInput with
         | Some keyInput -> keyInput = KeyInputUtil.CharToKeyInput '0' 
         | _ -> false
@@ -95,7 +95,7 @@ type Mapper
         // until the calling code has time to process the definitively mapped set of 
         // keys.  Doing so could change the key mapping mode and hence change how we map 
         // the remaining keys
-        let successfulMap (mappedKeyInputSet : KeyInputSet) (remainingKeyInputSet : KeyInputSet) = 
+        let successfulMap (mappedKeyInputSet: KeyInputSet) (remainingKeyInputSet: KeyInputSet) = 
             if remainingKeyInputSet.Length = 0 then
                 result := KeyMappingResult.Mapped mappedKeyInputSet
             else
@@ -167,11 +167,11 @@ type Mapper
 
 type internal KeyMap
     (
-        _globalSettings : IVimGlobalSettings,
-        _variableMap : VariableMap
+        _globalSettings: IVimGlobalSettings,
+        _variableMap: VariableMap
     ) =
 
-    let mutable _map : Map<KeyRemapMode, RemapModeMap> = Map.empty
+    let mutable _map: Map<KeyRemapMode, RemapModeMap> = Map.empty
     let mutable _isZeroMappingEnabled = true
 
     member x.IsZeroMappingEnabled 
@@ -191,16 +191,16 @@ type internal KeyMap
         | Some map -> map
 
     /// Get all of the mappings for the given KeyRemapMode
-    member x.GetKeyMappingsForMode mode : KeyMapping list = 
+    member x.GetKeyMappingsForMode mode: KeyMapping list = 
         match Map.tryFind mode _map with
         | None -> List.empty
         | Some map -> map |> Map.toSeq |> Seq.map snd |> List.ofSeq
 
     /// Main API for adding a key mapping into our storage
-    member x.MapCore (lhs : string) (rhs : string) (mode : KeyRemapMode) allowRemap = 
+    member x.MapCore (lhs: string) (rhs: string) (mode: KeyRemapMode) allowRemap = 
 
         // Replace the <Leader> value with the appropriate replacement string
-        let replaceLeader (str : string) =
+        let replaceLeader (str: string) =
             if str.IndexOf("<leader>", StringComparison.OrdinalIgnoreCase) >= 0 then
                 let replace =
                     let found, value = _variableMap.TryGetValue "mapleader"
@@ -261,7 +261,7 @@ type internal KeyMap
 
     /// Get the key mapping for the passed in data.  Returns a KeyMappingResult representing the 
     /// mapping
-    member x.GetKeyMapping (keyInputSet : KeyInputSet) mode =
+    member x.GetKeyMapping (keyInputSet: KeyInputSet) mode =
         let modeMap = x.GetRemapModeMap mode
         let mapper = Mapper(keyInputSet, modeMap, _globalSettings, _isZeroMappingEnabled)
         mapper.GetKeyMapping()

--- a/Src/VimCore/KeyMap.fsi
+++ b/Src/VimCore/KeyMap.fsi
@@ -6,5 +6,5 @@ type internal KeyMap =
 
     interface IKeyMap
 
-    new : settings : IVimGlobalSettings * variableMap : VariableMap -> KeyMap 
+    new: settings: IVimGlobalSettings * variableMap: VariableMap -> KeyMap 
 

--- a/Src/VimCore/KeyNotationUtil.fs
+++ b/Src/VimCore/KeyNotationUtil.fs
@@ -94,7 +94,7 @@ module KeyNotationUtil =
         |> Map.ofSeq
 
     /// Convert the given special key name + modifier into a KeyInput value 
-    let ConvertSpecialKeyName (dataCharSpan : CharSpan) modifier = 
+    let ConvertSpecialKeyName (dataCharSpan: CharSpan) modifier = 
 
         let keyInput = 
             match Map.tryFind dataCharSpan SpecialKeyMap with
@@ -128,7 +128,7 @@ module KeyNotationUtil =
                 KeyInputUtil.ApplyKeyModifiers keyInput modifier |> Some
 
     /// Try and convert a <char-...> notation into a KeyInput value 
-    let TryCharNotationToKeyInput (dataCharSpan : CharSpan) = 
+    let TryCharNotationToKeyInput (dataCharSpan: CharSpan) = 
         Contract.Assert(dataCharSpan.CharAt 0 = '<')
         Contract.Assert(dataCharSpan.CharAt (dataCharSpan.Length - 1) = '>')
 
@@ -157,7 +157,7 @@ module KeyNotationUtil =
             | _ -> None
 
     /// Try and convert a key notation that is bracketed with < and > to a KeyInput value
-    let TryKeyNotationToKeyInput (dataCharSpan : CharSpan) = 
+    let TryKeyNotationToKeyInput (dataCharSpan: CharSpan) = 
         Contract.Assert(dataCharSpan.CharAt 0 = '<')
         Contract.Assert(dataCharSpan.CharAt (dataCharSpan.Length - 1) = '>')
 
@@ -198,7 +198,7 @@ module KeyNotationUtil =
     /// Try and convert the given string value into a KeyInput.  If the value is wrapped in 
     /// < and > then it will be interpreted as a special key modifier as defined by 
     /// :help key-notation
-    let TryStringToKeyInputCore (dataCharSpan : CharSpan) =
+    let TryStringToKeyInputCore (dataCharSpan: CharSpan) =
         if dataCharSpan.Length = 0 then
             None
         elif dataCharSpan.CharAt 0 = '<' then
@@ -216,7 +216,7 @@ module KeyNotationUtil =
 
     /// Try and convert the given string value into a single KeyInput value.  If the conversion
     /// fails or is more than 1 KeyInput in length then None will be returned
-    let TryStringToKeyInput (data : string) = 
+    let TryStringToKeyInput (data: string) = 
         let dataCharSpan = CharSpan(data, CharComparer.IgnoreCase)
         match TryStringToKeyInputCore dataCharSpan with
         | Some (keyInput, length) ->
@@ -253,7 +253,7 @@ module KeyNotationUtil =
         | Some list -> list
         | None -> invalidArg "data" (Resources.KeyNotationUtil_InvalidNotation data)
 
-    let TryGetSpecialKeyName (keyInput : KeyInput) = 
+    let TryGetSpecialKeyName (keyInput: KeyInput) = 
         let found = 
             SpecialKeyMap
             |> Seq.tryFind (fun pair -> 
@@ -265,11 +265,11 @@ module KeyNotationUtil =
         match found with 
         | None -> None
         | Some pair ->
-            let extra : VimKeyModifiers = Util.UnsetFlag keyInput.KeyModifiers pair.Value.KeyModifiers
+            let extra: VimKeyModifiers = Util.UnsetFlag keyInput.KeyModifiers pair.Value.KeyModifiers
             Some (pair.Key.ToString(), extra)
 
     /// Get the display name for the specified KeyInput value.
-    let GetDisplayName (keyInput : KeyInput) = 
+    let GetDisplayName (keyInput: KeyInput) = 
 
         let inner name keyModifiers forceBookend = 
             let rec getPrefix current keyModifiers = 

--- a/Src/VimCore/KeyNotationUtil.fsi
+++ b/Src/VimCore/KeyNotationUtil.fsi
@@ -8,23 +8,23 @@ module KeyNotationUtil =
 
     /// Try to convert the passed in string into a single KeyInput value according to the
     /// guidelines specified in :help key-notation.  
-    val TryStringToKeyInput : string -> KeyInput option
+    val TryStringToKeyInput: string -> KeyInput option
 
     /// Convert the passed in string to a single KeyInput value.  In the case the string
     /// doesn't map to a single KeyInput value then an exception will be thrown
-    val StringToKeyInput : string -> KeyInput
+    val StringToKeyInput: string -> KeyInput
 
     /// Try to convert the passed in string to multiple KeyInput values.  Returns true only
     /// if the entire list succesfully parses
-    val TryStringToKeyInputSet : string -> KeyInputSet option
+    val TryStringToKeyInputSet: string -> KeyInputSet option
 
     /// Convert tho String to a KeyInputSet 
-    val StringToKeyInputSet : string -> KeyInputSet
+    val StringToKeyInputSet: string -> KeyInputSet
 
     /// Try and convert the passed in KeyInput into a special key name the extra set of 
     /// KeyModifiers on the original KeyInput
-    val TryGetSpecialKeyName : KeyInput -> (string * VimKeyModifiers) option
+    val TryGetSpecialKeyName: KeyInput -> (string * VimKeyModifiers) option
 
     /// Get the display name for the specified KeyInput value
-    val GetDisplayName : keyInput : KeyInput -> string
+    val GetDisplayName: keyInput: KeyInput -> string
 

--- a/Src/VimCore/LineChangeTracker.fs
+++ b/Src/VimCore/LineChangeTracker.fs
@@ -10,8 +10,8 @@ open System.ComponentModel.Composition
 /// Data relating to tracking changes to a line
 type internal LineChangeTrackingData =
     {
-        LineNumber : int
-        SavedLine : string option
+        LineNumber: int
+        SavedLine: string option
     }
     static member Empty = {
         LineNumber = 0
@@ -21,7 +21,7 @@ type internal LineChangeTrackingData =
 /// Used to track changes to the current line of an individual IVimBuffer
 type internal LineChangeTracker
     ( 
-        _vimBufferData : IVimBufferData
+        _vimBufferData: IVimBufferData
     ) as x =
 
     let _disposables = DisposableBag()
@@ -129,7 +129,7 @@ type internal LineChangeTrackerFactory
     let _key = System.Object()
     
     interface ILineChangeTrackerFactory with
-        member x.GetLineChangeTracker (bufferData : IVimBufferData) =
+        member x.GetLineChangeTracker (bufferData: IVimBufferData) =
             let textView = bufferData.TextView
             textView.Properties.GetOrCreateSingletonProperty(_key, (fun () -> 
                 LineChangeTracker(bufferData) :> ILineChangeTracker))

--- a/Src/VimCore/MacroRecorder.fs
+++ b/Src/VimCore/MacroRecorder.fs
@@ -1,11 +1,11 @@
 ﻿namespace Vim
 
 /// Macro recording implementation
-type internal MacroRecorder (_registerMap : IRegisterMap) =
+type internal MacroRecorder (_registerMap: IRegisterMap) =
 
     /// Option holding the data related to recording.  If it's Some then we are in the
     /// middle of recording.
-    let mutable _recordData : (Register * KeyInput list) option = None
+    let mutable _recordData: (Register * KeyInput list) option = None
 
     /// This records whether or not the KeyInputEnd event is valid or not for 
     /// recording.  The macro recorder needs to be careful to not record key
@@ -24,7 +24,7 @@ type internal MacroRecorder (_registerMap : IRegisterMap) =
     member x.IsRecording = Option.isSome _recordData
 
     /// Start recording KeyInput values which are processed
-    member x.StartRecording (register : Register) isAppend = 
+    member x.StartRecording (register: Register) isAppend = 
         Contract.Requires (Option.isNone _recordData)
 
         // Calculate the initial list.  If we are appending to the existing register
@@ -50,7 +50,7 @@ type internal MacroRecorder (_registerMap : IRegisterMap) =
         _recordingStoppedEvent.Trigger x
 
     /// Need to track the KeyInputProcessed event for every IVimBuffer in the system
-    member x.OnVimBufferCreated (buffer : IVimBuffer) =
+    member x.OnVimBufferCreated (buffer: IVimBuffer) =
         let bag = DisposableBag()
         buffer.KeyInputStart.Subscribe x.OnKeyInputStart |> bag.Add
         buffer.KeyInputEnd.Subscribe x.OnKeyInputEnd |> bag.Add
@@ -59,7 +59,7 @@ type internal MacroRecorder (_registerMap : IRegisterMap) =
     member x.OnKeyInputStart _ = 
         _isKeyInputEndValid <- Option.isSome _recordData
 
-    member x.OnKeyInputEnd (args : KeyInputEventArgs) =
+    member x.OnKeyInputEnd (args: KeyInputEventArgs) =
         if _isKeyInputEndValid then
             match _recordData with
             | None -> () 

--- a/Src/VimCore/MacroRecorder.fsi
+++ b/Src/VimCore/MacroRecorder.fsi
@@ -5,4 +5,4 @@ type internal MacroRecorder =
     interface IMacroRecorder
     interface IVimBufferCreationListener
 
-    new : IRegisterMap -> MacroRecorder
+    new: IRegisterMap -> MacroRecorder

--- a/Src/VimCore/MarkMap.fs
+++ b/Src/VimCore/MarkMap.fs
@@ -4,7 +4,7 @@ namespace Vim
 open Microsoft.VisualStudio.Text
 open System.Collections.Generic
 
-type MarkMap(_bufferTrackingService : IBufferTrackingService) =
+type MarkMap(_bufferTrackingService: IBufferTrackingService) =
 
     /// This is a map from letter to key.  The key is the key into the property collection
     /// of the ITextBuffer which holds the ITrackingLineColumn for the global mark.  We
@@ -18,9 +18,9 @@ type MarkMap(_bufferTrackingService : IBufferTrackingService) =
     /// is stored.  The MarkMap table lives much longer than the individual marks 
     /// so we hold them in a WeakReference<T> to prevent holding the ITextBuffer 
     /// in memory.
-    let mutable _globalMarkMap : Map<Letter, WeakReference<ITextBuffer>> = Map.empty
+    let mutable _globalMarkMap: Map<Letter, WeakReference<ITextBuffer>> = Map.empty
 
-    let mutable _globalLastExitedMap : Map<string, int * int> = Map.empty
+    let mutable _globalLastExitedMap: Map<string, int * int> = Map.empty
 
     /// Get the core information about the global mark represented by the letter
     member x.GetGlobalMarkData letter =
@@ -67,7 +67,7 @@ type MarkMap(_bufferTrackingService : IBufferTrackingService) =
         | Some (_, trackingLineColumn, _) -> trackingLineColumn.VirtualPoint
 
     /// Set the global mark to the value in question
-    member x.SetGlobalMark letter (vimTextBuffer : IVimTextBuffer) line column =
+    member x.SetGlobalMark letter (vimTextBuffer: IVimTextBuffer) line column =
         // First clear out the existing mark if it exists.  
         x.RemoveGlobalMark letter |> ignore
 
@@ -79,7 +79,7 @@ type MarkMap(_bufferTrackingService : IBufferTrackingService) =
         _globalMarkMap <- Map.add letter value _globalMarkMap
 
     /// Get the given mark in the context of the given IVimTextBuffer
-    member x.GetMark mark (vimBufferData : IVimBufferData) =
+    member x.GetMark mark (vimBufferData: IVimBufferData) =
         match mark with
         | Mark.GlobalMark letter -> 
 
@@ -116,7 +116,7 @@ type MarkMap(_bufferTrackingService : IBufferTrackingService) =
                     Some (VirtualSnapshotPointUtil.OfPoint snapshot)
 
     /// Set the given mark to the specified line and column in the context of the IVimTextBuffer
-    member x.SetMark mark (vimBufferData : IVimBufferData) line column = 
+    member x.SetMark mark (vimBufferData: IVimBufferData) line column = 
         let vimTextBuffer = vimBufferData.VimTextBuffer
         match mark with
         | Mark.GlobalMark letter -> 

--- a/Src/VimCore/MarkMap.fsi
+++ b/Src/VimCore/MarkMap.fsi
@@ -4,4 +4,4 @@ namespace Vim
 type MarkMap =
     interface IMarkMap
 
-    new : IBufferTrackingService -> MarkMap
+    new: IBufferTrackingService -> MarkMap

--- a/Src/VimCore/MefInterfaces.fs
+++ b/Src/VimCore/MefInterfaces.fs
@@ -12,27 +12,27 @@ open System.Configuration
 type IDisplayWindowBroker =
 
     /// TextView this broker is associated with
-    abstract TextView : ITextView 
+    abstract TextView: ITextView 
 
     /// Is there currently a completion window active on the given ITextView
-    abstract IsCompletionActive : bool
+    abstract IsCompletionActive: bool
 
     /// Is signature help currently active
-    abstract IsSignatureHelpActive : bool
+    abstract IsSignatureHelpActive: bool
 
     // Is Quick Info active
-    abstract IsQuickInfoActive : bool 
+    abstract IsQuickInfoActive: bool 
 
     /// Is there a smart tip window active
-    abstract IsSmartTagSessionActive : bool
+    abstract IsSmartTagSessionActive: bool
 
     /// Dismiss any completion windows on the given ITextView
-    abstract DismissDisplayWindows : unit -> unit
+    abstract DismissDisplayWindows: unit -> unit
 
 type IDisplayWindowBrokerFactoryService  =
 
     /// Get the display broker for the provided ITextView
-    abstract GetDisplayWindowBroker : textView : ITextView -> IDisplayWindowBroker
+    abstract GetDisplayWindowBroker: textView: ITextView -> IDisplayWindowBroker
 
 /// What type of tracking are we doing
 [<RequireQualifiedAccess>]
@@ -58,88 +58,88 @@ type LineColumnTrackingMode =
 type ITrackingLineColumn =
 
     /// ITextBuffer this ITrackingLineColumn is tracking against
-    abstract TextBuffer : ITextBuffer
+    abstract TextBuffer: ITextBuffer
 
     /// Returns the LineColumnTrackingMode for this instance
-    abstract TrackingMode : LineColumnTrackingMode
+    abstract TrackingMode: LineColumnTrackingMode
 
     /// Get the point as it relates to current Snapshot.
-    abstract Point : SnapshotPoint option 
+    abstract Point: SnapshotPoint option 
 
     /// Get the point as a VirtualSnapshot point on the current ITextSnapshot
-    abstract VirtualPoint : VirtualSnapshotPoint option
+    abstract VirtualPoint: VirtualSnapshotPoint option
 
     /// Needs to be called when you are done with the ITrackingLineColumn
-    abstract Close : unit -> unit
+    abstract Close: unit -> unit
 
 /// Tracks a VisualSpan across edits to the underlying ITextBuffer.
 type ITrackingVisualSpan = 
 
     /// The associated ITextBuffer instance
-    abstract TextBuffer : ITextBuffer
+    abstract TextBuffer: ITextBuffer
 
     /// Get the VisualSpan as it relates to the current ITextSnapshot
-    abstract VisualSpan : VisualSpan option
+    abstract VisualSpan: VisualSpan option
 
     /// Needs to be called when the consumer is finished with the ITrackingVisualSpan
-    abstract Close : unit -> unit
+    abstract Close: unit -> unit
 
 /// Tracks a Visual Selection across edits to the underlying ITextBuffer.  This tracks both
 /// the selection area and the caret within the selection
 type ITrackingVisualSelection = 
 
     /// The SnapshotPoint for the caret within the current ITextSnapshot
-    abstract CaretPoint : SnapshotPoint option
+    abstract CaretPoint: SnapshotPoint option
 
     /// The associated ITextBuffer instance
-    abstract TextBuffer : ITextBuffer
+    abstract TextBuffer: ITextBuffer
 
     /// Get the Visual Selection as it relates to the current ITextSnapshot
-    abstract VisualSelection : VisualSelection option
+    abstract VisualSelection: VisualSelection option
 
     /// Needs to be called when the consumer is finished with the ITrackingVisualSpan
-    abstract Close : unit -> unit
+    abstract Close: unit -> unit
 
 type IBufferTrackingService = 
 
     /// Create an ITrackingLineColumn at the given position in the buffer.  
-    abstract CreateLineColumn : textBuffer : ITextBuffer -> line : int -> column : int -> LineColumnTrackingMode -> ITrackingLineColumn
+    abstract CreateLineColumn: textBuffer: ITextBuffer -> line: int -> column: int -> LineColumnTrackingMode -> ITrackingLineColumn
 
     /// Create an ITrackingVisualSpan for the given VisualSpan
-    abstract CreateVisualSpan : visualSpan : VisualSpan -> ITrackingVisualSpan
+    abstract CreateVisualSpan: visualSpan: VisualSpan -> ITrackingVisualSpan
 
     /// Create an ITrackingVisualSelection for the given Visual Selection
-    abstract CreateVisualSelection : visualSelection : VisualSelection -> ITrackingVisualSelection
+    abstract CreateVisualSelection: visualSelection: VisualSelection -> ITrackingVisualSelection
 
     /// Does the given ITextBuffer have any out standing tracking instances 
-    abstract HasTrackingItems : textBuffer : ITextBuffer -> bool
+    abstract HasTrackingItems: textBuffer: ITextBuffer -> bool
 
 type IVimBufferCreationListener =
 
     /// Called whenever an IVimBuffer is created
-    abstract VimBufferCreated : vimBuffer : IVimBuffer -> unit
+    abstract VimBufferCreated: vimBuffer: IVimBuffer -> unit
 
 /// Supports the creation and deletion of folds within a ITextBuffer.  Most components
 /// should talk to IFoldManager directly
 type IFoldData = 
 
     /// Associated ITextBuffer the data is over
-    abstract TextBuffer : ITextBuffer
+    abstract TextBuffer: ITextBuffer
 
     /// Gets snapshot spans for all of the currently existing folds.  This will
     /// only return the folds explicitly created by vim.  It won't return any
     /// collapsed regions in the ITextView
-    abstract Folds : SnapshotSpan seq
+    abstract Folds: SnapshotSpan seq
 
     /// Create a fold for the given line range
-    abstract CreateFold : SnapshotLineRange -> unit 
+    abstract CreateFold: SnapshotLineRange -> unit 
 
     /// Delete a fold which crosses the given SnapshotPoint.  Returns false if 
     /// there was no fold to be deleted
-    abstract DeleteFold : SnapshotPoint -> bool
+    abstract DeleteFold: SnapshotPoint -> bool
 
     /// Delete all of the folds which intersect the given SnapshotSpan
-    abstract DeleteAllFolds : SnapshotSpan -> unit
+    abstract DeleteAllFolds: SnapshotSpan -> unit
 
     /// Raised when the collection of folds are updated for any reason
     [<CLIEvent>]
@@ -152,44 +152,44 @@ type IFoldData =
 type IFoldManager = 
 
     /// Associated ITextView
-    abstract TextView : ITextView
+    abstract TextView: ITextView
 
     /// Create a fold for the given line range.  The fold will be created in a closed state.
-    abstract CreateFold : range : SnapshotLineRange -> unit 
+    abstract CreateFold: range: SnapshotLineRange -> unit 
 
     /// Close 'count' fold values under the given SnapshotPoint
-    abstract CloseFold : point : SnapshotPoint -> count : int -> unit
+    abstract CloseFold: point: SnapshotPoint -> count: int -> unit
 
     /// Close all folds which intersect the given SnapshotSpan
-    abstract CloseAllFolds : span : SnapshotSpan -> unit
+    abstract CloseAllFolds: span: SnapshotSpan -> unit
 
     /// Delete a fold which crosses the given SnapshotPoint.  Returns false if 
     /// there was no fold to be deleted
-    abstract DeleteFold : point : SnapshotPoint -> unit
+    abstract DeleteFold: point: SnapshotPoint -> unit
 
     /// Delete all of the folds which intersect the SnapshotSpan
-    abstract DeleteAllFolds : span : SnapshotSpan -> unit
+    abstract DeleteAllFolds: span: SnapshotSpan -> unit
 
     /// Toggle fold under the given SnapshotPoint
-    abstract ToggleFold : point : SnapshotPoint -> count : int -> unit
+    abstract ToggleFold: point: SnapshotPoint -> count: int -> unit
 
     /// Toggle all folds under the given SnapshotPoint
-    abstract ToggleAllFolds : span : SnapshotSpan -> unit
+    abstract ToggleAllFolds: span: SnapshotSpan -> unit
 
     /// Open 'count' folds under the given SnapshotPoint
-    abstract OpenFold : point : SnapshotPoint -> count : int -> unit
+    abstract OpenFold: point: SnapshotPoint -> count: int -> unit
 
     /// Open all folds which intersect the given SnapshotSpan
-    abstract OpenAllFolds : span : SnapshotSpan -> unit
+    abstract OpenAllFolds: span: SnapshotSpan -> unit
 
 /// Supports the get and creation of IFoldManager for a given ITextBuffer
 type IFoldManagerFactory =
 
     /// Get the IFoldData for this ITextBuffer
-    abstract GetFoldData : textBuffer : ITextBuffer -> IFoldData
+    abstract GetFoldData: textBuffer: ITextBuffer -> IFoldData
 
     /// Get the IFoldManager for this ITextView.
-    abstract GetFoldManager : textView : ITextView -> IFoldManager
+    abstract GetFoldManager: textView: ITextView -> IFoldManager
 
 /// Used because the actual Point class is in WPF which isn't available at this layer.
 [<Struct>]
@@ -202,39 +202,39 @@ type VimPoint = {
 type IMouseDevice = 
     
     /// Is the left button pressed
-    abstract IsLeftButtonPressed : bool
+    abstract IsLeftButtonPressed: bool
 
     /// Get the position of the mouse position within the ITextView
-    abstract GetPosition : textView : ITextView -> VimPoint option
+    abstract GetPosition: textView: ITextView -> VimPoint option
 
     /// Is the given ITextView in the middle fo a drag operation?
-    abstract InDragOperation : textView : ITextView -> bool
+    abstract InDragOperation: textView: ITextView -> bool
 
 /// Abstract representation of the keyboard 
 type IKeyboardDevice = 
 
     /// Is the given key pressed
-    abstract IsArrowKeyDown : bool
+    abstract IsArrowKeyDown: bool
 
     /// The modifiers currently pressed on the keyboard
-    abstract KeyModifiers : VimKeyModifiers
+    abstract KeyModifiers: VimKeyModifiers
 
 /// Tracks changes to the associated ITextView
 type ILineChangeTracker =
 
     /// Swap the most recently changed line with its saved copy
-    abstract Swap : unit -> bool
+    abstract Swap: unit -> bool
 
 /// Manages the ILineChangeTracker instances
 type ILineChangeTrackerFactory =
 
     /// Get the ILineChangeTracker associated with the given vim buffer information
-    abstract GetLineChangeTracker : vimBufferData : IVimBufferData -> ILineChangeTracker
+    abstract GetLineChangeTracker: vimBufferData: IVimBufferData -> ILineChangeTracker
 
 /// Provides access to the system clipboard 
 type IClipboardDevice =
 
-    abstract Text : string with get, set
+    abstract Text: string with get, set
 
 [<RequireQualifiedAccess>]
 [<NoComparison>]
@@ -303,56 +303,56 @@ type RegisterOperation =
 type ICommonOperations =
 
     /// Run the beep operation
-    abstract Beep : unit -> unit
+    abstract Beep: unit -> unit
 
     /// Associated IEditorOperations
-    abstract EditorOperations : IEditorOperations
+    abstract EditorOperations: IEditorOperations
 
     /// Associated IEditorOptions
-    abstract EditorOptions : IEditorOptions
+    abstract EditorOptions: IEditorOptions
 
     /// The currently maintained caret column for up / down caret movements in the
     /// buffer
-    abstract MaintainCaretColumn : MaintainCaretColumn with get, set
+    abstract MaintainCaretColumn: MaintainCaretColumn with get, set
 
     /// Associated ITextView
-    abstract TextView : ITextView 
+    abstract TextView: ITextView 
 
     /// Associated VimBufferData instance
-    abstract VimBufferData : IVimBufferData
+    abstract VimBufferData: IVimBufferData
 
-    abstract AdjustCaretForScrollOffset : unit -> unit
+    abstract AdjustCaretForScrollOffset: unit -> unit
 
-    abstract member CloseWindowUnlessDirty : unit -> unit
+    abstract member CloseWindowUnlessDirty: unit -> unit
 
     /// Create a possibly LineWise register value with the specified string value at the given 
     /// point.  This is factored out here because a LineWise value in vim should always
     /// end with a new line but we can't always guarantee the text we are working with 
     /// contains a new line.  This normalizes out the process needed to make this correct
     /// while respecting the settings of the ITextBuffer
-    abstract CreateRegisterValue : point : SnapshotPoint -> stringData : StringData -> operationKind : OperationKind -> RegisterValue
+    abstract CreateRegisterValue: point: SnapshotPoint -> stringData: StringData -> operationKind: OperationKind -> RegisterValue
 
     /// Delete at least count lines from the buffer starting from the provided line.  The 
     /// operation will fail if there aren't at least 'maxCount' lines in the buffer from
     /// the start point.
     ///
     /// This operation is performed against the visual buffer.  
-    abstract DeleteLines : startLine : ITextSnapshotLine -> maxCount : int -> registerName : RegisterName option -> unit
+    abstract DeleteLines: startLine: ITextSnapshotLine -> maxCount: int -> registerName: RegisterName option -> unit
 
     /// Ensure the view properties are met at the caret
-    abstract EnsureAtCaret : viewFlags : ViewFlags -> unit
+    abstract EnsureAtCaret: viewFlags: ViewFlags -> unit
 
     /// Ensure the view properties are met at the point
-    abstract EnsureAtPoint : point : SnapshotPoint -> viewFlags : ViewFlags -> unit
+    abstract EnsureAtPoint: point: SnapshotPoint -> viewFlags: ViewFlags -> unit
 
     /// Format the specified line range
-    abstract FormatLines : SnapshotLineRange -> unit
+    abstract FormatLines: SnapshotLineRange -> unit
 
     /// Get the new line text which should be used for new lines at the given SnapshotPoint
-    abstract GetNewLineText : SnapshotPoint -> string
+    abstract GetNewLineText: SnapshotPoint -> string
 
     /// Get the register to use based on the name provided to the operation.
-    abstract GetRegister : name : RegisterName option -> Register
+    abstract GetRegister: name: RegisterName option -> Register
 
     /// Get the indentation for a newly created ITextSnasphotLine.  The context line is
     /// is provided to calculate the indentation off of 
@@ -362,119 +362,119 @@ type ICommonOperations =
     /// an edit to occur.  
     ///
     /// Issue #946
-    abstract GetNewLineIndent : contextLine : ITextSnapshotLine -> newLine : ITextSnapshotLine -> int option
+    abstract GetNewLineIndent: contextLine: ITextSnapshotLine -> newLine: ITextSnapshotLine -> int option
 
     /// Get the standard ReplaceData for the given SnapshotPoint
-    abstract GetReplaceData : point : SnapshotPoint -> VimRegexReplaceData
+    abstract GetReplaceData: point: SnapshotPoint -> VimRegexReplaceData
 
     /// Get the number of spaces (when tabs are expanded) that is necessary to get to the 
     /// specified point on it's line
-    abstract GetSpacesToPoint : point : SnapshotPoint -> int
+    abstract GetSpacesToPoint: point: SnapshotPoint -> int
 
     /// Get the point that visually corresponds to the specified column on its line
-    abstract GetPointForSpaces : contextLine : ITextSnapshotLine -> column : int -> SnapshotPoint
+    abstract GetPointForSpaces: contextLine: ITextSnapshotLine -> column: int -> SnapshotPoint
 
     /// Attempt to GoToDefinition on the current state of the buffer.  If this operation fails, an error message will 
     /// be generated as appropriate
-    abstract GoToDefinition : unit -> Result
+    abstract GoToDefinition: unit -> Result
 
     /// Go to the file named in the word under the cursor
-    abstract GoToFile : unit -> unit
+    abstract GoToFile: unit -> unit
 
     /// Go to the file name specified as a paramter
-    abstract GoToFile : string -> unit
+    abstract GoToFile: string -> unit
 
     /// Go to the file named in the word under the cursor in a new window
-    abstract GoToFileInNewWindow : unit -> unit
+    abstract GoToFileInNewWindow: unit -> unit
 
     /// Go to the file name specified as a paramter in a new window
-    abstract GoToFileInNewWindow : string -> unit
+    abstract GoToFileInNewWindow: string -> unit
 
     /// Go to the local declaration of the word under the cursor
-    abstract GoToLocalDeclaration : unit -> unit
+    abstract GoToLocalDeclaration: unit -> unit
 
     /// Go to the global declaration of the word under the cursor
-    abstract GoToGlobalDeclaration : unit -> unit
+    abstract GoToGlobalDeclaration: unit -> unit
 
     /// Go to the "count" next tab window in the specified direction.  This will wrap 
     /// around
-    abstract GoToNextTab : path : SearchPath -> count : int -> unit
+    abstract GoToNextTab: path: SearchPath -> count: int -> unit
 
     /// Go the nth tab.  This uses vim's method of numbering tabs which is a 1 based list.  Both
     /// 0 and 1 can be used to access the first tab
-    abstract GoToTab : int -> unit
+    abstract GoToTab: int -> unit
 
     /// Convert any virtual spaces into real spaces / tabs based on the current settings.  The caret 
     /// will be positioned at the end of that change
-    abstract FillInVirtualSpace : unit -> unit
+    abstract FillInVirtualSpace: unit -> unit
 
     /// Joins the lines in the range
-    abstract Join : SnapshotLineRange -> JoinKind -> unit
+    abstract Join: SnapshotLineRange -> JoinKind -> unit
 
     /// Move the caret in the specified direction
-    abstract MoveCaret : caretMovement : CaretMovement -> bool
+    abstract MoveCaret: caretMovement: CaretMovement -> bool
 
     /// Move the caret in the specified direction with an arrow key
-    abstract MoveCaretWithArrow : caretMovement : CaretMovement -> bool
+    abstract MoveCaretWithArrow: caretMovement: CaretMovement -> bool
 
     /// Move the caret to a given point on the screen and ensure the view has the specified
     /// properties at that point 
-    abstract MoveCaretToPoint : point : SnapshotPoint -> viewFlags : ViewFlags -> unit
+    abstract MoveCaretToPoint: point: SnapshotPoint -> viewFlags: ViewFlags -> unit
 
     /// Move the caret to the MotionResult value
-    abstract MoveCaretToMotionResult : motionResult : MotionResult -> unit
+    abstract MoveCaretToMotionResult: motionResult: MotionResult -> unit
 
     /// Navigate to the given point which may occur in any ITextBuffer.  This will not update the 
     /// jump list
-    abstract NavigateToPoint : VirtualSnapshotPoint -> bool
+    abstract NavigateToPoint: VirtualSnapshotPoint -> bool
 
     /// Normalize the spaces and tabs in the string
-    abstract NormalizeBlanks : text : string -> string
+    abstract NormalizeBlanks: text: string -> string
 
     /// Normalize the spaces and tabs in the string at the given column in the buffer
-    abstract NormalizeBlanksAtColumn : text : string -> column : SnapshotColumn -> string
+    abstract NormalizeBlanksAtColumn: text: string -> column: SnapshotColumn -> string
 
     /// Normalize the set of blanks into spaces
-    abstract NormalizeBlanksToSpaces : string -> string
+    abstract NormalizeBlanksToSpaces: string -> string
 
     /// Put the specified StringData at the given point.
-    abstract Put : SnapshotPoint -> StringData -> OperationKind -> unit
+    abstract Put: SnapshotPoint -> StringData -> OperationKind -> unit
 
     /// Raise the error / warning messages for the given SearchResult
-    abstract RaiseSearchResultMessage : SearchResult -> unit
+    abstract RaiseSearchResultMessage: SearchResult -> unit
 
     /// Redo the buffer changes "count" times
-    abstract Redo : count:int -> unit
+    abstract Redo: count:int -> unit
 
     /// Scrolls the number of lines given and keeps the caret in the view
-    abstract ScrollLines : ScrollDirection -> count:int -> unit
+    abstract ScrollLines: ScrollDirection -> count:int -> unit
 
     /// Update the register with the specified value
-    abstract SetRegisterValue : name : RegisterName option -> operation : RegisterOperation -> value : RegisterValue -> unit
+    abstract SetRegisterValue: name: RegisterName option -> operation: RegisterOperation -> value: RegisterValue -> unit
 
     /// Shift the block of lines to the left by shiftwidth * 'multiplier'
-    abstract ShiftLineBlockLeft : SnapshotSpan seq -> multiplier : int -> unit
+    abstract ShiftLineBlockLeft: SnapshotSpan seq -> multiplier: int -> unit
 
     /// Shift the block of lines to the right by shiftwidth * 'multiplier'
-    abstract ShiftLineBlockRight : SnapshotSpan seq -> multiplier : int -> unit
+    abstract ShiftLineBlockRight: SnapshotSpan seq -> multiplier: int -> unit
 
     /// Shift the given line range left by shiftwidth * 'multiplier'
-    abstract ShiftLineRangeLeft : SnapshotLineRange -> multiplier : int -> unit
+    abstract ShiftLineRangeLeft: SnapshotLineRange -> multiplier: int -> unit
 
     /// Shift the given line range right by shiftwidth * 'multiplier'
-    abstract ShiftLineRangeRight : SnapshotLineRange -> multiplier : int -> unit
+    abstract ShiftLineRangeRight: SnapshotLineRange -> multiplier: int -> unit
 
     /// Substitute Command implementation
-    abstract Substitute : pattern : string -> replace : string -> SnapshotLineRange -> flags : SubstituteFlags -> unit
+    abstract Substitute: pattern: string -> replace: string -> SnapshotLineRange -> flags: SubstituteFlags -> unit
 
     /// Undo the buffer changes "count" times
-    abstract Undo : count : int -> unit
+    abstract Undo: count: int -> unit
 
 /// Factory for getting ICommonOperations instances
 type ICommonOperationsFactory =
 
     /// Get the ICommonOperations instance for this IVimBuffer
-    abstract GetCommonOperations : IVimBufferData -> ICommonOperations
+    abstract GetCommonOperations: IVimBufferData -> ICommonOperations
 
 /// This interface is used to prevent the transition from insert to visual mode
 /// when a selection occurs.  In the majority case a selection of text should result
@@ -484,7 +484,7 @@ type ICommonOperationsFactory =
 type IVisualModeSelectionOverride =
 
     /// Is insert mode preferred for the current state of the buffer
-    abstract IsInsertModePreferred : textView : ITextView -> bool
+    abstract IsInsertModePreferred: textView: ITextView -> bool
 
 /// What source should the synchronizer use as the original settings?  The values
 /// in the selected source will be copied over the other settings
@@ -495,41 +495,41 @@ type SettingSyncSource =
 
  [<Struct>]
  type SettingSyncData = {
-    EditorOptionKey : string 
+    EditorOptionKey: string 
     GetEditorValue: IEditorOptions -> SettingValue option
-    VimSettingName : string
-    GetVimSettingValue : IVimBuffer -> obj
-    IsLocal : bool
+    VimSettingName: string
+    GetVimSettingValue: IVimBuffer -> obj
+    IsLocal: bool
 } with
 
     member x.IsWindow = not x.IsLocal
 
     member x.GetSettings vimBuffer = SettingSyncData.GetSettingsCore vimBuffer x.IsLocal
 
-    static member private GetSettingsCore (vimBuffer : IVimBuffer) isLocal = 
+    static member private GetSettingsCore (vimBuffer: IVimBuffer) isLocal = 
         if isLocal then vimBuffer.LocalSettings :> IVimSettings
         else vimBuffer.WindowSettings :> IVimSettings
 
-    static member GetBoolValueFunc (editorOptionKey : EditorOptionKey<bool>) = 
+    static member GetBoolValueFunc (editorOptionKey: EditorOptionKey<bool>) = 
         (fun editorOptions -> 
             match EditorOptionsUtil.GetOptionValue editorOptions editorOptionKey with
             | None -> None
             | Some value -> SettingValue.Toggle value |> Some)
 
-    static member GetNumberValueFunc (editorOptionKey : EditorOptionKey<int>) = 
+    static member GetNumberValueFunc (editorOptionKey: EditorOptionKey<int>) = 
         (fun editorOptions -> 
             match EditorOptionsUtil.GetOptionValue editorOptions editorOptionKey with
             | None -> None
             | Some value -> SettingValue.Number value |> Some)
 
-    static member GetStringValue (editorOptionKey : EditorOptionKey<string>) = 
+    static member GetStringValue (editorOptionKey: EditorOptionKey<string>) = 
         (fun editorOptions -> 
             match EditorOptionsUtil.GetOptionValue editorOptions editorOptionKey with
             | None -> None
             | Some value -> SettingValue.String value |> Some)
 
     static member GetSettingValueFunc name isLocal =
-        (fun (vimBuffer : IVimBuffer) ->
+        (fun (vimBuffer: IVimBuffer) ->
             let settings = SettingSyncData.GetSettingsCore vimBuffer isLocal
             match settings.GetSetting name with
             | None -> null
@@ -539,7 +539,7 @@ type SettingSyncSource =
                 | SettingValue.Toggle value -> box value
                 | SettingValue.Number value -> box value)
 
-    static member Create (key : EditorOptionKey<'T>) (settingName : string) (isLocal : bool) (convertEditorValue : Func<'T, SettingValue>) (convertSettingValue : Func<SettingValue, obj>) =
+    static member Create (key: EditorOptionKey<'T>) (settingName: string) (isLocal: bool) (convertEditorValue: Func<'T, SettingValue>) (convertSettingValue: Func<SettingValue, obj>) =
         {
             EditorOptionKey = key.Name
             GetEditorValue = (fun editorOptions ->
@@ -565,7 +565,7 @@ type IEditorToSettingsSynchronizer =
     ///
     /// This method can be called multiple times for the same IVimBuffer and it 
     /// will only synchronize once 
-    abstract StartSynchronizing : vimBuffer : IVimBuffer -> source : SettingSyncSource -> unit
+    abstract StartSynchronizing: vimBuffer: IVimBuffer -> source: SettingSyncSource -> unit
 
-    abstract SyncSetting : data : SettingSyncData -> unit
+    abstract SyncSetting: data: SettingSyncData -> unit
 

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -8,8 +8,8 @@ open System.Text.RegularExpressions
 
 type internal CommandMode
     ( 
-        _buffer : IVimBuffer, 
-        _operations : ICommonOperations
+        _buffer: IVimBuffer, 
+        _operations: ICommonOperations
     ) =
 
     let _commandChangedEvent = StandardEvent()
@@ -21,13 +21,13 @@ type internal CommandMode
     // Command to show when entering command from Visual Mode
     static let FromVisualModeString = "'<,'>"
 
-    static let BindDataError : BindData<int> = {
+    static let BindDataError: BindData<int> = {
         KeyRemapMode = KeyRemapMode.None;
         BindFunction = fun _ -> BindResult.Error
     }
 
     let mutable _command = StringUtil.Empty
-    let mutable _historySession : IHistorySession<int, int> option = None
+    let mutable _historySession: IHistorySession<int, int> option = None
     let mutable _bindData = BindDataError
     let mutable _keepSelection = false
 
@@ -44,7 +44,7 @@ type internal CommandMode
         | Some historySession -> historySession.InPasteWait
         | None -> false
 
-    member x.ParseAndRunInput (command : string) = 
+    member x.ParseAndRunInput (command: string) = 
         let command = 
             if command.Length > 0 && command.[0] = ':' then
                 command.Substring(1)
@@ -73,7 +73,7 @@ type internal CommandMode
             else 
                 selection.Clear()
 
-    member x.Process (keyInput : KeyInput) =
+    member x.Process (keyInput: KeyInput) =
 
         match _bindData.BindFunction keyInput with
         | BindResult.Complete _ ->

--- a/Src/VimCore/Modes_Command_CommandMode.fsi
+++ b/Src/VimCore/Modes_Command_CommandMode.fsi
@@ -6,5 +6,5 @@ open Vim.Interpreter
 
 type internal CommandMode =
     interface ICommandMode
-    new : IVimBuffer * ICommonOperations -> CommandMode
+    new: IVimBuffer * ICommonOperations -> CommandMode
     

--- a/Src/VimCore/Modes_Insert_Components.fs
+++ b/Src/VimCore/Modes_Insert_Components.fs
@@ -11,31 +11,31 @@ open Vim
 type internal ITextChangeTracker =
 
     /// Associated ITextView
-    abstract TextView : ITextView
+    abstract TextView: ITextView
 
     /// Whether or not change tracking is currently enabled.  Disabling the tracking will
     /// cause the current change to be completed
-    abstract TrackCurrentChange : bool with get, set
+    abstract TrackCurrentChange: bool with get, set
 
     /// Current change
-    abstract CurrentChange : TextChange option
+    abstract CurrentChange: TextChange option
 
     /// Complete the current change if there is one
-    abstract CompleteChange : unit -> unit
+    abstract CompleteChange: unit -> unit
 
     /// Clear out the current change without completing it
-    abstract ClearChange : unit -> unit
+    abstract ClearChange: unit -> unit
 
     /// Raised when a change is completed
     [<CLIEvent>]
-    abstract ChangeCompleted : IDelegateEvent<System.EventHandler<TextChangeEventArgs>>
+    abstract ChangeCompleted: IDelegateEvent<System.EventHandler<TextChangeEventArgs>>
 
 /// Used to track changes to an individual IVimBuffer
 type internal TextChangeTracker
     ( 
-        _vimTextBuffer : IVimTextBuffer,
-        _textView : ITextView,
-        _operations : ICommonOperations
+        _vimTextBuffer: IVimTextBuffer,
+        _textView: ITextView,
+        _operations: ICommonOperations
     ) as this =
 
     static let Key = System.Object()
@@ -44,7 +44,7 @@ type internal TextChangeTracker
     let _changeCompletedEvent = StandardEvent<TextChangeEventArgs>()
 
     /// Tracks the current active text change.  This will grow as the user edits
-    let mutable _currentTextChange : (TextChange * ITextChange) option = None
+    let mutable _currentTextChange: (TextChange * ITextChange) option = None
 
     /// Whether or not tracking is currently enabled
     let mutable _trackCurrentChange = false
@@ -88,7 +88,7 @@ type internal TextChangeTracker
 
     /// Convert the ITextChange value into a TextChange instance.  This will not handle any special 
     /// edit patterns and simply does a raw adjustment
-    member x.ConvertBufferChange (beforeSnapshot : ITextSnapshot) (change : ITextChange) =
+    member x.ConvertBufferChange (beforeSnapshot: ITextSnapshot) (change: ITextChange) =
 
         let convert () = 
 
@@ -130,14 +130,14 @@ type internal TextChangeTracker
         else 
             convert ()
 
-    member x.OnTextChanged (args : TextContentChangedEventArgs) = 
+    member x.OnTextChanged (args: TextContentChangedEventArgs) = 
 
         if x.TrackCurrentChange then
             x.UpdateCurrentChange args
 
         x.UpdateLastEditPoint args
 
-    member x.UpdateCurrentChange (args : TextContentChangedEventArgs) = 
+    member x.UpdateCurrentChange (args: TextContentChangedEventArgs) = 
 
         // At this time we only support contiguous changes (or rather a single change)
         if args.Changes.Count = 1 then
@@ -153,7 +153,7 @@ type internal TextChangeTracker
     /// Update the last edit point based on the latest change to the ITextBuffer.  Note that 
     /// this isn't necessarily a vim originated edit.  Can be done by another Visual Studio
     /// operation but we still treat it like a Vim edit
-    member x.UpdateLastEditPoint (args : TextContentChangedEventArgs) = 
+    member x.UpdateLastEditPoint (args: TextContentChangedEventArgs) = 
 
         if args.Changes.Count = 1 then
             let change = args.Changes.Item(0)
@@ -170,7 +170,7 @@ type internal TextChangeTracker
             _vimTextBuffer.LastEditPoint <- None
 
     /// Attempt to merge the change operations together
-    member x.MergeChange oldTextChange (oldChange : ITextChange) newTextChange (newChange : ITextChange) =
+    member x.MergeChange oldTextChange (oldChange: ITextChange) newTextChange (newChange: ITextChange) =
 
         // First step is to determine if we can merge the changes.  Essentially we need to ensure that
         // the changes are occurring at the same point in the ITextBuffer 
@@ -201,7 +201,7 @@ type internal TextChangeTracker
             x.CompleteChange()
             _currentTextChange <- Some (newTextChange, newChange)
 
-    static member GetTextChangeTracker (bufferData : IVimBufferData) (commonOperationsFactory : ICommonOperationsFactory) =
+    static member GetTextChangeTracker (bufferData: IVimBufferData) (commonOperationsFactory: ICommonOperationsFactory) =
         let textView = bufferData.TextView
         textView.Properties.GetOrCreateSingletonProperty(Key, (fun () -> 
             let operations = commonOperationsFactory.GetCommonOperations bufferData

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -12,8 +12,8 @@ open System.Collections.Generic
 
 type WordCompletionUtil
     (
-        _vim : IVim,
-        _wordUtil : IWordUtil
+        _vim: IVim,
+        _wordUtil: IWordUtil
     ) =
 
     let _globalSettings = _vim.GlobalSettings
@@ -23,11 +23,11 @@ type WordCompletionUtil
     ///
     /// This method will be called for every single word in the file hence avoid allocations whenever
     /// possible.  That dramatically reduces the allocations
-    static member private GetFilterFunc (filterText : string) (comparer : CharComparer) =
+    static member private GetFilterFunc (filterText: string) (comparer: CharComparer) =
 
         // Is this actually a word we're interest in.  Need to clear out new lines, 
         // comment characters, one character items, etc ... 
-        let isWord (span : SnapshotSpan) =
+        let isWord (span: SnapshotSpan) =
             if span.Length = 0 || span.Length = 1 then
                 false
             else
@@ -35,7 +35,7 @@ type WordCompletionUtil
                 TextUtil.IsWordChar WordKind.NormalWord c
 
         // Is this span a match for the filter text? 
-        let isMatch (span : SnapshotSpan) =
+        let isMatch (span: SnapshotSpan) =
             if span.Length < filterText.Length then
                 false
             else
@@ -56,7 +56,7 @@ type WordCompletionUtil
             isMatch
 
     /// Get the word completions for the given word text in the ITextBuffer
-    member private x.GetWordCompletionsCore (wordSpan : SnapshotSpan) (comparer : CharComparer) =
+    member private x.GetWordCompletionsCore (wordSpan: SnapshotSpan) (comparer: CharComparer) =
         // Get the sequence of words before the completion word 
         let snapshot = wordSpan.Snapshot
         let wordsBefore = 
@@ -88,14 +88,14 @@ type WordCompletionUtil
 
     /// Get the word completion entries in the specified ITextSnapshot.  If the token is cancelled the 
     /// exception will be propagated out of this method.  This method will return duplicate words too
-    member private x.GetWordCompletionsInFile (filterText : string) comparer (snapshot : ITextSnapshot) =
+    member private x.GetWordCompletionsInFile (filterText: string) comparer (snapshot: ITextSnapshot) =
         let filterFunc = WordCompletionUtil.GetFilterFunc filterText comparer
         let startPoint = SnapshotPoint(snapshot, 0) 
         startPoint
         |> _wordUtil.GetWords WordKind.NormalWord SearchPath.Forward
         |> Seq.filter filterFunc
 
-    member x.GetWordCompletions (wordSpan : SnapshotSpan) =
+    member x.GetWordCompletions (wordSpan: SnapshotSpan) =
         let comparer = if _globalSettings.IgnoreCase then CharComparer.IgnoreCase else CharComparer.Exact
         let filterText = wordSpan.GetText()
         let fileCompletions = x.GetWordCompletionsCore wordSpan comparer 
@@ -108,7 +108,7 @@ type WordCompletionUtil
             |> Seq.collect (fun snapshot -> x.GetWordCompletionsInFile filterText comparer snapshot)
 
         let wordSpanStart = wordSpan.Start.Position
-        let sortComparer (x : SnapshotSpan) (y : SnapshotSpan) = 
+        let sortComparer (x: SnapshotSpan) (y: SnapshotSpan) = 
             let xPos = x.Start.Position
             let yPos = y.Start.Position
             if x.Snapshot.TextBuffer = fileTextBuffer && y.Snapshot.TextBuffer = fileTextBuffer then
@@ -185,16 +185,16 @@ type ActiveEditItem =
 type InsertSessionData = {
 
     /// The transaction bracketing the edits of this session
-    Transaction : ILinkedUndoTransaction option
+    Transaction: ILinkedUndoTransaction option
 
     /// The kind of insert we are currently performing
-    InsertKind : InsertKind
+    InsertKind: InsertKind
 
     /// This is the current InsertCommand being built up
-    CombinedEditCommand : InsertCommand option
+    CombinedEditCommand: InsertCommand option
 
     /// The Active edit item 
-    ActiveEditItem : ActiveEditItem
+    ActiveEditItem: ActiveEditItem
 }
 
 [<RequireQualifiedAccess>]
@@ -204,21 +204,21 @@ type RawInsertCommand =
 
 type internal InsertMode
     ( 
-        _vimBuffer : IVimBuffer, 
-        _operations : ICommonOperations,
-        _broker : IDisplayWindowBroker, 
-        _editorOptions : IEditorOptions,
-        _undoRedoOperations : IUndoRedoOperations,
-        _textChangeTracker : ITextChangeTracker,
-        _insertUtil : IInsertUtil,
-        _motionUtil : IMotionUtil,
-        _commandUtil : ICommandUtil,
-        _capture : IMotionCapture,
-        _isReplace : bool,
-        _keyboard : IKeyboardDevice,
-        _mouse : IMouseDevice,
-        _wordUtil : IWordUtil,
-        _wordCompletionSessionFactoryService : IWordCompletionSessionFactoryService
+        _vimBuffer: IVimBuffer, 
+        _operations: ICommonOperations,
+        _broker: IDisplayWindowBroker, 
+        _editorOptions: IEditorOptions,
+        _undoRedoOperations: IUndoRedoOperations,
+        _textChangeTracker: ITextChangeTracker,
+        _insertUtil: IInsertUtil,
+        _motionUtil: IMotionUtil,
+        _commandUtil: ICommandUtil,
+        _capture: IMotionCapture,
+        _isReplace: bool,
+        _keyboard: IKeyboardDevice,
+        _mouse: IMouseDevice,
+        _wordUtil: IWordUtil,
+        _wordCompletionSessionFactoryService: IWordCompletionSessionFactoryService
     ) as this =
 
     static let _emptySessionData = {
@@ -269,7 +269,7 @@ type internal InsertMode
     let _editorOperations = _operations.EditorOperations
     let _commandRanEvent = StandardEvent<CommandRunDataEventArgs>()
     let _wordCompletionUtil = WordCompletionUtil(_vimBuffer.Vim, _wordUtil)
-    let mutable _commandMap : Map<KeyInput, RawInsertCommand> = Map.empty
+    let mutable _commandMap: Map<KeyInput, RawInsertCommand> = Map.empty
     let mutable _sessionData = _emptySessionData
     let mutable _isInProcess = false
 
@@ -298,7 +298,7 @@ type internal InsertMode
     member x.BuildCommands () =
 
         // These commands have nothing to do with selection settings
-        let regularCommands : (KeyInput * RawInsertCommand) seq =
+        let regularCommands: (KeyInput * RawInsertCommand) seq =
             [|
                 ("<Esc>", RawInsertCommand.CustomCommand this.ProcessEscape)
                 ("<Insert>", RawInsertCommand.CustomCommand this.ProcessInsert)
@@ -312,7 +312,7 @@ type internal InsertMode
                 let keyInput = KeyNotationUtil.StringToKeyInput text
                 (keyInput, rawInsertCommand))
 
-        let noSelectionCommands : (KeyInput * InsertCommand * CommandFlags) seq =
+        let noSelectionCommands: (KeyInput * InsertCommand * CommandFlags) seq =
             [|
                 ("<S-Left>", InsertCommand.MoveCaretByWord Direction.Left, CommandFlags.Movement)
                 ("<S-Right>", InsertCommand.MoveCaretByWord Direction.Right, CommandFlags.Movement)
@@ -325,7 +325,7 @@ type internal InsertMode
         ///
         /// TODO: Because insert mode does not yet use a command runner, we have
         /// to simulate a little mini-runner here.  Should this be upgraded?
-        let selectionCommands : (KeyInput * RawInsertCommand) seq =
+        let selectionCommands: (KeyInput * RawInsertCommand) seq =
 
             // Create a command factory so we can access the selection commands
             let factory = CommandFactory(_operations, _capture)
@@ -362,7 +362,7 @@ type internal InsertMode
 
         // Map all of the InsertCommand values to their RawInsertCommand counterpart 
         // Create a list of 
-        let mappedInsertCommands : (KeyInput * RawInsertCommand) seq = 
+        let mappedInsertCommands: (KeyInput * RawInsertCommand) seq = 
             InsertCommandDataArray
             |> Seq.append applicableNoSelectionCommands
             |> Seq.map (fun (keyInput, insertCommand, commandFlags) ->
@@ -489,7 +489,7 @@ type internal InsertMode
     /// Is this KeyInput a raw text insert into the ITextBuffer.  Anything that would be 
     /// processed by adding characters to the ITextBuffer.  This is anything which has an
     /// associated character that is not an insert mode command
-    member x.IsDirectInsert (keyInput : KeyInput) = 
+    member x.IsDirectInsert (keyInput: KeyInput) = 
         match x.GetRawInsertCommand keyInput with
         | None -> false
         | Some rawInsertCommand ->
@@ -662,7 +662,7 @@ type internal InsertMode
             | _ -> InsertCommand.Combined (left, right)
 
     /// Run the insert command with the given information
-    member x.RunInsertCommand (command : InsertCommand) (keyInputSet : KeyInputSet) commandFlags : ProcessResult =
+    member x.RunInsertCommand (command: InsertCommand) (keyInputSet: KeyInputSet) commandFlags: ProcessResult =
 
         // Dismiss the completion when running an explicit insert commend
         x.CancelWordCompletionSession()
@@ -716,7 +716,7 @@ type internal InsertMode
     /// TODO: Right now PasteFlags are ignored.  With better formatting support these should
     /// be respected.  Since we let the host control formatting at this point there isn't a lot
     /// that can be done now
-    member x.Paste (keyInput : KeyInput) (flags : PasteFlags) = 
+    member x.Paste (keyInput: KeyInput) (flags: PasteFlags) = 
 
         let isOverwrite = _sessionData.ActiveEditItem = ActiveEditItem.OverwriteReplace
         _sessionData <- { _sessionData with ActiveEditItem = ActiveEditItem.None }
@@ -753,7 +753,7 @@ type internal InsertMode
     member x.ProcessWithCurrentChange keyInput = 
 
         // Actually try and process this with the current change 
-        let func (text : string) = 
+        let func (text: string) = 
             let data = 
                 if text.EndsWith("0") && keyInput = KeyInputUtil.CharWithControlToKeyInput 'd' then
                     let keyInputSet = KeyNotationUtil.StringToKeyInputSet "0<C-d>"
@@ -786,7 +786,7 @@ type internal InsertMode
 
     /// Called when we need to process a key stroke and an IWordCompletionSession
     /// is active.
-    member x.ProcessWithWordCompletionSession (wordCompletionSession : IWordCompletionSession) keyInput = 
+    member x.ProcessWithWordCompletionSession (wordCompletionSession: IWordCompletionSession) keyInput = 
         let handled = 
             if keyInput = KeyNotationUtil.StringToKeyInput("<C-n>") then
                 wordCompletionSession.MoveNext() |> Some
@@ -913,7 +913,7 @@ type internal InsertMode
         _vimBuffer.VimTextBuffer.InsertStartPoint <- Some x.CaretPoint
         _vimBuffer.VimTextBuffer.IsSoftTabStopValidForBackspace <- true
 
-    member x.OnAfterRunInsertCommand (insertCommand : InsertCommand) =
+    member x.OnAfterRunInsertCommand (insertCommand: InsertCommand) =
 
         // If the user typed a <Space> then 'sts' shouldn't be considered for <BS> operations
         // until the start point is reset 
@@ -944,7 +944,7 @@ type internal InsertMode
     /// Raised on the completion of a TextChange event.  This event is not raised immediately
     /// and instead is added to the CombinedEditCommand value for this session which will be 
     /// raised as a command at a later time
-    member x.OnTextChangeCompleted (args : TextChangeEventArgs) =
+    member x.OnTextChangeCompleted (args: TextChangeEventArgs) =
 
         let textChange = args.TextChange
         let command = 
@@ -955,7 +955,7 @@ type internal InsertMode
             | Some command -> InsertCommand.Combined (command, textChangeCommand)
         x.ChangeCombinedEditCommand (Some command)
 
-    member x.ChangeCombinedEditCommand (command : InsertCommand option) =
+    member x.ChangeCombinedEditCommand (command: InsertCommand option) =
 
         let rec getText command = 
             match command with 
@@ -975,7 +975,7 @@ type internal InsertMode
         _sessionData <- { _sessionData with CombinedEditCommand = command } 
 
     /// Raised when a global setting is changed
-    member x.OnGlobalSettingsChanged (args : SettingEventArgs) =
+    member x.OnGlobalSettingsChanged (args: SettingEventArgs) =
 
         // The constructed command map depends on the value of the 'keymodel' setting so rebuild
         // if it ever changes 

--- a/Src/VimCore/Modes_Insert_InsertMode.fsi
+++ b/Src/VimCore/Modes_Insert_InsertMode.fsi
@@ -7,4 +7,4 @@ open Vim
 
 type internal InsertMode =
     interface IInsertMode
-    new : IVimBuffer * ICommonOperations * IDisplayWindowBroker * IEditorOptions * IUndoRedoOperations * ITextChangeTracker * IInsertUtil * IMotionUtil * ICommandUtil * IMotionCapture * bool * IKeyboardDevice * IMouseDevice * IWordUtil * IWordCompletionSessionFactoryService -> InsertMode
+    new: IVimBuffer * ICommonOperations * IDisplayWindowBroker * IEditorOptions * IUndoRedoOperations * ITextChangeTracker * IInsertUtil * IMotionUtil * ICommandUtil * IMotionCapture * bool * IKeyboardDevice * IMouseDevice * IWordUtil * IWordCompletionSessionFactoryService -> InsertMode

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -7,17 +7,17 @@ open Microsoft.VisualStudio.Text
 open Microsoft.VisualStudio.Text.Editor
 
 type internal NormalModeData = {
-    Command : string
-    InReplace : bool
+    Command: string
+    InReplace: bool
 }
 
 type internal NormalMode 
     ( 
-        _vimBufferData : IVimBufferData,
-        _operations : ICommonOperations,
-        _motionUtil : IMotionUtil,
-        _runner : ICommandRunner,
-        _capture : IMotionCapture
+        _vimBufferData: IVimBufferData,
+        _operations: ICommonOperations,
+        _motionUtil: IMotionUtil,
+        _runner: ICommandRunner,
+        _capture: IMotionCapture
     ) as this =
 
     let _vimTextBuffer = _vimBufferData.VimTextBuffer
@@ -40,7 +40,7 @@ type internal NormalMode
 
     /// This is the list of commands that have the same key binding as the selection 
     /// commands and run when keymodel doesn't have startsel as a value
-    let mutable _selectionAlternateCommands : CommandBinding list = List.empty
+    let mutable _selectionAlternateCommands: CommandBinding list = List.empty
 
     let _eventHandlers = DisposableBag()
 
@@ -172,9 +172,9 @@ type internal NormalMode
         Seq.append normalSeq motionSeq 
         |> List.ofSeq
 
-    let mutable _sharedSelectionCommands : List<CommandBinding> = List.empty
+    let mutable _sharedSelectionCommands: List<CommandBinding> = List.empty
 
-    let mutable _sharedSelectionCommandNameSet : Set<KeyInputSet> = Set.empty
+    let mutable _sharedSelectionCommandNameSet: Set<KeyInputSet> = Set.empty
 
     do
         // Up cast here to work around the F# bug which prevents accessing a CLIEvent from
@@ -245,7 +245,7 @@ type internal NormalMode
                 x.UpdateSelectionCommands()
 
     /// Raised when a global setting is changed
-    member x.OnGlobalSettingsChanged (args : SettingEventArgs) = 
+    member x.OnGlobalSettingsChanged (args: SettingEventArgs) = 
         if x.IsCommandRunnerPopulated then
             let setting = args.Setting
             if StringUtil.IsEqual setting.Name GlobalSettingNames.TildeOpName then
@@ -258,7 +258,7 @@ type internal NormalMode
         let func () = 
             _data <- { _data with InReplace = true }
 
-            let bind (keyInput : KeyInput) = 
+            let bind (keyInput: KeyInput) = 
                 _data <- { _data with InReplace = false }
                 match keyInput.Key with
                 | VimKey.Escape -> BindResult.Cancelled
@@ -273,7 +273,7 @@ type internal NormalMode
 
     /// Get a mark and us the provided 'func' to create a Motion value
     member x.BindMark func = 
-        let bindFunc (keyInput : KeyInput) =
+        let bindFunc (keyInput: KeyInput) =
             match Mark.OfChar keyInput.Char with
             | None -> BindResult<NormalCommand>.Error
             | Some localMark -> BindResult<_>.Complete (func localMark)
@@ -316,7 +316,7 @@ type internal NormalMode
         _runner.ResetState()
         _data <- EmptyData
 
-    member x.CanProcess (keyInput : KeyInput) =
+    member x.CanProcess (keyInput: KeyInput) =
         let doesCommandStartWith keyInput =
             let name = KeyInputSet.OneKeyInput keyInput
             _runner.Commands 
@@ -334,7 +334,7 @@ type internal NormalMode
         else 
             false
     
-    member x.Process (keyInput : KeyInput) = 
+    member x.Process (keyInput: KeyInput) = 
 
         // Update the text of the command so long as this isn't a control character 
         if not (CharUtil.IsControl keyInput.Char) then

--- a/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
+++ b/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
@@ -10,27 +10,27 @@ open System.Text.RegularExpressions
 type ConfirmData = { 
 
     /// This is the regex which is being matched
-    Regex : VimRegex
+    Regex: VimRegex
 
     /// The replacement text
-    SubstituteText : string
+    SubstituteText: string
 
     /// This is the current SnapshotSpan which is presented to the user for replacement
-    CurrentMatch : SnapshotSpan 
+    CurrentMatch: SnapshotSpan 
 
     /// This is the last line number on which the substitute should occur
-    LastLineNumber : int
+    LastLineNumber: int
 
     /// Is this a replace all operation? 
-    IsReplaceAll : bool
+    IsReplaceAll: bool
 }
 
 type ConfirmAction = ConfirmData -> ModeSwitch 
 
 type internal SubstituteConfirmMode
     (
-        _vimBufferData : IVimBufferData,
-        _operations : ICommonOperations
+        _vimBufferData: IVimBufferData,
+        _operations: ICommonOperations
     ) as this = 
 
     let _vimTextBuffer = _vimBufferData.VimTextBuffer
@@ -40,8 +40,8 @@ type internal SubstituteConfirmMode
     let _editorOperations = _operations.EditorOperations
     let _registerMap = _vimBufferData.Vim.RegisterMap
     let _currentMatchChanged = Event<_>()
-    let mutable _commandMap : Map<KeyInput, ConfirmAction> = Map.empty
-    let mutable _confirmData : ConfirmData option = None
+    let mutable _commandMap: Map<KeyInput, ConfirmAction> = Map.empty
+    let mutable _confirmData: ConfirmData option = None
 
     do
         let add keyInput func = 
@@ -65,7 +65,7 @@ type internal SubstituteConfirmMode
 
     member x.CurrentSnapshot = _textBuffer.CurrentSnapshot
 
-    member x.CanProcess (keyInput : KeyInput) = not keyInput.IsMouseKey
+    member x.CanProcess (keyInput: KeyInput) = not keyInput.IsMouseKey
 
     member x.CaretPoint = TextViewUtil.GetCaretPoint _textView
 
@@ -103,7 +103,7 @@ type internal SubstituteConfirmMode
         ModeSwitch.SwitchMode ModeKind.Normal
 
     /// Move to the next match given provided ConfirmData 
-    member x.MoveToNext (data : ConfirmData) = 
+    member x.MoveToNext (data: ConfirmData) = 
 
         // First we need to get the point after the Current selection.  This function
         // is called after edits so it's possible the Snapshot is different.

--- a/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fsi
+++ b/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fsi
@@ -5,7 +5,7 @@ open Vim
 open Vim.Modes
 
 type internal SubstituteConfirmMode =
-    new : IVimBufferData * ICommonOperations -> SubstituteConfirmMode
+    new: IVimBufferData * ICommonOperations -> SubstituteConfirmMode
 
     interface ISubstituteConfirmMode
 

--- a/Src/VimCore/Modes_Visual_ISelectionTracker.fs
+++ b/Src/VimCore/Modes_Visual_ISelectionTracker.fs
@@ -9,24 +9,24 @@ open Microsoft.VisualStudio.Text
 type ISelectionTracker = 
 
     /// Visual Kind this ISelectionTracker is tracking
-    abstract VisualKind : VisualKind
+    abstract VisualKind: VisualKind
 
     /// Is the selection currently being tracked
-    abstract IsRunning : bool 
+    abstract IsRunning: bool 
 
     /// Update the selection based on the current position of the caret or the active
     /// incremental search
-    abstract UpdateSelection : unit -> unit
+    abstract UpdateSelection: unit -> unit
 
     /// Reset the selection with the given anchor point 
-    abstract UpdateSelectionWithAnchorPoint : anchorPoint : SnapshotPoint -> unit
+    abstract UpdateSelectionWithAnchorPoint: anchorPoint: SnapshotPoint -> unit
 
     /// Start tracking the selection
-    abstract Start : unit -> unit
+    abstract Start: unit -> unit
 
     /// Reset the selection and stop tracking
-    abstract Stop : unit -> unit
+    abstract Stop: unit -> unit
 
     /// Record the caret tracking point
-    abstract RecordCaretTrackingPoint : ModeArgument -> unit
+    abstract RecordCaretTrackingPoint: ModeArgument -> unit
 

--- a/Src/VimCore/Modes_Visual_SelectMode.fs
+++ b/Src/VimCore/Modes_Visual_SelectMode.fs
@@ -7,14 +7,14 @@ open Vim.Modes
 
 type internal SelectMode
     (
-        _vimBufferData : IVimBufferData,
-        _commonOperations : ICommonOperations,
-        _motionUtil : IMotionUtil,
-        _visualKind : VisualKind,
-        _runner : ICommandRunner,
-        _capture : IMotionCapture,
-        _undoRedoOperations : IUndoRedoOperations,
-        _selectionTracker : ISelectionTracker
+        _vimBufferData: IVimBufferData,
+        _commonOperations: ICommonOperations,
+        _motionUtil: IMotionUtil,
+        _visualKind: VisualKind,
+        _runner: ICommandRunner,
+        _capture: IMotionCapture,
+        _undoRedoOperations: IUndoRedoOperations,
+        _selectionTracker: ISelectionTracker
     ) = 
 
     let _globalSettings = _vimBufferData.LocalSettings.GlobalSettings
@@ -43,7 +43,7 @@ type internal SelectMode
 
     /// A 'special key' is defined in :help keymodel as any of the following keys.  Depending
     /// on the value of the keymodel setting they can affect the selection
-    static let GetCaretMovement (keyInput : KeyInput) =
+    static let GetCaretMovement (keyInput: KeyInput) =
         if not (Util.IsFlagSet keyInput.KeyModifiers VimKeyModifiers.Control) then
             match keyInput.Key with
             | VimKey.Up -> Some CaretMovement.Up
@@ -66,7 +66,7 @@ type internal SelectMode
             | _ -> None
 
     /// Whether a key input corresponds to normal text
-    static let IsTextKeyInput (keyInput : KeyInput) =
+    static let IsTextKeyInput (keyInput: KeyInput) =
         Option.isSome keyInput.RawChar && not (CharUtil.IsControl keyInput.Char)
 
     let mutable _builtCommands = false
@@ -84,7 +84,7 @@ type internal SelectMode
     member x.EnsureCommandsBuilt() =
 
         /// Whether a command is bound to a key that is not insertable text
-        let isNonTextCommand (command : CommandBinding) =
+        let isNonTextCommand (command: CommandBinding) =
             match command.KeyInputSet.FirstKeyInput with
             | None ->
                 true
@@ -109,7 +109,7 @@ type internal SelectMode
 
     member x.CurrentSnapshot = _textView.TextSnapshot
 
-    member x.ShouldStopSelection (keyInput : KeyInput) =
+    member x.ShouldStopSelection (keyInput: KeyInput) =
         let hasShift = Util.IsFlagSet keyInput.KeyModifiers VimKeyModifiers.Shift
         let hasStopSelection = Util.IsFlagSet _globalSettings.KeyModelOptions KeyModelOptions.StopSelection
         not hasShift && hasStopSelection
@@ -130,7 +130,7 @@ type internal SelectMode
     /// transaction
     member x.ProcessInput text linked =
 
-        let replaceSelection (span : SnapshotSpan) text =
+        let replaceSelection (span: SnapshotSpan) text =
             _undoRedoOperations.EditWithUndoTransaction "Replace" _textView <| fun () ->
 
                 use edit = _textBuffer.CreateEdit()
@@ -172,7 +172,7 @@ type internal SelectMode
 
     /// Select Mode doesn't actually process any mouse keys.  Actual mouse events for
     /// selection are handled by the selection tracker 
-    member x.CanProcess (keyInput : KeyInput) = not keyInput.IsMouseKey
+    member x.CanProcess (keyInput: KeyInput) = not keyInput.IsMouseKey
 
     member x.Process keyInput = 
 

--- a/Src/VimCore/Modes_Visual_SelectMode.fsi
+++ b/Src/VimCore/Modes_Visual_SelectMode.fsi
@@ -7,5 +7,5 @@ open Vim.Modes
 
 type internal SelectMode =
     interface ISelectMode
-    new : IVimBufferData * ICommonOperations * IMotionUtil * VisualKind * ICommandRunner * IMotionCapture * IUndoRedoOperations * ISelectionTracker -> SelectMode
+    new: IVimBufferData * ICommonOperations * IMotionUtil * VisualKind * ICommandRunner * IMotionCapture * IUndoRedoOperations * ISelectionTracker -> SelectMode
 

--- a/Src/VimCore/Modes_Visual_SelectionTracker.fs
+++ b/Src/VimCore/Modes_Visual_SelectionTracker.fs
@@ -9,9 +9,9 @@ open Vim
 /// Responsible for tracking and updating the selection while we are in visual mode
 type internal SelectionTracker
     (
-        _vimBufferData : IVimBufferData,
-        _incrementalSearch : IIncrementalSearch,
-        _visualKind : VisualKind
+        _vimBufferData: IVimBufferData,
+        _incrementalSearch: IIncrementalSearch,
+        _visualKind: VisualKind
     ) as this =
 
     let _textView = _vimBufferData.TextView
@@ -21,14 +21,14 @@ type internal SelectionTracker
 
     /// The anchor point we are currently tracking.  This is always included in the selection which
     /// is created by this type 
-    let mutable _anchorPoint : SnapshotPoint option = None
+    let mutable _anchorPoint: SnapshotPoint option = None
 
     /// Should the selection be extended into the line break 
-    let mutable _extendIntoLineBreak : bool = false
+    let mutable _extendIntoLineBreak: bool = false
 
     /// When we are in the middle of an incremental search this will 
     /// track the most recent search result
-    let mutable _lastIncrementalSearchResult : SearchResult option = None
+    let mutable _lastIncrementalSearchResult: SearchResult option = None
 
     let mutable _textChangedHandler = ToggleHandler.Empty
     do 
@@ -156,7 +156,7 @@ type internal SelectionTracker
 
     /// When the text is changed it invalidates the anchor point.  It needs to be forwarded to
     /// the next version of the buffer.  If it's not present then just go to point 0
-    member x.OnTextChanged (args : TextContentChangedEventArgs) =
+    member x.OnTextChanged (args: TextContentChangedEventArgs) =
         match _anchorPoint with
         | None -> ()
         | Some anchorPoint ->

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -9,13 +9,13 @@ open Vim.Modes
 
 type internal VisualMode
     (
-        _vimBufferData : IVimBufferData,
-        _operations : ICommonOperations,
-        _motionUtil : IMotionUtil,
-        _visualKind : VisualKind,
-        _runner : ICommandRunner,
-        _capture : IMotionCapture,
-        _selectionTracker : ISelectionTracker
+        _vimBufferData: IVimBufferData,
+        _operations: ICommonOperations,
+        _motionUtil: IMotionUtil,
+        _visualKind: VisualKind,
+        _runner: ICommandRunner,
+        _capture: IMotionCapture,
+        _selectionTracker: ISelectionTracker
     ) = 
 
     let _vimTextBuffer = _vimBufferData.VimTextBuffer
@@ -31,7 +31,7 @@ type internal VisualMode
 
     /// Get a mark and use the provided 'func' to create a Motion value
     static let BindMark func = 
-        let bindFunc (keyInput : KeyInput) =
+        let bindFunc (keyInput: KeyInput) =
             match Mark.OfChar keyInput.Char with
             | None -> BindResult<NormalCommand>.Error
             | Some localMark -> BindResult<_>.Complete (func localMark)
@@ -137,7 +137,7 @@ type internal VisualMode
 
     /// Visual Mode doesn't actually process any mouse keys.  Actual mouse events for
     /// selection are handled by the selection tracker 
-    member x.CanProcess (keyInput : KeyInput) = not keyInput.IsMouseKey
+    member x.CanProcess (keyInput: KeyInput) = not keyInput.IsMouseKey
 
     member x.CommandNames = 
         x.EnsureCommandsBuilt()
@@ -180,7 +180,7 @@ type internal VisualMode
         _runner.ResetState()
         _selectionTracker.Stop()
 
-    member x.Process (ki : KeyInput) =  
+    member x.Process (ki: KeyInput) =  
 
         // Save the VisualSelection before executing the command.  Many commands which exit
         // visual mode such as 'y' change the selection during execution.  We want to restore

--- a/Src/VimCore/Modes_Visual_VisualMode.fsi
+++ b/Src/VimCore/Modes_Visual_VisualMode.fsi
@@ -9,4 +9,4 @@ open Vim.Modes
 
 type internal VisualMode =
     interface IVisualMode
-    new : IVimBufferData * ICommonOperations * IMotionUtil * VisualKind * ICommandRunner * IMotionCapture * ISelectionTracker -> VisualMode
+    new: IVimBufferData * ICommonOperations * IMotionUtil * VisualKind * ICommandRunner * IMotionCapture * ISelectionTracker -> VisualMode

--- a/Src/VimCore/MotionCapture.fs
+++ b/Src/VimCore/MotionCapture.fs
@@ -6,8 +6,8 @@ open Microsoft.VisualStudio.Text.Editor;
 
 type internal MotionCapture 
     (
-        _vimBufferData : IVimBufferData,
-        _incrementalSearch : IIncrementalSearch
+        _vimBufferData: IVimBufferData,
+        _incrementalSearch: IIncrementalSearch
     ) = 
 
     let _textView = _vimBufferData.TextView
@@ -15,7 +15,7 @@ type internal MotionCapture
     let _localSettings = _vimBufferData.LocalSettings
 
     static let SharedMotions =  
-        let motionSeq : (string * MotionFlags * Motion) seq = 
+        let motionSeq: (string * MotionFlags * Motion) seq = 
             seq { 
                 yield ("ab", MotionFlags.TextObject ||| MotionFlags.TextObjectWithAlwaysCharacter, Motion.AllBlock BlockKind.Paren)
                 yield ("aB", MotionFlags.TextObject ||| MotionFlags.TextObjectWithAlwaysCharacter, Motion.AllBlock BlockKind.CurlyBracket)
@@ -140,7 +140,7 @@ type internal MotionCapture
 
     /// Get a local mark and us the provided 'func' to create a Motion value
     let GetLocalMark func = 
-        let bindFunc (keyInput : KeyInput) =
+        let bindFunc (keyInput: KeyInput) =
             match LocalMark.OfChar keyInput.Char with
             | None -> BindResult<Motion>.Error
             | Some localMark -> BindResult<_>.Complete (func localMark)
@@ -170,7 +170,7 @@ type internal MotionCapture
         BindDataStorage.Complex activateFunc
 
     let ComplexMotions = 
-        let motionSeq : (string * MotionFlags * BindDataStorage<Motion>) seq = 
+        let motionSeq: (string * MotionFlags * BindDataStorage<Motion>) seq = 
             seq {
                 yield (
                     "f", 
@@ -223,7 +223,7 @@ type internal MotionCapture
     /// Get the Motion value for the given KeyInput.  Will return a BindResult<Motion> which 
     /// digs through the values until a valid Motion result is detected 
     member x.GetMotion keyInput = 
-        let rec inner (previousName : KeyInputSet) keyInput =
+        let rec inner (previousName: KeyInputSet) keyInput =
             if keyInput = KeyInputUtil.EscapeKey then 
                 // User hit escape so abandon the motion
                 BindResult.Cancelled 

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -21,11 +21,11 @@ type OptionBuilder() =
     member x.Zero () = None
 
 type CachedParsedItem<'T> = { 
-    Version : int
-    Items : List<'T>
+    Version: int
+    Items: List<'T>
 } with
 
-    static member GetItems (snapshot : ITextSnapshot) key doParse = 
+    static member GetItems (snapshot: ITextSnapshot) key doParse = 
         let textBuffer = snapshot.TextBuffer
         let propertyCollection = textBuffer.Properties
 
@@ -46,10 +46,10 @@ type CachedParsedItem<'T> = {
 /// Used to represent xml / html tags within the file.  
 type TagBlock
     (
-        text : string,
-        fullSpan : Span,
-        innerSpan : Span,
-        children : List<TagBlock>
+        text: string,
+        fullSpan: Span,
+        innerSpan: Span,
+        children: List<TagBlock>
     ) =
 
     let _text = text
@@ -60,7 +60,7 @@ type TagBlock
     // This is the span within the tag block that does not include the tags
     let _innerSpan = innerSpan
 
-    let mutable _parent : TagBlock option = None
+    let mutable _parent: TagBlock option = None
 
     let _children = children
 
@@ -76,7 +76,7 @@ type TagBlock
         with get () = _parent
         and set value = _parent <- value
 
-type TagBlockParser (snapshot : ITextSnapshot) = 
+type TagBlockParser (snapshot: ITextSnapshot) = 
 
     let _snapshot = snapshot
     let _builder = OptionBuilder()
@@ -142,7 +142,7 @@ type TagBlockParser (snapshot : ITextSnapshot) =
             None
 
     /// Parse out a single attribute name value pair 
-    member x.ParseAttribute startPosition : Span option = 
+    member x.ParseAttribute startPosition: Span option = 
         let position = x.SkipBlanks startPosition
         _builder { 
             let! nameSpan = x.ParseAttributeName position
@@ -224,12 +224,12 @@ type TagBlockParser (snapshot : ITextSnapshot) =
 
     /// Parse out the contents of a tag with the specified name within the given Span.  This returns
     /// a tuple of the tag contents and whether or not the ending tag was ever found.  
-    member x.ParseTagContents tagName tagStartPosition contentStartPosition : TagBlock option = 
+    member x.ParseTagContents tagName tagStartPosition contentStartPosition: TagBlock option = 
         let children = List<TagBlock>()
 
         // This is a tuple of values.  The first value is the end of the content 
         // portion of the text while the second is the end of the closing tag
-        let mutable endPosition : (int * int) option = None
+        let mutable endPosition: (int * int) option = None
         let mutable position = contentStartPosition
         while position < _snapshot.Length && Option.isNone endPosition do
             match x.ParseStartTag position with
@@ -291,10 +291,10 @@ module TagBlockUtil =
     let GetTagBlocks snapshot = 
         CachedParsedItem<TagBlock>.GetItems snapshot _tagBlockKey ParseTagBlocks
 
-    let GetTagBlockForPoint (point : SnapshotPoint) =
+    let GetTagBlockForPoint (point: SnapshotPoint) =
         let tagBlocks = GetTagBlocks point.Snapshot
 
-        let isMatch (tagBlock : TagBlock) = 
+        let isMatch (tagBlock: TagBlock) = 
             let span = tagBlock.FullSpan
             span.Contains point.Position
 
@@ -314,8 +314,8 @@ type DirectiveKind =
     | EndIf
 
 type Directive = { 
-    Kind : DirectiveKind;
-    Span : Span
+    Kind: DirectiveKind;
+    Span: Span
 }
     with
 
@@ -327,8 +327,8 @@ type Directive = {
     override x.ToString() = sprintf "%O - %O" x.Kind x.Span
 
 type DirectiveBlock = {
-    Directives : List<Directive>
-    IsComplete : bool
+    Directives: List<Directive>
+    IsComplete: bool
 }
 
 [<RequireQualifiedAccess>]
@@ -385,13 +385,13 @@ type MatchingTokenUtil() =
 
                 // Process the token kind and the token to determine the span of the 
                 // directive on this line 
-                let func kind (token : Token) = 
+                let func kind (token: Token) = 
                     let endPosition = token.StartIndex + token.Length
                     let span = Span.FromBounds(start, endPosition)
                     { Kind = kind; Span = span } |> Some
 
                 // The span of the token for the #if variety blocks is the entire line
-                let all kind (token : Token) = 
+                let all kind (token: Token) = 
                     let span = Span.FromBounds(start, lineText.Length)
                     { Kind = kind; Span = span; } |> Some
 
@@ -410,7 +410,7 @@ type MatchingTokenUtil() =
     /// Parse out the directive blocks for the given ITextSnapshot.  Don't use
     /// this method directly.  Instead go through GetDirectiveBlocks which will
     /// cache the value
-    member x.ParseDirectiveBlocks (snapshot : ITextSnapshot) = 
+    member x.ParseDirectiveBlocks (snapshot: ITextSnapshot) = 
 
         let lastLineNumber = snapshot.LineCount - 1
 
@@ -430,7 +430,7 @@ type MatchingTokenUtil() =
 
         // Parse out the remainder of a directive given an initial directive value.  Then
         // return the line number after the completion of this block 
-        let rec parseBlockRemainder (startDirective : Directive) lineNumber = 
+        let rec parseBlockRemainder (startDirective: Directive) lineNumber = 
             let list = List<Directive>()
             list.Add(startDirective)
 
@@ -485,7 +485,7 @@ type MatchingTokenUtil() =
         allBlocksList
 
     /// Get the directive blocks for the specified ITextSnapshot
-    member x.GetDirectiveBlocks (snapshot : ITextSnapshot) = 
+    member x.GetDirectiveBlocks (snapshot: ITextSnapshot) = 
         CachedParsedItem<DirectiveBlock>.GetItems snapshot _directiveBlocksKey x.ParseDirectiveBlocks
 
     /// Find the correct MatchingTokenKind for the given line and column position on that 
@@ -579,8 +579,8 @@ type MatchingTokenUtil() =
         let findMatchingTokenChar target startChar endChar = 
             let stack = Stack<int>()
             let length = SnapshotUtil.GetLength snapshot
-            let mutable found : int option = None
-            let mutable targetDepth : int option = None
+            let mutable found: int option = None
+            let mutable targetDepth: int option = None
             let mutable index = 0
             while index < length do
                 let c = SnapshotUtil.GetChar index snapshot
@@ -639,9 +639,9 @@ type MatchingTokenUtil() =
                         false
                 (fun index -> matches index '/' '*'), (fun index -> matches index '*' '/')
 
-            let mutable commentStart : int option = None
+            let mutable commentStart: int option = None
             let mutable index = 0
-            let mutable found : int option = None
+            let mutable found: int option = None
             while index < length do 
                 if Option.isNone commentStart && isBegin index then
                     commentStart <- Some index
@@ -671,10 +671,10 @@ type MatchingTokenUtil() =
             | Some start -> Span(start, 1) |> Some
 
         // Find the matching directive starting from the buffer position 'target'
-        let findMatchingDirective (target : int) = 
+        let findMatchingDirective (target: int) = 
 
             let blockList = x.GetDirectiveBlocks snapshot
-            let mutable found : Span option = None
+            let mutable found: Span option = None
             let mutable blockIndex = 0
             while blockIndex < blockList.Count do
                 let block = blockList.[blockIndex]
@@ -754,7 +754,7 @@ type MatchingTokenUtil() =
 
         let mutable depth = 0
         let mutable count = count
-        let mutable found : SnapshotPoint option = None
+        let mutable found: SnapshotPoint option = None
         use e = charSeq.GetEnumerator()
         while e.MoveNext() && Option.isNone found do
             let c = e.Current.GetChar()
@@ -769,11 +769,11 @@ type MatchingTokenUtil() =
         found
 
 type QuotedStringData =  {
-    LeadingWhiteSpace : SnapshotSpan
-    LeadingQuote : SnapshotPoint
-    Contents : SnapshotSpan
-    TrailingQuote : SnapshotPoint
-    TrailingWhiteSpace : SnapshotSpan 
+    LeadingWhiteSpace: SnapshotSpan
+    LeadingQuote: SnapshotPoint
+    Contents: SnapshotSpan
+    TrailingQuote: SnapshotPoint
+    TrailingWhiteSpace: SnapshotSpan 
 } with
     
     member x.FullSpan = SnapshotSpanUtil.Create x.LeadingWhiteSpace.Start x.TrailingWhiteSpace.End
@@ -799,8 +799,8 @@ type VisualMotionResult =
 
 type internal MotionUtil 
     ( 
-        _vimBufferData : IVimBufferData,
-        _commonOperations : ICommonOperations
+        _vimBufferData: IVimBufferData,
+        _commonOperations: ICommonOperations
     ) = 
 
     let _vimTextBuffer = _vimBufferData.VimTextBuffer
@@ -844,7 +844,7 @@ type internal MotionUtil
 
     /// Apply the 'startofline' option to the given MotionResult.  This function must be 
     /// called with the MotionData mapped back to the edit snapshot
-    member x.ApplyStartOfLineOption (motionData : MotionResult) =
+    member x.ApplyStartOfLineOption (motionData: MotionResult) =
         Contract.Assert(match motionData.MotionKind with MotionKind.LineWise _ -> true | _ -> false)
         Contract.Assert(motionData.Span.Snapshot = x.CurrentSnapshot)
         if not _globalSettings.StartOfLine then 
@@ -860,7 +860,7 @@ type internal MotionUtil
                 MotionKind = MotionKind.LineWise 
                 DesiredColumn = column }
 
-    member x.ApplyBigDelete (result : MotionResult) =
+    member x.ApplyBigDelete (result: MotionResult) =
         let flags = result.MotionResultFlags ||| MotionResultFlags.BigDelete
         { result with MotionResultFlags = flags }
 
@@ -870,7 +870,7 @@ type internal MotionUtil
     ///
     /// This function wraps the conversion of the information from the edit buffer into the 
     /// visual buffer and back again when we are done. 
-    member x.MotionWithVisualSnapshotCore (action : SnapshotData -> 'T) (getMotionResult : 'T -> MotionResult option) =
+    member x.MotionWithVisualSnapshotCore (action: SnapshotData -> 'T) (getMotionResult: 'T -> MotionResult option) =
 
         // First get the SnapshotData for the VisualBuffer based on the current position of the
         // caret in the EditBuffer.  
@@ -903,7 +903,7 @@ type internal MotionUtil
                     VisualMotionResult.FailedNoMapToEditSnapshot
 
     /// Run the motion function against the Visual Snapshot
-    member x.MotionWithVisualSnapshot (action : SnapshotData -> MotionResult) = 
+    member x.MotionWithVisualSnapshot (action: SnapshotData -> MotionResult) = 
 
         match x.MotionWithVisualSnapshotCore action (fun x -> Some x) with
         | VisualMotionResult.Succeeded motionResult ->
@@ -916,7 +916,7 @@ type internal MotionUtil
             action snapshotData
 
     /// Run the motion function against the Visual Snapshot
-    member x.MotionOptionWithVisualSnapshot (action : SnapshotData -> MotionResult option) = 
+    member x.MotionOptionWithVisualSnapshot (action: SnapshotData -> MotionResult option) = 
 
         match x.MotionWithVisualSnapshotCore action (fun x -> x) with
         | VisualMotionResult.Succeeded motionResult ->
@@ -1024,7 +1024,7 @@ type internal MotionUtil
             MotionResult.Create span true MotionKind.CharacterWiseExclusive |> Some
 
     member x.DisplayLineMiddleOfScreen() =
-        let createForPoint (point : SnapshotPoint) = 
+        let createForPoint (point: SnapshotPoint) = 
             let isForward = x.CaretPoint.Position <= point.Position
             let startPoint, endPoint = SnapshotPointUtil.OrderAscending x.CaretPoint point
             let span = SnapshotSpan(startPoint, endPoint)
@@ -1048,7 +1048,7 @@ type internal MotionUtil
     /// Get the motion between the provided two lines.  The motion will be linewise
     /// and have a column of the first non-whitespace character.  If the 'startofline'
     /// option is not set it will keep the original column
-    member x.LineToLineFirstNonBlankMotion (flags : MotionResultFlags) (startLine : ITextSnapshotLine) (endLine : ITextSnapshotLine) = 
+    member x.LineToLineFirstNonBlankMotion (flags: MotionResultFlags) (startLine: ITextSnapshotLine) (endLine: ITextSnapshotLine) = 
 
         // Get the column based on the 'startofline' option
         let column = 
@@ -1068,7 +1068,7 @@ type internal MotionUtil
         MotionResult.CreateExEx range.ExtentIncludingLineBreak isForward MotionKind.LineWise flags column
 
     /// Get the block span for the specified char at the given context point
-    member x.GetBlock (blockKind : BlockKind) contextPoint = 
+    member x.GetBlock (blockKind: BlockKind) contextPoint = 
 
         let startChar, endChar = blockKind.Characters
 
@@ -1119,7 +1119,7 @@ type internal MotionUtil
         | Some startPoint, Some lastPoint -> Some (startPoint, lastPoint)
         | _ -> None
 
-    member x.GetBlockWithCount (blockKind : BlockKind) contextPoint count = 
+    member x.GetBlockWithCount (blockKind: BlockKind) contextPoint count = 
 
         // Need to wrap GetBlock to account for blocks being side by 
         // side.  In that case we have to detect a side by side block and 
@@ -1127,7 +1127,7 @@ type internal MotionUtil
         let getBlockHelper closePoint =
             let mutable isDone = false
             let mutable contextPoint = SnapshotPointUtil.AddOne closePoint
-            let mutable result : (SnapshotPoint * SnapshotPoint) option = None
+            let mutable result: (SnapshotPoint * SnapshotPoint) option = None
 
             while not isDone do
                 match x.GetBlock blockKind contextPoint with
@@ -1193,8 +1193,8 @@ type internal MotionUtil
                 index <- index + 1
             list
 
-        let getStringData (stringSpan : SnapshotSpan) = 
-            let isWhiteSpace (position : int) = 
+        let getStringData (stringSpan: SnapshotSpan) = 
+            let isWhiteSpace (position: int) = 
                 let c = x.CurrentSnapshot.[position]
                 CharUtil.IsWhiteSpace c
 
@@ -1240,7 +1240,7 @@ type internal MotionUtil
         // the string which contains the position.  The tricky case is when the position falls directly
         // on a quote.  In that case we have to determine if it is the start or end quote (just check 
         // for an even count to make that determination)
-        let mutable data : QuotedStringData option = None
+        let mutable data: QuotedStringData option = None
         let mutable index = 0 
         while index < quoteSpans.Count && Option.isNone data do
             let span = quoteSpans.[index]
@@ -1980,10 +1980,10 @@ type internal MotionUtil
         //
         // Note: Line breaks do not factor into this calculation.  This can be demonstrated 
         // experimentally
-        let getSpan (startPoint : SnapshotPoint) point count =
+        let getSpan (startPoint: SnapshotPoint) point count =
             Contract.Assert(not (SnapshotPointUtil.IsInsideLineBreak point))
 
-            let rec inner (wordSpan : SnapshotSpan) (remainingWords : SnapshotSpan list) count = 
+            let rec inner (wordSpan: SnapshotSpan) (remainingWords: SnapshotSpan list) count = 
                 if count = 0 then 
                     // Count gets us to this word so return it's start
                     Some wordSpan.Start
@@ -2535,7 +2535,7 @@ type internal MotionUtil
             MotionResult.Create span true MotionKind.CharacterWiseInclusive |> Some
 
     /// Get the motion for a search command.  Used to implement the '/' and '?' motions
-    member x.Search (searchData : SearchData) count = 
+    member x.Search (searchData: SearchData) count = 
 
         // Searching as part of a motion should update the last pattern information
         // irrespective of whether or not the search completes
@@ -2545,7 +2545,7 @@ type internal MotionUtil
 
     /// Implements the core searching motion.  Will *not* update the LastPatternData 
     /// value.  Simply performs the search and returns the result
-    member x.SearchCore (searchData : SearchData) searchPoint count =
+    member x.SearchCore (searchData: SearchData) searchPoint count =
 
         // All search operations update the jump list
         _jumpList.Add x.CaretPoint
@@ -2689,7 +2689,7 @@ type internal MotionUtil
     /// The documentation around 'exclusive-linewise' says it applies to any 
     /// exclusive motion.  However in practice it doesn't appear to apply to 
     /// word motions
-    member x.AdjustMotionResult motion (motionResult : MotionResult) =
+    member x.AdjustMotionResult motion (motionResult: MotionResult) =
 
         // Do the actual adjustment for exclusive motions.  The kind which should be 
         // added to the adjusted motion is provided
@@ -2738,7 +2738,7 @@ type internal MotionUtil
         | MotionKind.LineWise _ -> motionResult
 
     /// Run the specified motion and return it's result
-    member x.GetMotion motion (motionArgument : MotionArgument) = 
+    member x.GetMotion motion (motionArgument: MotionArgument) = 
 
         let motionResult = 
             match motion with 

--- a/Src/VimCore/MotionUtil.fsi
+++ b/Src/VimCore/MotionUtil.fsi
@@ -7,6 +7,6 @@ open Microsoft.VisualStudio.Text.Editor
 open Microsoft.VisualStudio.Text.Operations
 
 type internal MotionUtil =
-    new : IVimBufferData * ICommonOperations -> MotionUtil
+    new: IVimBufferData * ICommonOperations -> MotionUtil
 
     interface IMotionUtil

--- a/Src/VimCore/Register.fs
+++ b/Src/VimCore/Register.fs
@@ -37,7 +37,7 @@ type StringData =
         | Block left, Simple right -> Block (NonEmptyCollectionUtil.Append [ right ] left)
         | Block left, Block right -> Block (NonEmptyCollectionUtil.Append (right.All |> List.ofSeq) left)
 
-    static member OfNormalizedSnasphotSpanCollection (col : NormalizedSnapshotSpanCollection) = 
+    static member OfNormalizedSnasphotSpanCollection (col: NormalizedSnapshotSpanCollection) = 
         if col.Count = 0 then
             StringData.Simple StringUtil.Empty
         elif col.Count = 1 then 
@@ -452,10 +452,10 @@ module RegisterNameUtil =
 /// will be fidelity loss in some
 type RegisterValue
     (
-        _isString : bool,
-        _stringData : StringData,
-        _keyInputs : KeyInput list,
-        _operationKind : OperationKind
+        _isString: bool,
+        _stringData: StringData,
+        _keyInputs: KeyInput list,
+        _operationKind: OperationKind
     ) =
 
     /// Once a line wise value is in a string form it should always end with a new line.  It's
@@ -466,15 +466,15 @@ type RegisterValue
         | StringData.Simple str, OperationKind.LineWise -> EditUtil.EndsWithNewLine str
         | _ -> true
         
-    new (value : string, operationKind : OperationKind) =
+    new (value: string, operationKind: OperationKind) =
         RegisterValue(StringData.Simple value, operationKind)
 
-    new (stringData : StringData, operationKind : OperationKind) =
+    new (stringData: StringData, operationKind: OperationKind) =
         // TODO: Why do we allow an OperationKind here?  Can you ever have a line wise block StringData?
         Debug.Assert(IsNormalized stringData operationKind)
         RegisterValue(true, stringData, List.empty, operationKind)
 
-    new (keyInputs : KeyInput list) =
+    new (keyInputs: KeyInput list) =
         RegisterValue(false, StringData.Simple "", keyInputs, OperationKind.CharacterWise)
 
     /// Get the RegisterData as a StringData instance
@@ -516,7 +516,7 @@ type RegisterValue
 
     /// Append the provided RegisterValue to this one.  Used for append register operations (yank, 
     /// delete, etc ... with an upper case register)
-    member x.Append (value : RegisterValue) =
+    member x.Append (value: RegisterValue) =
         if _isString then
             let stringData = x.StringData.Append value.StringData
             RegisterValue(stringData, x.OperationKind)
@@ -530,7 +530,7 @@ type RegisterValue
 type internal IRegisterValueBacking = 
 
     /// The RegisterValue to use
-    abstract RegisterValue : RegisterValue with get, set
+    abstract RegisterValue: RegisterValue with get, set
 
 /// Default implementation of IRegisterValueBacking.  Just holds the RegisterValue
 /// in a mutable field
@@ -545,8 +545,8 @@ type internal DefaultRegisterValueBacking() =
 type Register
     internal 
     ( 
-        _name : RegisterName,
-        _valueBacking : IRegisterValueBacking ) = 
+        _name: RegisterName,
+        _valueBacking: IRegisterValueBacking ) = 
 
     new (c:char) =
         let name = RegisterNameUtil.CharToRegister c |> Option.get
@@ -566,12 +566,12 @@ type Register
 type IRegisterMap = 
 
     /// Gets all of the available register name values
-    abstract RegisterNames : seq<RegisterName>
+    abstract RegisterNames: seq<RegisterName>
 
     /// Get the register with the specified name
-    abstract GetRegister : registerName : RegisterName -> Register
+    abstract GetRegister: registerName: RegisterName -> Register
 
     /// Update the register with the specified value
-    abstract SetRegisterValue : registerName : RegisterName -> value : RegisterValue -> unit
+    abstract SetRegisterValue: registerName: RegisterName -> value: RegisterValue -> unit
 
 

--- a/Src/VimCore/RegisterMap.fs
+++ b/Src/VimCore/RegisterMap.fs
@@ -3,7 +3,7 @@
 namespace Vim
 
 /// IRegisterValueBacking implementation for the clipboard 
-type ClipboardRegisterValueBacking (_device : IClipboardDevice) =
+type ClipboardRegisterValueBacking (_device: IClipboardDevice) =
 
     member x.RegisterValue = 
         let text = _device.Text
@@ -23,25 +23,25 @@ type ClipboardRegisterValueBacking (_device : IClipboardDevice) =
 /// case letter registers can be accessed via an upper case version.  The only
 /// difference is when accessed via upper case sets of the value should be 
 /// append operations
-type AppendRegisterValueBacking (_register : Register) =
+type AppendRegisterValueBacking (_register: Register) =
     interface IRegisterValueBacking with
         member x.RegisterValue 
             with get () = _register.RegisterValue
             and set value = _register.RegisterValue <- _register.RegisterValue.Append value
 
-type LastSearchRegisterValueBacking (_vimData : IVimData) = 
+type LastSearchRegisterValueBacking (_vimData: IVimData) = 
     interface IRegisterValueBacking with
         member x.RegisterValue 
             with get () = RegisterValue(_vimData.LastSearchData.Pattern, OperationKind.CharacterWise)
             and set value = _vimData.LastSearchData <- SearchData(value.StringValue, SearchPath.Forward, false)
 
-type CommandLineBacking (_vimData : IVimData) = 
+type CommandLineBacking (_vimData: IVimData) = 
     interface IRegisterValueBacking  with
         member x.RegisterValue
             with get() = RegisterValue(_vimData.LastCommandLine, OperationKind.CharacterWise)
             and set _ = ()
 
-type LastTextInsertBacking (_vimData : IVimData) = 
+type LastTextInsertBacking (_vimData: IVimData) = 
     interface IRegisterValueBacking with
         member x.RegisterValue 
             with get() = 
@@ -56,8 +56,8 @@ type internal BlackholeRegisterValueBacking() =
             with get() = _value
             and set _ = ()
 
-type internal RegisterMap (_map : Map<RegisterName, Register>) =
-    new(vimData : IVimData, clipboard : IClipboardDevice, currentFileNameFunc : unit -> string option) = 
+type internal RegisterMap (_map: Map<RegisterName, Register>) =
+    new(vimData: IVimData, clipboard: IClipboardDevice, currentFileNameFunc: unit -> string option) = 
         let clipboardBacking = ClipboardRegisterValueBacking(clipboard) :> IRegisterValueBacking
         let commandLineBacking = CommandLineBacking(vimData) :> IRegisterValueBacking
         let lastTextInsertBacking = LastTextInsertBacking(vimData) :> IRegisterValueBacking
@@ -72,7 +72,7 @@ type internal RegisterMap (_map : Map<RegisterName, Register>) =
                 and set _ = () }
 
         // Is this an append register 
-        let isAppendRegister (name : RegisterName) = name.IsAppend
+        let isAppendRegister (name: RegisterName) = name.IsAppend
 
         let getBacking name = 
             match name with 
@@ -98,7 +98,7 @@ type internal RegisterMap (_map : Map<RegisterName, Register>) =
             let originalMap = map
             RegisterName.All
             |> Seq.filter isAppendRegister
-            |> Seq.fold (fun map (name : RegisterName) ->
+            |> Seq.fold (fun map (name: RegisterName) ->
                 match name.Char with
                 | None -> map
                 | Some c ->

--- a/Src/VimCore/RegisterMap.fsi
+++ b/Src/VimCore/RegisterMap.fsi
@@ -4,6 +4,6 @@
 namespace Vim
 
 type internal RegisterMap = 
-    new : IVimData * IClipboardDevice * (unit -> string option) -> RegisterMap
+    new: IVimData * IClipboardDevice * (unit -> string option) -> RegisterMap
 
     interface IRegisterMap

--- a/Src/VimCore/SearchService.fsi
+++ b/Src/VimCore/SearchService.fsi
@@ -4,7 +4,7 @@ open Microsoft.VisualStudio.Text.Operations
 open Microsoft.VisualStudio.Text.Editor
 
 type internal SearchService =
-    new : ITextSearchService * IVimGlobalSettings -> SearchService
+    new: ITextSearchService * IVimGlobalSettings -> SearchService
 
     interface ISearchService
 

--- a/Src/VimCore/SelectionChangeTracker.fs
+++ b/Src/VimCore/SelectionChangeTracker.fs
@@ -17,10 +17,10 @@ open System.Collections.Generic
 /// inside on
 type internal SelectionChangeTracker
     ( 
-        _vimBuffer : IVimBuffer,
-        _commonOperations : ICommonOperations,
-        _selectionOverrideList : IVisualModeSelectionOverride list,
-        _mouseDevice : IMouseDevice
+        _vimBuffer: IVimBuffer,
+        _commonOperations: ICommonOperations,
+        _selectionOverrideList: IVisualModeSelectionOverride list,
+        _mouseDevice: IMouseDevice
     ) as this =
 
     let _globalSettings = _vimBuffer.GlobalSettings
@@ -234,9 +234,9 @@ type internal SelectionChangeTracker
 type internal SelectionChangeTrackerFactory
     [<ImportingConstructor>]
     (
-        [<ImportMany>] _selectionOverrideList : IVisualModeSelectionOverride seq,
-        _mouseDevice : IMouseDevice,
-        _commonOperationsFactory : ICommonOperationsFactory
+        [<ImportMany>] _selectionOverrideList: IVisualModeSelectionOverride seq,
+        _mouseDevice: IMouseDevice,
+        _commonOperationsFactory: ICommonOperationsFactory
     ) =
 
     let _selectionOverrideList = _selectionOverrideList |> List.ofSeq

--- a/Src/VimCore/SelectionChangeTracker.fsi
+++ b/Src/VimCore/SelectionChangeTracker.fsi
@@ -6,5 +6,5 @@ open Microsoft.VisualStudio.Text.Operations
 open Microsoft.VisualStudio.Text.Editor
 
 type internal SelectionChangeTracker =
-    new : vimBuffer : IVimBuffer * ICommonOperations * visualModeSelectionOverrideList : IVisualModeSelectionOverride list * mouseDevice : IMouseDevice -> SelectionChangeTracker
+    new: vimBuffer: IVimBuffer * ICommonOperations * visualModeSelectionOverrideList: IVisualModeSelectionOverride list * mouseDevice: IMouseDevice -> SelectionChangeTracker
 

--- a/Src/VimCore/StatusUtil.fs
+++ b/Src/VimCore/StatusUtil.fs
@@ -10,7 +10,7 @@ open System.Collections.Generic
 open System.ComponentModel.Composition
 
 type internal StatusUtil() = 
-    let mutable _vimBuffer : IVimBufferInternal option = None
+    let mutable _vimBuffer: IVimBufferInternal option = None
 
     member x.VimBuffer 
         with get () = _vimBuffer
@@ -46,16 +46,16 @@ type StatusUtilFactory () =
     let _key = new System.Object()
 
     /// Get or create an PropagatingStatusUtil instance for the ITextBuffer
-    member x.GetStatusUtilForBuffer (textBuffer : ITextBuffer) =
+    member x.GetStatusUtilForBuffer (textBuffer: ITextBuffer) =
         textBuffer.Properties.GetOrCreateSingletonProperty(_key, (fun unused -> PropagatingStatusUtil()))
 
     /// Get or create an StatusUtil instance for the ITextView
-    member x.GetStatusUtilForView (textView : ITextView) =
+    member x.GetStatusUtilForView (textView: ITextView) =
         textView.Properties.GetOrCreateSingletonProperty(_key, (fun unused -> StatusUtil()))
 
     /// When an IVimBuffer is created go ahead and update the backing VimBuffer value for
     /// the status util
-    member x.InitializeVimBuffer (vimBuffer : IVimBufferInternal) = 
+    member x.InitializeVimBuffer (vimBuffer: IVimBufferInternal) = 
         try
             let statusUtil = x.GetStatusUtilForView vimBuffer.TextView
             statusUtil.VimBuffer <- Some vimBuffer

--- a/Src/VimCore/StringUtil.fs
+++ b/Src/VimCore/StringUtil.fs
@@ -39,7 +39,7 @@ module internal StringUtil =
                 buffer.AppendString value
             buffer.ToString()
 
-    let ReplaceNoCase (source : string) (toFind : string) (toReplace : string) = 
+    let ReplaceNoCase (source: string) (toFind: string) (toReplace: string) = 
         let builder = System.Text.StringBuilder()
         let mutable lastIndex = 0
         let mutable index = source.IndexOf(toFind, StringComparison.OrdinalIgnoreCase)
@@ -53,7 +53,7 @@ module internal StringUtil =
             builder.AppendSubstring source lastIndex (source.Length - lastIndex)
         builder.ToString()
 
-    let RepeatChar count (value : char) =
+    let RepeatChar count (value: char) =
         if 1 = count then 
             (value.ToString())
         else
@@ -66,14 +66,14 @@ module internal StringUtil =
     let OfCharArray (chars:char[]) = new System.String(chars)
 
     /// Create a String from a sequence of chars
-    let OfCharSeq (chars : char seq) = chars |> Array.ofSeq |> OfCharArray
+    let OfCharSeq (chars: char seq) = chars |> Array.ofSeq |> OfCharArray
 
     let OfCharList (chars :char list) = chars |> Seq.ofList |> OfCharSeq
 
     /// Create a String from a single char
     let OfChar c = System.String(c,1)
 
-    let OfStringSeq (strings : string seq) = 
+    let OfStringSeq (strings: string seq) = 
         let builder = System.Text.StringBuilder()
         for value in strings do
             builder.AppendString value
@@ -81,22 +81,22 @@ module internal StringUtil =
 
     let IsNullOrEmpty str = System.String.IsNullOrEmpty(str)
 
-    let IndexOfChar (c : char) (str : string) = 
+    let IndexOfChar (c: char) (str: string) = 
         let result = str.IndexOf(c)
         if result < 0 then None
         else Some result
 
-    let IndexOfCharAt (c : char) (index : int) (str : string) = 
+    let IndexOfCharAt (c: char) (index: int) (str: string) = 
         let result = str.IndexOf(c, index)
         if result < 0 then None
         else Some result
 
-    let IndexOfString (toFind : string) (str : string) = 
+    let IndexOfString (toFind: string) (str: string) = 
         let result = str.IndexOf(toFind)
         if result < 0 then None
         else Some result
 
-    let IndexOfStringAt (toFind : string) (index : int) (str : string) = 
+    let IndexOfStringAt (toFind: string) (index: int) (str: string) = 
         let result = str.IndexOf(toFind, index)
         if result < 0 then None
         else Some result
@@ -135,13 +135,13 @@ module internal StringUtil =
 
     let ContainsChar (arg:string) (c:char) = arg.IndexOf(c) >= 0
 
-    let IsWhiteSpace (arg : string) = not (Seq.exists CharUtil.IsNotWhiteSpace arg)
+    let IsWhiteSpace (arg: string) = not (Seq.exists CharUtil.IsNotWhiteSpace arg)
 
-    let IsBlanks (arg : string) = Seq.forall CharUtil.IsBlank arg
+    let IsBlanks (arg: string) = Seq.forall CharUtil.IsBlank arg
 
     /// Is the specified check string a substring of the given argument at the specified
     /// index
-    let IsSubstringAt (arg : string) (check : string) (index : int) (comparer : CharComparer) =
+    let IsSubstringAt (arg: string) (check: string) (index: int) (comparer: CharComparer) =
         if index + check.Length >= arg.Length then
             false
         else

--- a/Src/VimCore/Tagger.fs
+++ b/Src/VimCore/Tagger.fs
@@ -13,14 +13,14 @@ open System.Threading
 open VimCoreExtensions
 
 /// Tagger for incremental searches
-type IncrementalSearchTaggerSource (_vimBuffer : IVimBuffer) as this =
+type IncrementalSearchTaggerSource (_vimBuffer: IVimBuffer) as this =
 
     let _search = _vimBuffer.IncrementalSearch
     let _textBuffer = _vimBuffer.TextBuffer
     let _globalSettings = _vimBuffer.GlobalSettings
     let _eventHandlers = DisposableBag()
     let _changed = StandardEvent()
-    let mutable _searchSpan : ITrackingSpan option = None
+    let mutable _searchSpan: ITrackingSpan option = None
 
     static let EmptyTagList = ReadOnlyCollection<ITagSpan<TextMarkerTag>>([| |])
 
@@ -105,13 +105,13 @@ type IncrementalSearchTaggerSource (_vimBuffer : IVimBuffer) as this =
 type internal IncrementalSearchTaggerProvider
     [<ImportingConstructor>]
     (
-        _vim : IVim
+        _vim: IVim
     ) = 
 
     let _key = obj()
 
     interface IViewTaggerProvider with 
-        member x.CreateTagger<'T when 'T :> ITag> (textView : ITextView, textBuffer) = 
+        member x.CreateTagger<'T when 'T :> ITag> (textView: ITextView, textBuffer) = 
             if textView.TextBuffer = textBuffer then
                 match _vim.GetOrCreateVimBufferForHost textView with
                 | None -> null
@@ -125,17 +125,17 @@ type internal IncrementalSearchTaggerProvider
                 null
 
 type HighlightSearchData = {
-    Pattern : string
-    VimRegexOptions : VimRegexOptions
+    Pattern: string
+    VimRegexOptions: VimRegexOptions
 }
 
 /// Tagger for completed incremental searches
 type HighlightSearchTaggerSource
     ( 
-        _textView : ITextView,
-        _globalSettings : IVimGlobalSettings,
-        _vimData : IVimData,
-        _vimHost : IVimHost
+        _textView: ITextView,
+        _globalSettings: IVimGlobalSettings,
+        _vimData: IVimData,
+        _vimHost: IVimHost
     ) as this =
 
     let _textBuffer = _textView.TextBuffer
@@ -206,7 +206,7 @@ type HighlightSearchTaggerSource
             None
 
     [<UsedInBackgroundThread>]
-    static member GetTagsInBackground (highlightSearchData : HighlightSearchData) span (cancellationToken : CancellationToken) = 
+    static member GetTagsInBackground (highlightSearchData: HighlightSearchData) span (cancellationToken: CancellationToken) = 
 
         if StringUtil.IsNullOrEmpty highlightSearchData.Pattern then
             EmptyTagList
@@ -278,13 +278,13 @@ type HighlightSearchTaggerSource
 type HighlightIncrementalSearchTaggerProvider
     [<ImportingConstructor>]
     ( 
-        _vim : IVim
+        _vim: IVim
     ) = 
 
     let _key = obj()
 
     interface IViewTaggerProvider with 
-        member x.CreateTagger<'T when 'T :> ITag> ((textView : ITextView), textBuffer) = 
+        member x.CreateTagger<'T when 'T :> ITag> ((textView: ITextView), textBuffer) = 
             if textView.TextBuffer = textBuffer then
                 match _vim.GetOrCreateVimBufferForHost textView with
                 | None -> null
@@ -301,13 +301,13 @@ type HighlightIncrementalSearchTaggerProvider
 /// Tagger for matches as they appear during a confirm substitute
 type SubstituteConfirmTaggerSource
     ( 
-        _textBuffer : ITextBuffer,
-        _mode : ISubstituteConfirmMode
+        _textBuffer: ITextBuffer,
+        _mode: ISubstituteConfirmMode
     ) as this =
 
     let _changed = StandardEvent()
     let _eventHandlers = DisposableBag()
-    let mutable _currentMatch : SnapshotSpan option = None
+    let mutable _currentMatch: SnapshotSpan option = None
 
     static let EmptyTagList = ReadOnlyCollection<ITagSpan<TextMarkerTag>>([| |])
 
@@ -344,13 +344,13 @@ type SubstituteConfirmTaggerSource
 type SubstituteConfirmTaggerProvider
     [<ImportingConstructor>]
     ( 
-        _vim : IVim
+        _vim: IVim
     ) = 
 
     let _key = obj()
 
     interface IViewTaggerProvider with 
-        member x.CreateTagger<'T when 'T :> ITag> ((textView : ITextView), textBuffer) = 
+        member x.CreateTagger<'T when 'T :> ITag> ((textView: ITextView), textBuffer) = 
             if textView.TextBuffer = textBuffer then
                 match _vim.GetOrCreateVimBufferForHost textView with
                 | None -> null
@@ -366,7 +366,7 @@ type SubstituteConfirmTaggerProvider
 /// Fold tagger for the IOutliningRegion tags created by folds.  Note that folds work
 /// on an ITextBuffer level and not an ITextView level.  Hence this works directly with
 /// IFoldManagerData instead of IFoldManager
-type internal FoldTaggerSource(_foldData : IFoldData) as this =
+type internal FoldTaggerSource(_foldData: IFoldData) as this =
 
     let _textBuffer = _foldData.TextBuffer
     let _changed = StandardEvent()
@@ -408,7 +408,7 @@ type internal FoldTaggerSource(_foldData : IFoldData) as this =
 type FoldTaggerProvider
     [<ImportingConstructor>]
     (
-        _factory : IFoldManagerFactory
+        _factory: IFoldManagerFactory
     ) =
 
     let _key = obj()

--- a/Src/VimCore/TaggerUtil.fs
+++ b/Src/VimCore/TaggerUtil.fs
@@ -37,7 +37,7 @@ module TaggerUtilCore =
     /// In order to provide the minimum possible valid SnapshotSpan the simple taggers
     /// cache the overarching SnapshotSpan for the latest ITextSnapshot of all requests
     /// to which they are given.
-    let AdjustRequestedSpan (cachedRequestSpan : SnapshotSpan option) (requestSpan : SnapshotSpan) =
+    let AdjustRequestedSpan (cachedRequestSpan: SnapshotSpan option) (requestSpan: SnapshotSpan) =
         match cachedRequestSpan with
         | None -> requestSpan
         | Some cachedRequestSpan ->
@@ -67,9 +67,9 @@ module TaggerUtilCore =
 /// This solves the same problem as CountedTagger but for IClassifier
 type internal CountedValue<'T> 
     (
-        _value : 'T,
-        _key : obj,
-        _propertyCollection : PropertyCollection
+        _value: 'T,
+        _key: obj,
+        _propertyCollection: PropertyCollection
     ) = 
 
     let mutable _count = 1
@@ -86,7 +86,7 @@ type internal CountedValue<'T>
             | _ -> ()
             _propertyCollection.RemoveProperty(_key) |> ignore
 
-    static member GetOrCreate propertyCollection key (createFunc : unit -> 'T) = 
+    static member GetOrCreate propertyCollection key (createFunc: unit -> 'T) = 
         match PropertyCollectionUtil.GetValue<CountedValue<'T>> key propertyCollection with
         | Some countedValue ->
             countedValue.Increment()
@@ -106,13 +106,13 @@ type internal CountedValue<'T>
 /// for only one ITagger to be created for the same scenario
 type internal CountedTagger<'TTag when 'TTag :> ITag>  =
 
-    val private _countedValue : CountedValue<ITagger<'TTag>>
+    val private _countedValue: CountedValue<ITagger<'TTag>>
 
     member x.Tagger = x._countedValue.Value
 
     member x.Dispose() = x._countedValue.Release()
 
-    new (propertyCollection : PropertyCollection, key : obj, createFunc : (unit -> ITagger<'TTag>)) =
+    new (propertyCollection: PropertyCollection, key: obj, createFunc: (unit -> ITagger<'TTag>)) =
         let value = CountedValue<ITagger<'TTag>>.GetOrCreate propertyCollection key createFunc
         { _countedValue = value }
 
@@ -128,13 +128,13 @@ type internal CountedTagger<'TTag when 'TTag :> ITag>  =
 /// This solves the same problem as CountedTagger but for IClassifier
 type internal CountedClassifier =
 
-    val private _countedValue : CountedValue<IClassifier>
+    val private _countedValue: CountedValue<IClassifier>
 
     member x.Classifier = x._countedValue.Value
 
     member x.Dispose() = x._countedValue.Release()
 
-    new (propertyCollection : PropertyCollection, key : obj, createFunc : (unit -> IClassifier)) =
+    new (propertyCollection: PropertyCollection, key: obj, createFunc: (unit -> IClassifier)) =
         let value = CountedValue<IClassifier>.GetOrCreate propertyCollection key createFunc
         { _countedValue = value }
 
@@ -151,16 +151,16 @@ type internal CountedClassifier =
 [<Struct>]
 type internal OutliningData = 
     {
-        TrackingSpan : ITrackingSpan;
-        Tag : OutliningRegionTag;
-        Cookie : int
+        TrackingSpan: ITrackingSpan;
+        Tag: OutliningRegionTag;
+        Cookie: int
     }
 
 /// Implementation of the IAdhocOutliner service.  This class is only used for testing
 /// so it's focused on creating the simplest implementation vs. the most efficient
 type internal AdhocOutliner 
     (
-        _textBuffer : ITextBuffer
+        _textBuffer: ITextBuffer
     ) =
 
     let _map = new Dictionary<int, OutliningData>()
@@ -182,7 +182,7 @@ type internal AdhocOutliner
             raise (new Exception(msg))
 
     /// Get all of the values which map to the given ITextSnapshot
-    member private x.GetOutliningRegions (span : SnapshotSpan) =
+    member private x.GetOutliningRegions (span: SnapshotSpan) =
         // Avoid allocating a map or new collection if we are simply empty
         if _map.Count = 0 then
             s_emptyCollection
@@ -196,7 +196,7 @@ type internal AdhocOutliner
 
             ReadOnlyCollection<OutliningRegion>(list)
 
-    member private x.CreateOutliningRegion (span : SnapshotSpan) spanTrackingMode text hint = 
+    member private x.CreateOutliningRegion (span: SnapshotSpan) spanTrackingMode text hint = 
         let trackingSpan = span.Snapshot.CreateTrackingSpan(span.Span, spanTrackingMode) 
         let tag = OutliningRegionTag(text, hint) 
         let data = { TrackingSpan = trackingSpan; Tag = tag; Cookie = _counter }
@@ -205,7 +205,7 @@ type internal AdhocOutliner
         _changed.Trigger x
         { Tag = tag; Span = span; Cookie = data.Cookie }
 
-    static member GetOrCreate (textBuffer : ITextBuffer) = 
+    static member GetOrCreate (textBuffer: ITextBuffer) = 
         let propertyCollection = textBuffer.Properties
         propertyCollection.GetOrCreateSingletonProperty(s_outlinerKey, (fun _ -> AdhocOutliner(textBuffer)))
 
@@ -237,7 +237,7 @@ type internal AdhocOutliner
 
 type internal Classifier
     (
-        _tagger : ITagger<IClassificationTag>
+        _tagger: ITagger<IClassificationTag>
     ) as this =
 
     let _changed = StandardEvent<ClassificationChangedEventArgs>()
@@ -271,12 +271,12 @@ type internal Classifier
 
 type internal BasicTagger<'TTag when 'TTag :> ITag>
     (
-        _basicTaggerSource : IBasicTaggerSource<'TTag>
+        _basicTaggerSource: IBasicTaggerSource<'TTag>
     ) as this = 
 
     let _changed = StandardEvent<SnapshotSpanEventArgs>()
     let _eventHandlers = DisposableBag()
-    let mutable _cachedRequestSpan : SnapshotSpan option = None
+    let mutable _cachedRequestSpan: SnapshotSpan option = None
 
     do 
         _basicTaggerSource.Changed
@@ -298,7 +298,7 @@ type internal BasicTagger<'TTag when 'TTag :> ITag>
         | :? IDisposable as d -> d.Dispose()
         | _ -> ()
 
-    member x.GetTags (col : NormalizedSnapshotSpanCollection) = 
+    member x.GetTags (col: NormalizedSnapshotSpanCollection) = 
         if col.Count > 0 then
             let span = NormalizedSnapshotSpanCollectionUtil.GetOverarchingSpan col
             _cachedRequestSpan <- Some (TaggerUtilCore.AdjustRequestedSpan _cachedRequestSpan span)
@@ -320,7 +320,7 @@ type internal BasicTagger<'TTag when 'TTag :> ITag>
 /// guarantees to use Interlocked.Exchange
 type TextViewLineRange = 
     {
-        LineRange : SnapshotLineRange
+        LineRange: SnapshotLineRange
     }
 
 /// This class is used to support the one way transfer of SnapshotLineRange values between
@@ -332,11 +332,11 @@ type internal Channel() =
 
     /// This is the normal request stack from the main thread.  More recently requested items
     /// are given higher priority than older items
-    let mutable _stack : SnapshotLineRange list = list.Empty
+    let mutable _stack: SnapshotLineRange list = list.Empty
 
     /// When set this is represents the visible line range of the text view.  It has the highest
     /// priority for the background thread
-    let mutable _textViewLineRange : TextViewLineRange option = None
+    let mutable _textViewLineRange: TextViewLineRange option = None
 
     /// Version number tracks the number of writes to the channel
     let mutable _version = 0
@@ -363,7 +363,7 @@ type internal Channel() =
         Interlocked.Increment(& _version) |> ignore
 
     member private x.ReadNormal() = 
-        let mutable value : SnapshotLineRange option = None
+        let mutable value: SnapshotLineRange option = None
         let mutable isDone = false
         while not isDone do
             let oldStack = _stack
@@ -376,7 +376,7 @@ type internal Channel() =
         value
 
     member private x.ReadVisibleLines() = 
-        let mutable value : SnapshotLineRange option = None
+        let mutable value: SnapshotLineRange option = None
         let mutable isDone = false
         while not isDone do
             let oldTextViewLineRange = _textViewLineRange
@@ -422,7 +422,7 @@ type internal NormalizedLineRangeCollection() =
     member x.Item
         with get(index) = _list.[index]
        
-    member x.Add (lineRange : LineRange) = 
+    member x.Add (lineRange: LineRange) = 
         match x.FindInsertionPoint lineRange.StartLineNumber with
         | None ->
             // Just insert at the end and let the collapse code do the work in this case 
@@ -499,8 +499,8 @@ type internal NormalizedLineRangeCollection() =
             if removeCount > 0 then
                 _list.RemoveRange(index + 1, removeCount)
 
-    member private x.FindInsertionPoint (startLineNumber : int) =
-        let mutable value : int option = None
+    member private x.FindInsertionPoint (startLineNumber: int) =
+        let mutable value: int option = None
         let mutable index = 0
         while index < _list.Count do
             if startLineNumber <= _list.[index].StartLineNumber then
@@ -510,7 +510,7 @@ type internal NormalizedLineRangeCollection() =
                 index <- index + 1
         value
 
-    static member Create (collection : LineRange seq) = 
+    static member Create (collection: LineRange seq) = 
         let range = NormalizedLineRangeCollection()
         for r in collection do
             range.Add r
@@ -532,15 +532,15 @@ type internal TagCacheState =
 [<Struct>]
 type internal TrackingCacheData<'TTag when 'TTag :> ITag>
     (
-        _trackingSpan : ITrackingSpan,
-        _trackingList : ReadOnlyCollection<(ITrackingSpan * 'TTag)> 
+        _trackingSpan: ITrackingSpan,
+        _trackingList: ReadOnlyCollection<(ITrackingSpan * 'TTag)> 
     ) =
 
     member x.TrackingSpan = _trackingSpan
 
     member x.TrackingList = _trackingList
 
-    member x.Merge (snapshot : ITextSnapshot) (trackingCacheData : TrackingCacheData<'TTag>) =
+    member x.Merge (snapshot: ITextSnapshot) (trackingCacheData: TrackingCacheData<'TTag>) =
         let left = TrackingSpanUtil.GetSpan snapshot (x.TrackingSpan)
         let right = TrackingSpanUtil.GetSpan snapshot trackingCacheData.TrackingSpan
         let span = 
@@ -561,7 +561,7 @@ type internal TrackingCacheData<'TTag when 'TTag :> ITag>
 
     /// Does this tracking information contain tags over the given span in it's 
     /// ITextSnapshot
-    member x.ContainsCachedTags (span : SnapshotSpan) =
+    member x.ContainsCachedTags (span: SnapshotSpan) =
         let snapshot = span.Snapshot
         TrackingSpanUtil.GetSpan snapshot x.TrackingSpan |> Option.isSome
 
@@ -592,9 +592,9 @@ type internal TrackingCacheData<'TTag when 'TTag :> ITag>
 [<Struct>]
 type BackgroundCacheData<'TTag when 'TTag :> ITag> =
 
-    val private _snapshot : ITextSnapshot
-    val private _visitedCollection : NormalizedLineRangeCollection
-    val private _tagList : ReadOnlyCollection<ITagSpan<'TTag>>
+    val private _snapshot: ITextSnapshot
+    val private _visitedCollection: NormalizedLineRangeCollection
+    val private _tagList: ReadOnlyCollection<ITagSpan<'TTag>>
 
     member x.Snapshot = x._snapshot
 
@@ -614,13 +614,13 @@ type BackgroundCacheData<'TTag when 'TTag :> ITag> =
     new (snapshot, visitedCollection, tagList) = 
         { _snapshot = snapshot; _visitedCollection = visitedCollection; _tagList = tagList }
 
-    new (lineRange : SnapshotLineRange, tagList) =
+    new (lineRange: SnapshotLineRange, tagList) =
         let col = NormalizedLineRangeCollection()
         col.Add(lineRange.LineRange)
         { _snapshot = lineRange.Snapshot; _visitedCollection = col; _tagList = tagList }
 
     /// Determine tag cache state we have for the given SnapshotSpan
-    member x.GetTagCacheState (span : SnapshotSpan) =
+    member x.GetTagCacheState (span: SnapshotSpan) =
         // If the requested span doesn't even intersect with the overarching SnapshotSpan
         // of the cached data in the background then a more exhaustive search isn't needed
         // at this time
@@ -650,8 +650,8 @@ type BackgroundCacheData<'TTag when 'TTag :> ITag> =
 
 [<Struct>]
 type internal TagCache<'TTag when 'TTag :> ITag> = 
-    val mutable private _backgroundCacheData : BackgroundCacheData<'TTag> option
-    val mutable private _trackingCacheData : TrackingCacheData<'TTag> option
+    val mutable private _backgroundCacheData: BackgroundCacheData<'TTag> option
+    val mutable private _trackingCacheData: TrackingCacheData<'TTag> option
 
     member x.BackgroundCacheData
         with get() = x._backgroundCacheData
@@ -671,15 +671,15 @@ type internal TagCache<'TTag when 'TTag :> ITag> =
 [<Struct>]
 type internal AsyncBackgroundRequest =
     {
-        Snapshot : ITextSnapshot
-        Channel : Channel
-        Task : Task
-        CancellationTokenSource : CancellationTokenSource
+        Snapshot: ITextSnapshot
+        Channel: Channel
+        Task: Task
+        CancellationTokenSource: CancellationTokenSource
     }
 
 type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag> 
     (
-        _asyncTaggerSource : IAsyncTaggerSource<'TData, 'TTag>
+        _asyncTaggerSource: IAsyncTaggerSource<'TData, 'TTag>
     ) as this = 
 
     /// This number was chosen virtually at random.  In extremely large files it's legal
@@ -700,7 +700,7 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
     /// The one and only active AsyncBackgroundRequest instance.  There can be several
     /// in flight at once.  But we will cancel the earlier ones should a new one be 
     /// requested
-    let mutable _asyncBackgroundRequest : AsyncBackgroundRequest option = None
+    let mutable _asyncBackgroundRequest: AsyncBackgroundRequest option = None
 
     /// The current cache of tags we've provided to our consumer
     let mutable _tagCache = TagCache<'TTag>.Empty
@@ -711,7 +711,7 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
     /// for the cases where IAsyncTaggerSource declares that it changes.  It's not incorrect
     /// to say the overarching SnapshotSpan has changed in this case.  And it's cheaper
     /// to use the overaching span in the case of odd requests like time travel ones
-    let mutable _cachedOverarchingRequestSpan : SnapshotSpan option = None
+    let mutable _cachedOverarchingRequestSpan: SnapshotSpan option = None
 
     let mutable _chunkCount = DefaultChunkCount;
 
@@ -753,7 +753,7 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
     /// returning from our TrackingCacheData over the same SnapshotSpan.  Often times the 
     /// new data is the same as the old hence we don't need to produce any changed information
     /// to the buffer
-    member x.DidTagsChange (span : SnapshotSpan) (tagList : ReadOnlyCollection<ITagSpan<'TTag>>) =
+    member x.DidTagsChange (span: SnapshotSpan) (tagList: ReadOnlyCollection<ITagSpan<'TTag>>) =
         match _tagCache.TrackingCacheData with
         | None -> 
             // Nothing in the tracking cache so it changed if there is anything in the new
@@ -778,7 +778,7 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
 
     /// Get the tags for the specified NormalizedSnapshotSpanCollection.  Use the cache if 
     /// possible and possibly go to the background if necessary
-    member x.GetTags (col : NormalizedSnapshotSpanCollection) =
+    member x.GetTags (col: NormalizedSnapshotSpanCollection) =
         // The editor itself will never send an empty collection to GetTags.  But this is an 
         // API and other components are free to call it with whatever values they like
         if col.Count = 0 then
@@ -791,7 +791,7 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
                 x.GetTagsForSpan col.[0]
             else
                 VimTrace.TraceInfo("AsyncTagger::GetTags Count {0}", col.Count);
-                let mutable all : ITagSpan<'TTag> seq = Seq.empty
+                let mutable all: ITagSpan<'TTag> seq = Seq.empty
                 for span in col do 
                     let current = x.GetTagsForSpan span
                     all <- Seq.append all current
@@ -854,7 +854,7 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
 
     /// Get the tags for the specified SnapshotSpan in a background task.  If there are outstanding
     /// requests for SnapshotSpan values then this one will take priority over those 
-    member x.GetTagsInBackground (span : SnapshotSpan) =
+    member x.GetTagsInBackground (span: SnapshotSpan) =
         let synchronizationContext = SynchronizationContext.Current
         if synchronizationContext <> null then
             // The background processing should now be focussed on the specified ITextSnapshot 
@@ -947,14 +947,14 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
     [<UsedInBackgroundThread>]
     static member GetTagsInBackgroundCore
         (
-            asyncTaggerSource : IAsyncTaggerSource<'TData, 'TTag>,
-            data : 'TData,
-            chunkCount : int,
-            channel : Channel,
-            visited : NormalizedLineRangeCollection,
-            cancellationToken : CancellationToken,
-            onComplete : CompleteReason -> unit,
-            onProgress : SnapshotLineRange -> ReadOnlyCollection<ITagSpan<'TTag>> -> unit
+            asyncTaggerSource: IAsyncTaggerSource<'TData, 'TTag>,
+            data: 'TData,
+            chunkCount: int,
+            channel: Channel,
+            visited: NormalizedLineRangeCollection,
+            cancellationToken: CancellationToken,
+            onComplete: CompleteReason -> unit,
+            onProgress: SnapshotLineRange -> ReadOnlyCollection<ITagSpan<'TTag>> -> unit
         ) =
         let completeReason = 
             try
@@ -988,7 +988,7 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
 
                 // Get the tags for the specified SnapshotLineRange and return the results.  No chunking is done here,
                 // the data is just directly processed
-                let getTags (tagLineRange : SnapshotLineRange) =
+                let getTags (tagLineRange: SnapshotLineRange) =
                     match visited.GetUnvisited tagLineRange.LineRange with
                     | None -> ()
                     | Some unvisited ->
@@ -1058,7 +1058,7 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
 
             _asyncBackgroundRequest <- None
 
-    member private x.AdjustRequestSpan (col : NormalizedSnapshotSpanCollection) =
+    member private x.AdjustRequestSpan (col: NormalizedSnapshotSpanCollection) =
         if col.Count > 0 then
             // Note that we only use the overarching span to track what data we are responsible 
             // for in a
@@ -1135,7 +1135,7 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
     ///
     /// Called on the main thread
     /// </summary>
-    member private x.OnGetTagsInBackgroundProgress cancellationTokenSource (lineRange : SnapshotLineRange) tagList =
+    member private x.OnGetTagsInBackgroundProgress cancellationTokenSource (lineRange: SnapshotLineRange) tagList =
         if x.IsActiveBackgroundRequest cancellationTokenSource then
             // Merge the existing background data if it's present and on the same ITextSnapshot
             let newData =
@@ -1163,7 +1163,7 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
     /// Called when the background request is completed
     ///
     /// Called on the main thread
-    member private x.OnGetTagsInBackgroundComplete reason (channel : Channel) cancellationTokenSource =
+    member private x.OnGetTagsInBackgroundComplete reason (channel: Channel) cancellationTokenSource =
         if x.IsActiveBackgroundRequest cancellationTokenSource then
             // The request is complete.  Reset the active request information
             x.CancelAsyncBackgroundRequest()
@@ -1198,53 +1198,53 @@ type internal AsyncTagger<'TData, 'TTag when 'TTag :> ITag>
 
 module TaggerUtil =
 
-    let CreateAsyncTaggerRaw (asyncTaggerSource : IAsyncTaggerSource<'TData, 'TTag>) =
+    let CreateAsyncTaggerRaw (asyncTaggerSource: IAsyncTaggerSource<'TData, 'TTag>) =
         let tagger = new AsyncTagger<'TData, 'TTag>(asyncTaggerSource)
         tagger :> ITagger<'TTag>
 
-    let CreateAsyncTagger propertyCollection (key : obj) (createFunc : unit -> IAsyncTaggerSource<'TData, 'TTag>) =
+    let CreateAsyncTagger propertyCollection (key: obj) (createFunc: unit -> IAsyncTaggerSource<'TData, 'TTag>) =
         let createTagger () = 
             let source = createFunc ()
             CreateAsyncTaggerRaw source
         let countedTagger = new CountedTagger<'TTag>(propertyCollection, key, createTagger)
         countedTagger :> ITagger<'TTag>
 
-    let CreateAsyncClassifierRaw (asyncTaggerSource : IAsyncTaggerSource<'TData, IClassificationTag>) =
+    let CreateAsyncClassifierRaw (asyncTaggerSource: IAsyncTaggerSource<'TData, IClassificationTag>) =
         let tagger = CreateAsyncTaggerRaw asyncTaggerSource
         let classifier = new Classifier(tagger)
         classifier :> IClassifier
 
-    let CreateAsyncClassifier propertyCollection (key : obj) (createFunc : unit -> IAsyncTaggerSource<'TData, IClassificationTag>) =
+    let CreateAsyncClassifier propertyCollection (key: obj) (createFunc: unit -> IAsyncTaggerSource<'TData, IClassificationTag>) =
         let createClassifier () = 
             let source = createFunc ()
             CreateAsyncClassifierRaw source
         let countedClassifier = new CountedClassifier(propertyCollection, key, createClassifier)
         countedClassifier :> IClassifier
 
-    let CreateBasicTaggerRaw (basicTaggerSource : IBasicTaggerSource<'TTag>) =
+    let CreateBasicTaggerRaw (basicTaggerSource: IBasicTaggerSource<'TTag>) =
         let tagger = new BasicTagger<'TTag>(basicTaggerSource)
         tagger :> ITagger<'TTag>
 
-    let CreateBasicTagger propertyCollection (key : obj) (createFunc : unit -> IBasicTaggerSource<'TTag>) =
+    let CreateBasicTagger propertyCollection (key: obj) (createFunc: unit -> IBasicTaggerSource<'TTag>) =
         let createTagger () = 
             let source = createFunc ()
             CreateBasicTaggerRaw source
         let countedTagger = new CountedTagger<'TTag>(propertyCollection, key, createTagger)
         countedTagger :> ITagger<'TTag>
 
-    let CreateBasicClassifierRaw (basicTaggerSource : IBasicTaggerSource<IClassificationTag>) =
+    let CreateBasicClassifierRaw (basicTaggerSource: IBasicTaggerSource<IClassificationTag>) =
         let tagger = CreateBasicTaggerRaw basicTaggerSource
         let classifier = new Classifier(tagger)
         classifier :> IClassifier
 
-    let CreateBasicClassifier propertyCollection (key : obj) (createFunc : unit -> IBasicTaggerSource<IClassificationTag>) =
+    let CreateBasicClassifier propertyCollection (key: obj) (createFunc: unit -> IBasicTaggerSource<IClassificationTag>) =
         let createClassifier () = 
             let source = createFunc ()
             CreateBasicClassifierRaw source
         let countedClassifier = new CountedClassifier(propertyCollection, key, createClassifier)
         countedClassifier :> IClassifier
 
-    let GetOrCreateOutliner (textBuffer : ITextBuffer) =
+    let GetOrCreateOutliner (textBuffer: ITextBuffer) =
         let outliner = AdhocOutliner.GetOrCreate textBuffer
         outliner :> IAdhocOutliner
 

--- a/Src/VimCore/TaggerUtil.fsi
+++ b/Src/VimCore/TaggerUtil.fsi
@@ -31,15 +31,15 @@ module TaggerUtil =
     val CreateBasicTagger<'TTag when 'TTag :> ITag> : PropertyCollection -> obj -> (unit -> IBasicTaggerSource<'TTag>) -> ITagger<'TTag>
 
     /// Create an IClassifieer implementation for the IBasicTaggerSource.
-    val CreateBasicClassifierRaw : IBasicTaggerSource<IClassificationTag> -> IClassifier
+    val CreateBasicClassifierRaw: IBasicTaggerSource<IClassificationTag> -> IClassifier
 
     /// Create an IClassifieer implementation for the IBasicTaggerSource.
-    val CreateBasicClassifier : PropertyCollection -> obj -> (unit -> IBasicTaggerSource<IClassificationTag>) -> IClassifier
+    val CreateBasicClassifier: PropertyCollection -> obj -> (unit -> IBasicTaggerSource<IClassificationTag>) -> IClassifier
 
     /// Get or create the IAdhocOutliner instance for the given ITextBuffer.  This return will be useless 
     /// unless the code which calls this method exports an ITaggerProvider which proxies the return 
     /// of GetOrCreateOutlinerTagger
-    val GetOrCreateOutliner : ITextBuffer -> IAdhocOutliner
+    val GetOrCreateOutliner: ITextBuffer -> IAdhocOutliner
 
     /// This is the ITagger implementation for IAdhocOutliner
-    val CreateOutlinerTagger : ITextBuffer -> ITagger<OutliningRegionTag>
+    val CreateOutlinerTagger: ITextBuffer -> ITagger<OutliningRegionTag>

--- a/Src/VimCore/TaggingInterfaces.fs
+++ b/Src/VimCore/TaggingInterfaces.fs
@@ -23,90 +23,90 @@ type IAsyncTaggerSource<'TData, 'TTag when 'TTag :> ITag> =
 
     /// Delay in milliseconds which should occur between the call to GetTags and the kicking off
     /// of a background task
-    abstract Delay : int option
+    abstract Delay: int option
 
     /// The current Snapshot.  
     ///
     /// Called from the main thread only
-    abstract TextSnapshot : ITextSnapshot
+    abstract TextSnapshot: ITextSnapshot
 
     /// The current ITextView if this tagger is attached to a ITextView.  This is an optional
     /// value
     ///
     /// Called from the main thread only
-    abstract TextView : ITextView option
+    abstract TextView: ITextView option
 
     /// This method is called to gather data on the UI thread which will then be passed
     /// down to the background thread for processing
     ///
     /// Called from the main thread only
-    abstract GetDataForSnapshot : snapshot : ITextSnapshot -> 'TData
+    abstract GetDataForSnapshot: snapshot: ITextSnapshot -> 'TData
 
     /// Return the applicable tags for the given SnapshotSpan instance.  This will be
     /// called on a background thread and should respect the provided CancellationToken
     ///
     /// Called from the background thread only
     [<UsedInBackgroundThread>]
-    abstract GetTagsInBackground : data : 'TData -> span : SnapshotSpan -> cancellationToken : CancellationToken -> ReadOnlyCollection<ITagSpan<'TTag>>
+    abstract GetTagsInBackground: data: 'TData -> span: SnapshotSpan -> cancellationToken: CancellationToken -> ReadOnlyCollection<ITagSpan<'TTag>>
 
     /// To prevent needless spawning of Task<T> values the async tagger has the option
     /// of providing prompt data.  This method should only be used when determination
     /// of the tokens requires no calculation.
     ///
     /// Called from the main thread only
-    abstract TryGetTagsPrompt : span : SnapshotSpan -> IEnumerable<ITagSpan<'TTag>> option
+    abstract TryGetTagsPrompt: span: SnapshotSpan -> IEnumerable<ITagSpan<'TTag>> option
 
     /// <summary>
     /// Raised by the source when the underlying source has changed.  All previously
     /// provided data should be considered incorrect after this event
     /// </summary>
     [<CLIEvent>]
-    abstract Changed : IDelegateEvent<System.EventHandler>
+    abstract Changed: IDelegateEvent<System.EventHandler>
 
 type IBasicTaggerSource<'TTag when 'TTag :> ITag> = 
 
     /// Get the tags for the given SnapshotSpan
-    abstract GetTags : span : SnapshotSpan -> ReadOnlyCollection<ITagSpan<'TTag>>
+    abstract GetTags: span: SnapshotSpan -> ReadOnlyCollection<ITagSpan<'TTag>>
 
     /// Raised when the source changes in some way
     [<CLIEvent>]
-    abstract Changed : IDelegateEvent<System.EventHandler>
+    abstract Changed: IDelegateEvent<System.EventHandler>
 
 [<StructuralEquality>]
 [<NoComparison>]
 [<Struct>]
 type OutliningRegion =
     {
-        Tag : OutliningRegionTag
-        Span : SnapshotSpan
-        Cookie : int
+        Tag: OutliningRegionTag
+        Span: SnapshotSpan
+        Cookie: int
     }
 
 /// Allows callers to create outlining regions over arbitrary SnapshotSpan values
 type IAdhocOutliner =
 
     /// Get the ITextBuffer associated with this instance
-    abstract TextBuffer : ITextBuffer
+    abstract TextBuffer: ITextBuffer
 
     /// Get all of the regions in the given ITextSnapshot
-    abstract GetOutliningRegions : span : SnapshotSpan -> ReadOnlyCollection<OutliningRegion>
+    abstract GetOutliningRegions: span: SnapshotSpan -> ReadOnlyCollection<OutliningRegion>
 
     /// Create an outlining region over the given SnapshotSpan.  The int value returned is 
     /// a cookie for later deleting the region
-    abstract CreateOutliningRegion : span : SnapshotSpan -> spanTrackingMode : SpanTrackingMode -> text : string -> hint : string -> OutliningRegion
+    abstract CreateOutliningRegion: span: SnapshotSpan -> spanTrackingMode: SpanTrackingMode -> text: string -> hint: string -> OutliningRegion
 
     /// Delete the previously created outlining region with the given cookie
-    abstract DeleteOutliningRegion : cookie : int -> bool
+    abstract DeleteOutliningRegion: cookie: int -> bool
 
     /// Raised when any outlining regions change
     [<CLIEvent>]
-    abstract Changed : IDelegateEvent<System.EventHandler>
+    abstract Changed: IDelegateEvent<System.EventHandler>
 
 [<AbstractClass>]
 type AsyncTaggerSource<'TData, 'TTag when 'TTag :> ITag> 
     (
-        _textBuffer : ITextBuffer,
-        _textView : ITextView option
+        _textBuffer: ITextBuffer,
+        _textView: ITextView option
     ) =
 
     let _changed = StandardEvent()
@@ -123,15 +123,15 @@ type AsyncTaggerSource<'TData, 'TTag when 'TTag :> ITag>
     [<CLIEvent>]
     member x.Changed = _changed.Publish
 
-    abstract TryGetTagsPrompt : span : SnapshotSpan -> IEnumerable<ITagSpan<'TTag>> option
-    default x.TryGetTagsPrompt (span : SnapshotSpan) : IEnumerable<ITagSpan<'TTag>> option = None
+    abstract TryGetTagsPrompt: span: SnapshotSpan -> IEnumerable<ITagSpan<'TTag>> option
+    default x.TryGetTagsPrompt (span: SnapshotSpan): IEnumerable<ITagSpan<'TTag>> option = None
 
     /// Get the data needed in the background thread from the specified SnapshotSpan.  This is called on
     /// the main thread
-    abstract GetDataForSnapshot : snapshot : ITextSnapshot -> 'TData
+    abstract GetDataForSnapshot: snapshot: ITextSnapshot -> 'TData
 
     /// Get the tags for the specified span.  This is called on the background thread
-    abstract GetTagsInBackground : data : 'TData -> span : SnapshotSpan -> cancellationToken : CancellationToken -> ReadOnlyCollection<ITagSpan<'TTag>> 
+    abstract GetTagsInBackground: data: 'TData -> span: SnapshotSpan -> cancellationToken: CancellationToken -> ReadOnlyCollection<ITagSpan<'TTag>> 
 
     interface IAsyncTaggerSource<'TData, 'TTag> with
         member x.Delay = Option.Some DefaultAsyncDelay

--- a/Src/VimCore/TextObjectUtil.fs
+++ b/Src/VimCore/TextObjectUtil.fs
@@ -44,8 +44,8 @@ type internal SectionKind =
 
 type internal TextObjectUtil
     (
-        _globalSettings : IVimGlobalSettings,
-        _textBuffer : ITextBuffer
+        _globalSettings: IVimGlobalSettings,
+        _textBuffer: ITextBuffer
     ) = 
 
     /// List of characters which represent the end of a sentence. 
@@ -58,14 +58,14 @@ type internal TextObjectUtil
     member x.CurrentSnapshot = _textBuffer.CurrentSnapshot
 
     /// Is the line above the specified line empty
-    member x.IsLineAboveEmpty (line : ITextSnapshotLine) = 
+    member x.IsLineAboveEmpty (line: ITextSnapshotLine) = 
         let number = line.LineNumber - 1
         match SnapshotUtil.TryGetLine line.Snapshot number with
         | None -> true
         | Some line -> SnapshotLineUtil.IsEmpty line
 
     /// Is the line above the specified line blank or empty
-    member x.IsLineAboveBlankOrEmpty (line : ITextSnapshotLine) = 
+    member x.IsLineAboveBlankOrEmpty (line: ITextSnapshotLine) = 
         let number = line.LineNumber - 1
         match SnapshotUtil.TryGetLine line.Snapshot number with
         | None -> true
@@ -93,7 +93,7 @@ type internal TextObjectUtil
 
     /// Is this point the start of a paragraph.  Considers both paragraph and section 
     /// start points
-    member x.IsParagraphStart (column : SnapshotColumn) =
+    member x.IsParagraphStart (column: SnapshotColumn) =
         if column.IsStartOfLine then
             let line = column.Line
             x.IsParagraphStartOnly line || x.IsSectionStart SectionKind.Default line
@@ -144,7 +144,7 @@ type internal TextObjectUtil
 
     /// Is this the end point of the span of an actual sentence.  Considers sentence, paragraph and 
     /// section semantics
-    member x.IsSentenceEnd sentenceKind (column : SnapshotColumn) = 
+    member x.IsSentenceEnd sentenceKind (column: SnapshotColumn) = 
         let line = column.Line
         if column.IsStartOfLine && x.IsSentenceLine line then
             // If this point is the start of a sentence line then it's the end point of the
@@ -172,7 +172,7 @@ type internal TextObjectUtil
 
     /// Checks for a simple end of a sentence.  Only checks for the characters case and
     /// will ignore items like sentence lines and new lines
-    member x.IsSentenceEndSimple sentenceKind (column : SnapshotColumn) = 
+    member x.IsSentenceEndSimple sentenceKind (column: SnapshotColumn) = 
         if not (x.IsSentenceEndWhiteSpace column.Point) then
             // If the column doesn't begin in the white space that ends a sentence then
             // this can't possible be the end of a simple sentence
@@ -183,7 +183,7 @@ type internal TextObjectUtil
 
     /// Checks for the last character of a simple sentence.  Only checks for the characters 
     /// case and will ignore items like sentence lines
-    member x.IsSentenceLastSimple sentenceKind (point : SnapshotPoint) = 
+    member x.IsSentenceLastSimple sentenceKind (point: SnapshotPoint) = 
         // Is the char for the provided point in the given list.  Make sure to 
         // account for the snapshot end point here as it makes the remaining 
         // logic easier 
@@ -215,7 +215,7 @@ type internal TextObjectUtil
 
     /// Is this point the star of a sentence.  Considers sentences, paragraphs and section
     /// boundaries
-    member x.IsSentenceStart sentenceKind (column : SnapshotColumn) = 
+    member x.IsSentenceStart sentenceKind (column: SnapshotColumn) = 
         if x.IsSentenceStartOnly sentenceKind column then
             true
         else
@@ -234,7 +234,7 @@ type internal TextObjectUtil
 
     /// Is the start of a sentence.  This doesn't consider section or paragraph boundaries
     /// but specifically items related to the start of a sentence
-    member x.IsSentenceStartOnly sentenceKind (column : SnapshotColumn) = 
+    member x.IsSentenceStartOnly sentenceKind (column: SnapshotColumn) = 
         let mutable adjustedColumn = column 
         while adjustedColumn.Column > 0 && SnapshotPointUtil.IsBlank (adjustedColumn.Point.Subtract(1)) do
             adjustedColumn <- adjustedColumn.Subtract 1
@@ -266,7 +266,7 @@ type internal TextObjectUtil
                 x.IsSentenceEnd sentenceKind column
 
     /// Is the SnapshotPoint in the white space between sentences
-    member x.IsSentenceWhiteSpace sentenceKind (column : SnapshotColumn) =
+    member x.IsSentenceWhiteSpace sentenceKind (column: SnapshotColumn) =
         if column.IsStartOfLine && x.IsEmptyLineWithNoEmptyAbove column.Line then
             false
         else
@@ -288,7 +288,7 @@ type internal TextObjectUtil
 
     /// This function is used to match nroff macros for both section and paragraph sections.  It 
     /// determines if the line starts with the proper macro string
-    member x.IsTextMacroMatchLine (line : ITextSnapshotLine) macroString =
+    member x.IsTextMacroMatchLine (line: ITextSnapshotLine) macroString =
         let isLengthCorrect = 0 = (String.length macroString) % 2
         if not isLengthCorrect then 
             // Match can only occur with a valid macro string length
@@ -318,7 +318,7 @@ type internal TextObjectUtil
     member x.GetParagraphs path point = 
 
         // Get the full span of a paragraph given a start point
-        let getFullSpanFromStartColumn (column : SnapshotColumn) =
+        let getFullSpanFromStartColumn (column: SnapshotColumn) =
             Contract.Assert (x.IsParagraphStart column)
             let point = column.Point
             let snapshot = SnapshotPointUtil.GetSnapshot point
@@ -424,10 +424,10 @@ type internal TextObjectUtil
     /// Get the SnapshotSpan values for the sentence values starting from the given SnapshotPoint 
     /// in the specified direction.  Note: The full span of the section will be returned if the 
     /// provided SnapshotPoint is in the middle of it
-    member x.GetSentences sentenceKind path (point : SnapshotPoint) =
+    member x.GetSentences sentenceKind path (point: SnapshotPoint) =
 
         // Get the full span of a sentence given the particular start point
-        let getFullSpanFromStartColumn (column : SnapshotColumn) =
+        let getFullSpanFromStartColumn (column: SnapshotColumn) =
             Contract.Assert (x.IsSentenceStart sentenceKind column)
 
             let point = column.Point
@@ -447,14 +447,14 @@ type internal TextObjectUtil
         x.GetTextObjectsCore point path (x.IsSentenceStart sentenceKind) getFullSpanFromStartColumn
 
     /// Get the text objects core from the given point in the given direction
-    member x.GetTextObjectsCore (point : SnapshotPoint) path (isStartColumn : SnapshotColumn -> bool) (getSpanFromStartColumn : SnapshotColumn -> SnapshotSpan) = 
+    member x.GetTextObjectsCore (point: SnapshotPoint) path (isStartColumn: SnapshotColumn -> bool) (getSpanFromStartColumn: SnapshotColumn -> SnapshotSpan) = 
 
         let column = SnapshotColumnUtil.CreateFromPoint point
         let snapshot = SnapshotPointUtil.GetSnapshot point
         let isNotStartColumn column = not (isStartColumn column)
 
         // Wrap the get full span method to deal with <end>.  
-        let getSpanFromStartColumn (column : SnapshotColumn) = 
+        let getSpanFromStartColumn (column: SnapshotColumn) = 
             if SnapshotPointUtil.IsEndPoint column.Point then
                 SnapshotSpan(column.Point, 0)
             else

--- a/Src/VimCore/TextObjectUtil.fsi
+++ b/Src/VimCore/TextObjectUtil.fsi
@@ -43,29 +43,29 @@ type internal SectionKind =
 
 type internal TextObjectUtil =
 
-    new : globalSettings : IVimGlobalSettings * textBuffer : ITextBuffer -> TextObjectUtil
+    new: globalSettings: IVimGlobalSettings * textBuffer: ITextBuffer -> TextObjectUtil
 
     /// Get the SnapshotSpan values for the paragraph object starting from the given SnapshotPoint
     /// in the specified direction.  
-    member GetParagraphs : path : SearchPath -> point : SnapshotPoint -> SnapshotSpan seq
+    member GetParagraphs: path: SearchPath -> point: SnapshotPoint -> SnapshotSpan seq
 
     /// Get the SnapshotLineRange values for the section values starting from the given SnapshotPoint 
     /// in the specified direction.  Note: The full span of the section will be returned if the 
     /// provided SnapshotPoint is in the middle of it
-    member GetSectionRanges : sectionKind : SectionKind -> path : SearchPath -> point : SnapshotPoint -> SnapshotLineRange seq
+    member GetSectionRanges: sectionKind: SectionKind -> path: SearchPath -> point: SnapshotPoint -> SnapshotLineRange seq
 
     /// Get the SnapshotSpan values for the section values starting from the given SnapshotPoint 
     /// in the specified direction.  Note: The full span of the section will be returned if the 
     /// provided SnapshotPoint is in the middle of it
-    member GetSections : sectionKind : SectionKind -> path : SearchPath -> point : SnapshotPoint -> SnapshotSpan seq
+    member GetSections: sectionKind: SectionKind -> path: SearchPath -> point: SnapshotPoint -> SnapshotSpan seq
 
     /// Get the SnapshotSpan values for the sentence values starting from the given SnapshotPoint 
     /// in the specified direction.  Note: The full span of the section will be returned if the 
     /// provided SnapshotPoint is in the middle of it
-    member GetSentences : sentenceKind : SentenceKind -> path : SearchPath -> point : SnapshotPoint -> SnapshotSpan seq
+    member GetSentences: sentenceKind: SentenceKind -> path: SearchPath -> point: SnapshotPoint -> SnapshotSpan seq
 
     /// Is the SnapshotPoint the start of a sentence 
-    member IsSentenceStart : sentenceKind : SentenceKind -> column : SnapshotColumn -> bool
+    member IsSentenceStart: sentenceKind: SentenceKind -> column: SnapshotColumn -> bool
 
     /// Is the SnapshotPoint in the white space between sentences
-    member IsSentenceWhiteSpace : sentenceKind : SentenceKind -> column : SnapshotColumn -> bool
+    member IsSentenceWhiteSpace: sentenceKind: SentenceKind -> column: SnapshotColumn -> bool

--- a/Src/VimCore/TextUtil.fsi
+++ b/Src/VimCore/TextUtil.fsi
@@ -6,13 +6,13 @@ open Microsoft.VisualStudio.Text
 module internal TextUtil = 
 
     /// Is this a word character for the specified WordKind
-    val IsWordChar : WordKind -> char -> bool
+    val IsWordChar: WordKind -> char -> bool
 
     /// Get the spans of word values in the given string in the provided direction
-    val GetWordSpans : WordKind -> SearchPath -> string -> Span seq
+    val GetWordSpans: WordKind -> SearchPath -> string -> Span seq
 
-    val FindCurrentWordSpan : WordKind -> string -> int -> option<Span>
-    val FindFullWordSpan : WordKind -> string -> int -> option<Span>
-    val FindPreviousWordSpan : WordKind -> string -> int -> option<Span>
-    val FindNextWordSpan : WordKind -> string -> int -> option<Span>
+    val FindCurrentWordSpan: WordKind -> string -> int -> option<Span>
+    val FindFullWordSpan: WordKind -> string -> int -> option<Span>
+    val FindPreviousWordSpan: WordKind -> string -> int -> option<Span>
+    val FindNextWordSpan: WordKind -> string -> int -> option<Span>
 

--- a/Src/VimCore/UndoRedoOperations.fs
+++ b/Src/VimCore/UndoRedoOperations.fs
@@ -38,9 +38,9 @@ type TransactionCloseResult =
 
 type NormalUndoTransaction 
     (
-        _name : string,
-        _transaction : ITextUndoTransaction option,
-        _undoRedoOperations : UndoRedoOperations
+        _name: string,
+        _transaction: ITextUndoTransaction option,
+        _undoRedoOperations: UndoRedoOperations
     ) =
 
     let mutable _isComplete = false
@@ -70,10 +70,10 @@ type NormalUndoTransaction
 
 and TextViewUndoTransaction 
     (
-        _name : string,
-        _transaction : ITextUndoTransaction option,
-        _editorOperations : IEditorOperations option,
-        _undoRedoOperations : UndoRedoOperations
+        _name: string,
+        _transaction: ITextUndoTransaction option,
+        _editorOperations: IEditorOperations option,
+        _undoRedoOperations: UndoRedoOperations
     ) =
     inherit NormalUndoTransaction(_name, _transaction, _undoRedoOperations)
 
@@ -93,9 +93,9 @@ and TextViewUndoTransaction
 /// that it is linked to
 and LinkedUndoTransaction
     (
-        _name : string,
-        _flags : LinkedUndoTransactionFlags,
-        _undoRedoOperations : UndoRedoOperations
+        _name: string,
+        _flags: LinkedUndoTransactionFlags,
+        _undoRedoOperations: UndoRedoOperations
     ) = 
 
     let mutable _isComplete = false
@@ -121,10 +121,10 @@ and LinkedUndoTransaction
 /// undo rather than throwing and killing the ITextBuffer.  
 and UndoRedoOperations 
     (
-        _vimHost : IVimHost,
-        _statusUtil : IStatusUtil,
-        _textUndoHistory : ITextUndoHistory option,
-        _editorOperationsFactoryService : IEditorOperationsFactoryService
+        _vimHost: IVimHost,
+        _statusUtil: IStatusUtil,
+        _textUndoHistory: ITextUndoHistory option,
+        _editorOperationsFactoryService: IEditorOperationsFactoryService
     ) as this =
 
     let _linkedUndoTransactionStack = Stack<LinkedUndoTransaction>()
@@ -133,8 +133,8 @@ and UndoRedoOperations
 
     // Contains the active set of operations to undo from the perspective of Vim.  If 
     // there is no history this should always be empty
-    let mutable _undoStack : UndoRedoData list = List.empty
-    let mutable _redoStack : UndoRedoData list = List.empty
+    let mutable _undoStack: UndoRedoData list = List.empty
+    let mutable _redoStack: UndoRedoData list = List.empty
     let _bag = DisposableBag()
 
     do
@@ -221,7 +221,7 @@ and UndoRedoOperations
             VimTrace.TraceInfo("!!! Broken undo / redo chain")
             _statusUtil.OnError Resources.Undo_ChainBroken
 
-    member x.CreateUndoTransaction (name : string) = 
+    member x.CreateUndoTransaction (name: string) = 
         VimTrace.TraceInfo("Open Undo Transaction: {0}", name)
         let undoTransaction = 
             match _textUndoHistory with
@@ -234,7 +234,7 @@ and UndoRedoOperations
         _normalUndoTransactionStack.Push(undoTransaction)
         undoTransaction :> IUndoTransaction
 
-    member x.CreateTextViewUndoTransaction (name : string) (textView : ITextView) = 
+    member x.CreateTextViewUndoTransaction (name: string) (textView: ITextView) = 
         VimTrace.TraceInfo("Open Text View Undo Transaction: {0}", name)
         let textViewUndoTransaction = 
             match _textUndoHistory with
@@ -252,7 +252,7 @@ and UndoRedoOperations
         textViewUndoTransaction :> ITextViewUndoTransaction
 
     /// Create a linked undo transaction.
-    member x.CreateLinkedUndoTransaction (name : string) flags =
+    member x.CreateLinkedUndoTransaction (name: string) flags =
         VimTrace.TraceInfo("Open Linked Undo Transaction: {0}", name)
 
         // A linked undo transaction works by simply counting all of the normal undo transactions
@@ -333,7 +333,7 @@ and UndoRedoOperations
 
     /// Called when a transaction is closed.  Need to determine the close state based on the current
     /// expected undo stack 
-    member x.UndoTransactionClosedCore<'T> (undoTransaction : 'T) (stack : Stack<'T>) : TransactionCloseResult =
+    member x.UndoTransactionClosedCore<'T> (undoTransaction: 'T) (stack: Stack<'T>): TransactionCloseResult =
         if stack.Count > 0 then
             if obj.ReferenceEquals(stack.Peek(), undoTransaction) then
                 // This is the most recently open linked transaction which is what we are expecting
@@ -351,7 +351,7 @@ and UndoRedoOperations
     ///
     ///     - transactions we orphaned in ResetState because of detected errors
     ///     - transactions closed out of order 
-    member x.LinkedUndoTransactionClosed (linkedUndoTransaction : LinkedUndoTransaction) = 
+    member x.LinkedUndoTransactionClosed (linkedUndoTransaction: LinkedUndoTransaction) = 
         match x.UndoTransactionClosedCore linkedUndoTransaction _linkedUndoTransactionStack with
         | TransactionCloseResult.Expected -> 
             if _linkedUndoTransactionStack.Count = 0 && Option.isSome _textUndoHistory then
@@ -387,7 +387,7 @@ and UndoRedoOperations
     ///
     ///     - transactions we orphaned in ResetState because of detected errors
     ///     - transactions closed out of order 
-    member x.NormalUndoTransactionClosed (normalUndoTransaction : NormalUndoTransaction) = 
+    member x.NormalUndoTransactionClosed (normalUndoTransaction: NormalUndoTransaction) = 
         match x.UndoTransactionClosedCore normalUndoTransaction _normalUndoTransactionStack with
         | TransactionCloseResult.Expected -> ()
         | TransactionCloseResult.Orphaned -> ()

--- a/Src/VimCore/UndoRedoOperations.fsi
+++ b/Src/VimCore/UndoRedoOperations.fsi
@@ -8,5 +8,5 @@ open Microsoft.VisualStudio.Text.Operations
 
 type UndoRedoOperations =
     interface IUndoRedoOperations
-    new : IVimHost * IStatusUtil * ITextUndoHistory option * IEditorOperationsFactoryService -> UndoRedoOperations
+    new: IVimHost * IStatusUtil * ITextUndoHistory option * IEditorOperationsFactoryService -> UndoRedoOperations
 

--- a/Src/VimCore/Util.fs
+++ b/Src/VimCore/Util.fs
@@ -18,11 +18,11 @@ module internal Util =
         LanguagePrimitives.EnumOfValue value
 
     /// Get the declared values of the specified enumeration
-    let GetEnumValues<'T when 'T : enum<int>>() : 'T seq=
+    let GetEnumValues<'T when 'T: enum<int>>(): 'T seq=
         System.Enum.GetValues(typeof<'T>) |> Seq.cast<'T>
 
     /// Type safe helper method for creating a WeakReference<'T>
-    let CreateWeakReference<'T when 'T : not struct> (value : 'T) =
+    let CreateWeakReference<'T when 'T: not struct> (value: 'T) =
         let weakRef = System.WeakReference(value)
         Vim.WeakReference<'T>(weakRef)
 

--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -19,19 +19,19 @@ open Vim.Interpreter
 [<DataContract>]
 type SessionRegisterValue = {
     [<field: DataMember(Name = "name")>] 
-    Name : char
+    Name: char
 
     [<field: DataMember(Name = "isCharacterWise")>]
-    IsCharacterWise : bool
+    IsCharacterWise: bool
 
     [<field: DataMember(Name = "value")>]
-    Value : string
+    Value: string
 }
 
 [<DataContract>]
 type SessionData = {
     [<field: DataMember(Name = "registers")>]
-    Registers : SessionRegisterValue[]
+    Registers: SessionRegisterValue[]
 } 
     with
 
@@ -42,7 +42,7 @@ type SessionData = {
 type internal BulkOperations  
     [<ImportingConstructor>]
     (
-        _vimHost : IVimHost
+        _vimHost: IVimHost
     ) =
 
     /// The active count of bulk operations
@@ -67,22 +67,22 @@ type internal BulkOperations
         member x.InBulkOperation = _bulkOperationCount > 0
         member x.BeginBulkOperation () = x.BeginBulkOperation()
 
-type internal VimData(_globalSettings : IVimGlobalSettings) as this =
+type internal VimData(_globalSettings: IVimGlobalSettings) as this =
 
-    let mutable _autoCommandGroups : AutoCommandGroup list = List.Empty
-    let mutable _autoCommands : AutoCommand list = List.Empty
+    let mutable _autoCommandGroups: AutoCommandGroup list = List.Empty
+    let mutable _autoCommands: AutoCommand list = List.Empty
     let mutable _currentDirectory = System.Environment.CurrentDirectory
     let mutable _previousCurrentDirecotry = _currentDirectory
     let mutable _commandHistory = HistoryList()
     let mutable _searchHistory = HistoryList()
-    let mutable _lastSubstituteData : SubstituteData option = None
+    let mutable _lastSubstituteData: SubstituteData option = None
     let mutable _lastSearchData = SearchData("", SearchPath.Forward)
-    let mutable _lastShellCommand : string option = None
-    let mutable _lastTextInsert : string option = None
-    let mutable _lastCharSearch : (CharSearchKind * SearchPath * char) option = None
-    let mutable _lastMacroRun : char option = None
-    let mutable _lastCommand : StoredCommand option = None
-    let mutable _lastVisualSelection : StoredVisualSelection option = None
+    let mutable _lastShellCommand: string option = None
+    let mutable _lastTextInsert: string option = None
+    let mutable _lastCharSearch: (CharSearchKind * SearchPath * char) option = None
+    let mutable _lastMacroRun: char option = None
+    let mutable _lastCommand: StoredCommand option = None
+    let mutable _lastVisualSelection: StoredVisualSelection option = None
     let mutable _lastCommandLine = ""
     let mutable _displayPattern = ""
     let mutable _displayPatternSuspended = false
@@ -189,27 +189,27 @@ type internal VimBufferFactory
 
     [<ImportingConstructor>]
     (
-        _host : IVimHost,
-        _editorOperationsFactoryService : IEditorOperationsFactoryService,
-        _editorOptionsFactoryService : IEditorOptionsFactoryService,
-        _outliningManagerService : IOutliningManagerService,
-        _completionWindowBrokerFactoryService : IDisplayWindowBrokerFactoryService,
-        _commonOperationsFactory : ICommonOperationsFactory,
-        _wordUtil : IWordUtil,
-        _lineChangeTrackerFactory : ILineChangeTrackerFactory,
-        _textSearchService : ITextSearchService,
-        _bufferTrackingService : IBufferTrackingService,
-        _undoManagerProvider : ITextBufferUndoManagerProvider,
-        _statusUtilFactory : IStatusUtilFactory,
-        _foldManagerFactory : IFoldManagerFactory,
-        _keyboardDevice : IKeyboardDevice,
-        _mouseDevice : IMouseDevice,
-        _wordCompletionSessionFactoryService : IWordCompletionSessionFactoryService,
-        _bulkOperations : IBulkOperations
+        _host: IVimHost,
+        _editorOperationsFactoryService: IEditorOperationsFactoryService,
+        _editorOptionsFactoryService: IEditorOptionsFactoryService,
+        _outliningManagerService: IOutliningManagerService,
+        _completionWindowBrokerFactoryService: IDisplayWindowBrokerFactoryService,
+        _commonOperationsFactory: ICommonOperationsFactory,
+        _wordUtil: IWordUtil,
+        _lineChangeTrackerFactory: ILineChangeTrackerFactory,
+        _textSearchService: ITextSearchService,
+        _bufferTrackingService: IBufferTrackingService,
+        _undoManagerProvider: ITextBufferUndoManagerProvider,
+        _statusUtilFactory: IStatusUtilFactory,
+        _foldManagerFactory: IFoldManagerFactory,
+        _keyboardDevice: IKeyboardDevice,
+        _mouseDevice: IMouseDevice,
+        _wordCompletionSessionFactoryService: IWordCompletionSessionFactoryService,
+        _bulkOperations: IBulkOperations
     ) =
 
     /// Create an IVimTextBuffer instance for the provided ITextBuffer
-    member x.CreateVimTextBuffer (textBuffer : ITextBuffer) (vim : IVim) = 
+    member x.CreateVimTextBuffer (textBuffer: ITextBuffer) (vim: IVim) = 
         let localSettings = LocalSettings(vim.GlobalSettings) :> IVimLocalSettings
         let wordNavigator = _wordUtil.CreateTextStructureNavigator WordKind.NormalWord textBuffer.ContentType
         let statusUtil = _statusUtilFactory.GetStatusUtilForBuffer textBuffer
@@ -224,7 +224,7 @@ type internal VimBufferFactory
 
     /// Create a VimBufferData instance for the given ITextView and IVimTextBuffer.  This is mainly
     /// used for testing purposes
-    member x.CreateVimBufferData (vimTextBuffer : IVimTextBuffer) (textView : ITextView) =
+    member x.CreateVimBufferData (vimTextBuffer: IVimTextBuffer) (textView: ITextView) =
         Contract.Requires (vimTextBuffer.TextBuffer = textView.TextBuffer)
 
         let vim = vimTextBuffer.Vim
@@ -236,7 +236,7 @@ type internal VimBufferFactory
         VimBufferData(vimTextBuffer, textView, windowSettings, jumpList, statusUtil, _wordUtil) :> IVimBufferData
 
     /// Create an IVimBuffer instance for the provided VimBufferData
-    member x.CreateVimBuffer (vimBufferData : IVimBufferData) = 
+    member x.CreateVimBuffer (vimBufferData: IVimBufferData) = 
         let textView = vimBufferData.TextView
         let commonOperations = _commonOperationsFactory.GetCommonOperations vimBufferData
         let wordUtil = vimBufferData.WordUtil
@@ -304,7 +304,7 @@ type internal VimBufferFactory
     /// often are, passed to CreateVimBuffer in an uninitialized state.  In that state certain
     /// operations like Select can't be done.  Hence we have to delay the mode switch until 
     /// the ITextView is fully initialized.  Put all of that logic here.
-    member x.SetupInitialMode (vimBuffer : IVimBuffer) =
+    member x.SetupInitialMode (vimBuffer: IVimBuffer) =
 
         let textView = vimBuffer.TextView
         let vimBufferData = vimBuffer.VimBufferData
@@ -352,21 +352,21 @@ type internal VimBufferFactory
 [<Export(typeof<IVim>)>]
 type internal Vim
     (
-        _vimHost : IVimHost,
-        _bufferFactoryService : IVimBufferFactory,
-        _interpreterFactory : IVimInterpreterFactory,
-        _bufferCreationListeners : Lazy<IVimBufferCreationListener> list,
-        _globalSettings : IVimGlobalSettings,
-        _markMap : IMarkMap,
-        _keyMap : IKeyMap,
-        _clipboardDevice : IClipboardDevice,
-        _search : ISearchService,
-        _fileSystem : IFileSystem,
-        _vimData : IVimData,
-        _bulkOperations : IBulkOperations,
-        _variableMap : VariableMap,
-        _editorToSettingSynchronizer : IEditorToSettingsSynchronizer,
-        _statusUtilFactory : IStatusUtilFactory
+        _vimHost: IVimHost,
+        _bufferFactoryService: IVimBufferFactory,
+        _interpreterFactory: IVimInterpreterFactory,
+        _bufferCreationListeners: Lazy<IVimBufferCreationListener> list,
+        _globalSettings: IVimGlobalSettings,
+        _markMap: IMarkMap,
+        _keyMap: IKeyMap,
+        _clipboardDevice: IClipboardDevice,
+        _search: ISearchService,
+        _fileSystem: IFileSystem,
+        _vimData: IVimData,
+        _bulkOperations: IBulkOperations,
+        _variableMap: VariableMap,
+        _editorToSettingSynchronizer: IEditorToSettingsSynchronizer,
+        _statusUtilFactory: IStatusUtilFactory
     ) as this =
 
     /// This key is placed in the ITextView property bag to note that vim buffer creation has
@@ -381,7 +381,7 @@ type internal Vim
     let _vimBufferMap = Dictionary<ITextView, IVimBuffer * IVimInterpreter * DisposableBag>()
 
     /// Holds the active stack of IVimBuffer instances
-    let mutable _activeBufferStack : IVimBuffer list = List.empty
+    let mutable _activeBufferStack: IVimBuffer list = List.empty
 
     /// Whether or not the vimrc file should be automatically loaded before creating the 
     /// first IVimBuffer instance
@@ -436,17 +436,17 @@ type internal Vim
 
     [<ImportingConstructor>]
     new(
-        host : IVimHost,
-        bufferFactoryService : IVimBufferFactory,
-        interpreterFactory : IVimInterpreterFactory,
-        bufferTrackingService : IBufferTrackingService,
-        [<ImportMany>] bufferCreationListeners : Lazy<IVimBufferCreationListener> seq,
-        search : ITextSearchService,
-        fileSystem : IFileSystem,
-        clipboard : IClipboardDevice,
-        bulkOperations : IBulkOperations,
-        editorToSettingSynchronizer : IEditorToSettingsSynchronizer,
-        statusUtilFactory : IStatusUtilFactory) =
+        host: IVimHost,
+        bufferFactoryService: IVimBufferFactory,
+        interpreterFactory: IVimInterpreterFactory,
+        bufferTrackingService: IBufferTrackingService,
+        [<ImportMany>] bufferCreationListeners: Lazy<IVimBufferCreationListener> seq,
+        search: ITextSearchService,
+        fileSystem: IFileSystem,
+        clipboard: IClipboardDevice,
+        bulkOperations: IBulkOperations,
+        editorToSettingSynchronizer: IEditorToSettingsSynchronizer,
+        statusUtilFactory: IStatusUtilFactory) =
         let markMap = MarkMap(bufferTrackingService)
         let globalSettings = GlobalSettings() :> IVimGlobalSettings
         let vimData = VimData(globalSettings) :> IVimData
@@ -539,7 +539,7 @@ type internal Vim
     /// Create an IVimTextBuffer for the given ITextBuffer.  If an IVimLocalSettings instance is 
     /// provided then attempt to copy them into the created IVimTextBuffer copy of the 
     /// IVimLocalSettings
-    member x.CreateVimTextBuffer (textBuffer : ITextBuffer) (localSettings : IVimLocalSettings option) = 
+    member x.CreateVimTextBuffer (textBuffer: ITextBuffer) (localSettings: IVimLocalSettings option) = 
         if textBuffer.Properties.ContainsProperty _vimTextBufferKey then
             invalidArg "textBuffer" Resources.Vim_TextViewAlreadyHasVimBuffer
 
@@ -566,7 +566,7 @@ type internal Vim
     /// Create an IVimBuffer for the given ITextView and associated IVimTextBuffer.  This 
     /// will not notify the IVimBufferCreationListener collection about the new
     /// IVimBuffer
-    member x.CreateVimBufferCore textView (windowSettings : IVimWindowSettings option) =
+    member x.CreateVimBufferCore textView (windowSettings: IVimWindowSettings option) =
         if _vimBufferMap.ContainsKey(textView) then 
             invalidArg "textView" Resources.Vim_TextViewAlreadyHasVimBuffer
 
@@ -612,7 +612,7 @@ type internal Vim
         _bufferCreationListeners |> Seq.iter (fun x -> x.Value.VimBufferCreated vimBuffer)
         vimBuffer
 
-    member x.GetVimInterpreter (vimBuffer : IVimBuffer) = 
+    member x.GetVimInterpreter (vimBuffer: IVimBuffer) = 
         let tuple = _vimBufferMap.TryGetValue vimBuffer.TextView
         match tuple with 
         | (true, (_, vimInterpreter, _)) -> vimInterpreter
@@ -662,7 +662,7 @@ type internal Vim
             let bag = new DisposableBag()
             let errorList = List<string>()
             let textView = _vimHost.CreateHiddenTextView()
-            let mutable createdVimBuffer : IVimBuffer option = None
+            let mutable createdVimBuffer: IVimBuffer option = None
 
             try
                 // For the vimrc IVimBuffer we go straight to the factory methods.  We don't want
@@ -727,7 +727,7 @@ type internal Vim
 
     /// Called when there is no vimrc file.  Update IVimGlobalSettings to be the appropriate
     /// value for what the host requests
-    member x.LoadDefaultSettings() : unit = 
+    member x.LoadDefaultSettings(): unit = 
         match _vimHost.DefaultSettings with
         | DefaultSettings.GVim73 ->
             // Strictly speaking this is not the default for 7.3.  However given this is running
@@ -766,7 +766,7 @@ type internal Vim
             with
                 _ -> SessionData.Empty
 
-    member x.WriteSessionData (sessionData : SessionData) filePath = 
+    member x.WriteSessionData (sessionData: SessionData) filePath = 
         let serializer = new DataContractJsonSerializer(typeof<SessionData>)
         use stream = new MemoryStream()
         try
@@ -813,7 +813,7 @@ type internal Vim
             bag.DisposeAll()
         _vimBufferMap.Remove textView
 
-    member x.TryGetVimBuffer(textView : ITextView, [<Out>] vimBuffer : IVimBuffer byref) =
+    member x.TryGetVimBuffer(textView: ITextView, [<Out>] vimBuffer: IVimBuffer byref) =
         let tuple = _vimBufferMap.TryGetValue textView
         match tuple with 
         | (true, (buffer, _, _)) -> 
@@ -832,7 +832,7 @@ type internal Vim
     /// Also we want to reduce the number of times we ask the host this question.  The determination
     /// could be expensive and there is no need to do it over and over again.  Scenarios like
     /// the command window end up forcing this code path a large number of times.  
-    member x.ShouldCreateVimBuffer (textView : ITextView) = 
+    member x.ShouldCreateVimBuffer (textView: ITextView) = 
         match PropertyCollectionUtil.GetValue<bool> ShouldCreateVimBufferKey textView.Properties with 
         | Some value -> value
         | None -> 
@@ -840,7 +840,7 @@ type internal Vim
             textView.Properties.AddProperty(ShouldCreateVimBufferKey, (box value))
             value
 
-    member x.TryGetOrCreateVimBufferForHost(textView : ITextView, [<Out>] vimBuffer : IVimBuffer byref) =
+    member x.TryGetOrCreateVimBufferForHost(textView: ITextView, [<Out>] vimBuffer: IVimBuffer byref) =
         if x.TryGetVimBuffer(textView, &vimBuffer) then
             true
         elif x.ShouldCreateVimBuffer textView then
@@ -850,7 +850,7 @@ type internal Vim
         else
             false
 
-    member x.TryGetVimTextBuffer (textBuffer : ITextBuffer, [<Out>] vimTextBuffer : IVimTextBuffer byref) =
+    member x.TryGetVimTextBuffer (textBuffer: ITextBuffer, [<Out>] vimTextBuffer: IVimTextBuffer byref) =
         match PropertyCollectionUtil.GetValue<IVimTextBuffer> _vimTextBufferKey textBuffer.Properties with
         | Some found ->
             vimTextBuffer <- found
@@ -858,10 +858,10 @@ type internal Vim
         | None ->
             false
 
-    member x.DisableVimBuffer (vimBuffer : IVimBuffer) =
+    member x.DisableVimBuffer (vimBuffer: IVimBuffer) =
         vimBuffer.SwitchMode ModeKind.Disabled ModeArgument.None |> ignore
 
-    member x.EnableVimBuffer (vimBuffer : IVimBuffer) =
+    member x.EnableVimBuffer (vimBuffer: IVimBuffer) =
         let modeKind =
             if vimBuffer.TextView.Selection.IsEmpty then
                 ModeKind.Normal

--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -12,17 +12,17 @@ open Microsoft.VisualStudio.Utilities
 /// need the same data provided by IVimBuffer.
 type VimBufferData 
     (
-        _vimTextBuffer : IVimTextBuffer,
-        _textView : ITextView,
-        _windowSettings : IVimWindowSettings,
-        _jumpList : IJumpList,
-        _statusUtil : IStatusUtil,
-        _wordUtil : IWordUtil
+        _vimTextBuffer: IVimTextBuffer,
+        _textView: ITextView,
+        _windowSettings: IVimWindowSettings,
+        _jumpList: IJumpList,
+        _statusUtil: IStatusUtil,
+        _wordUtil: IWordUtil
     ) = 
 
-    let mutable _currentDirectory : string option = None
-    let mutable _visualCaretStartPoint : ITrackingPoint option = None
-    let mutable _visualAnchorPoint : ITrackingPoint option = None 
+    let mutable _currentDirectory: string option = None
+    let mutable _visualCaretStartPoint: ITrackingPoint option = None
+    let mutable _visualAnchorPoint: ITrackingPoint option = None 
 
     interface IVimBufferData with
         member x.CurrentDirectory 
@@ -48,7 +48,7 @@ type VimBufferData
 /// Implementation of the uninitialized mode.  This is designed to handle the ITextView
 /// while it's in an uninitialized state.  It shouldn't touch the ITextView in any way.  
 /// This is why it doesn't even contain a reference to it
-type UninitializedMode(_vimTextBuffer : IVimTextBuffer) =
+type UninitializedMode(_vimTextBuffer: IVimTextBuffer) =
     interface IMode with
         member x.VimTextBuffer = _vimTextBuffer
         member x.ModeKind = ModeKind.Uninitialized
@@ -61,11 +61,11 @@ type UninitializedMode(_vimTextBuffer : IVimTextBuffer) =
 
 type internal ModeMap
     (
-        _vimTextBuffer : IVimTextBuffer,
-        _incrementalSearch : IIncrementalSearch
+        _vimTextBuffer: IVimTextBuffer,
+        _incrementalSearch: IIncrementalSearch
     ) = 
 
-    let mutable _modeMap : Map<ModeKind, IMode> = Map.empty
+    let mutable _modeMap: Map<ModeKind, IMode> = Map.empty
     let mutable _mode = UninitializedMode(_vimTextBuffer) :> IMode
     let mutable _previousMode = None
     let mutable _isSwitchingMode = false
@@ -134,24 +134,24 @@ type internal ModeMap
 
     member x.GetMode kind = Map.find kind _modeMap
 
-    member x.AddMode (mode : IMode) = 
+    member x.AddMode (mode: IMode) = 
         _modeMap <- Map.add (mode.ModeKind) mode _modeMap
 
-    member x.RemoveMode (mode : IMode) = 
+    member x.RemoveMode (mode: IMode) = 
         _modeMap <- Map.remove mode.ModeKind _modeMap
 
-    member x.Reset (mode : IMode) =
+    member x.Reset (mode: IMode) =
         _mode <- mode
         _previousMode <- None
 
 type internal VimBuffer 
     (
-        _vimBufferData : IVimBufferData,
-        _incrementalSearch : IIncrementalSearch,
-        _motionUtil : IMotionUtil,
-        _wordNavigator : ITextStructureNavigator,
-        _windowSettings : IVimWindowSettings,
-        _commandUtil : ICommandUtil
+        _vimBufferData: IVimBufferData,
+        _incrementalSearch: IIncrementalSearch,
+        _motionUtil: IMotionUtil,
+        _wordNavigator: ITextStructureNavigator,
+        _windowSettings: IVimWindowSettings,
+        _commandUtil: ICommandUtil
     ) as this =
 
     /// Maximum number of maps which can occur for a key map.  This is not a standard vim or gVim
@@ -176,11 +176,11 @@ type internal VimBuffer
     /// Are we in the middle of executing a single action in a given mode after which we
     /// return back to insert mode.  When Some the value can only be Insert or Replace as 
     /// they are the only modes to issue the command
-    let mutable _inOneTimeCommand : ModeKind option = None
+    let mutable _inOneTimeCommand: ModeKind option = None
 
     /// This is the buffered input when a remap request needs more than one 
     /// element
-    let mutable _bufferedKeyInput : KeyInputSet option = None
+    let mutable _bufferedKeyInput: KeyInputSet option = None
 
     let _keyInputStartEvent = StandardEvent<KeyInputStartEventArgs>()
     let _keyInputProcessingEvent = StandardEvent<KeyInputStartEventArgs>()
@@ -293,7 +293,7 @@ type internal VimBuffer
             else
                 false
 
-        let mapped (keyInputSet : KeyInputSet) =
+        let mapped (keyInputSet: KeyInputSet) =
             // Simplest case.  Mapped to a set of values so just consider the first one
             //
             // Note: This is not necessarily the provided KeyInput.  There could be several
@@ -389,7 +389,7 @@ type internal VimBuffer
 
     /// Process the single KeyInput value.  No mappings are considered here.  The KeyInput is 
     /// simply processed directly
-    member x.ProcessOneKeyInput (keyInput : KeyInput) =
+    member x.ProcessOneKeyInput (keyInput: KeyInput) =
 
         let processResult = 
 
@@ -466,7 +466,7 @@ type internal VimBuffer
 
     /// Process the provided KeyInputSet until completion or until a point where an 
     /// ambiguous mapping is reached
-    member x.ProcessCore (keyInputSet : KeyInputSet) = 
+    member x.ProcessCore (keyInputSet: KeyInputSet) = 
         Contract.Assert(Option.isNone _bufferedKeyInput)
 
         let mapCount = ref 0
@@ -482,7 +482,7 @@ type internal VimBuffer
 
         // Process the KeyInput values in the given set to completion without considering
         // any further key mappings
-        let processSet (keyInputSet : KeyInputSet) = 
+        let processSet (keyInputSet: KeyInputSet) = 
             let mutable error = false
             for keyInput in keyInputSet.KeyInputs do
                 if not (isError ()) then 
@@ -531,7 +531,7 @@ type internal VimBuffer
         processResult.Value
 
     /// Actually process the input key.  Raise the change event on an actual change
-    member x.Process (keyInput : KeyInput) =
+    member x.Process (keyInput: KeyInput) =
 
         // Raise the event that we received the key
         let args = KeyInputStartEventArgs(keyInput)

--- a/Src/VimCore/VimBuffer.fsi
+++ b/Src/VimCore/VimBuffer.fsi
@@ -8,15 +8,15 @@ open Microsoft.VisualStudio.Text.Operations
 open Microsoft.VisualStudio.Utilities
 
 type internal VimBufferData = 
-    new : IVimTextBuffer * ITextView * IVimWindowSettings * IJumpList * IStatusUtil * IWordUtil -> VimBufferData
+    new: IVimTextBuffer * ITextView * IVimWindowSettings * IJumpList * IStatusUtil * IWordUtil -> VimBufferData
 
     interface IVimBufferData
 
 type internal VimBuffer =
 
-    new : IVimBufferData * IIncrementalSearch * IMotionUtil * ITextStructureNavigator * IVimWindowSettings * ICommandUtil -> VimBuffer
+    new: IVimBufferData * IIncrementalSearch * IMotionUtil * ITextStructureNavigator * IVimWindowSettings * ICommandUtil -> VimBuffer
 
-    member AddMode : IMode -> unit
+    member AddMode: IMode -> unit
 
     interface IVimBuffer
 

--- a/Src/VimCore/VimRegex.fs
+++ b/Src/VimCore/VimRegex.fs
@@ -15,7 +15,7 @@ module VimRegexUtils =
     ///
     /// Note: This is shared amongst threads but not protected by a lock.  We don't want
     /// any contention issues here.
-    let mutable _sharedRegexCache : (string * RegexOptions * Regex) list = List.empty
+    let mutable _sharedRegexCache: (string * RegexOptions * Regex) list = List.empty
 
     let GetRegexFromCache pattern options = 
         let list = _sharedRegexCache
@@ -64,9 +64,9 @@ type VimReplaceCaseState =
 [<Sealed>]
 type VimRegexReplaceUtil
     (
-        _input : string,
-        _matchCollection : MatchCollection,
-        _registerMap : IRegisterMap
+        _input: string,
+        _matchCollection: MatchCollection,
+        _registerMap: IRegisterMap
     ) =
 
     let mutable _replaceCount = 0
@@ -94,13 +94,13 @@ type VimRegexReplaceUtil
     member private x.AppendReplaceString str = 
         str |> Seq.iter x.AppendReplaceChar
 
-    member private x.AppendGroup (m : Match) digit = 
+    member private x.AppendGroup (m: Match) digit = 
         Contract.Requires (digit <> 0)
         if digit < m.Groups.Count then
             let group = m.Groups.[digit]
             x.AppendReplaceString group.Value
 
-    member private x.AppendRegister (c : char) = 
+    member private x.AppendRegister (c: char) = 
         match RegisterName.OfChar c with
         | None -> ()
         | Some name ->
@@ -113,7 +113,7 @@ type VimRegexReplaceUtil
     /// be more if the character is an escape sequence.  
     ///
     /// This method is responsible for updating _index based on the value consumed
-    member private x.AppendNextElement (m : Match) =  
+    member private x.AppendNextElement (m: Match) =  
         Contract.Requires (_index < _replacement.Length)
 
         match _replacement.[_index] with
@@ -157,13 +157,13 @@ type VimRegexReplaceUtil
                 x.AppendReplaceChar c
             _index <- _index + 1
 
-    member private x.AppendReplacementCore (m : Match) =
+    member private x.AppendReplacementCore (m: Match) =
         _caseState <- VimReplaceCaseState.None
         _index <- 0
         while _index < _replacement.Length do
             x.AppendNextElement m
 
-    member private x.AppendReplacement (m : Match) =
+    member private x.AppendReplacement (m: Match) =
         match _replaceData.Count with
         | VimRegexReplaceCount.All -> x.AppendReplacementCore m
         | VimRegexReplaceCount.One when _replaceCount = 0 -> x.AppendReplacementCore m
@@ -172,7 +172,7 @@ type VimRegexReplaceUtil
         _replaceCount <- _replaceCount + 1
 
     /// Append the text which occurred before the match specified by this index.
-    member private x.AppendInputBefore (matchIndex : int) =
+    member private x.AppendInputBefore (matchIndex: int) =
         if matchIndex = 0 then
             let m = _matchCollection.[matchIndex]
             _builder.AppendSubstring _input 0 m.Index
@@ -187,7 +187,7 @@ type VimRegexReplaceUtil
         let charSpan = CharSpan.FromBounds _input (last.Index + last.Length) _input.Length CharComparer.Exact
         _builder.AppendCharSpan charSpan
 
-    member x.Replace (replacement : string) (replaceData : VimRegexReplaceData) = 
+    member x.Replace (replacement: string) (replaceData: VimRegexReplaceData) = 
         _replaceCount <- 0
         _replacement <- replacement
         _replaceData <- replaceData
@@ -209,11 +209,11 @@ type VimRegexReplaceUtil
 [<Sealed>]
 type VimRegex 
     (
-        _vimPattern : string,
-        _caseSpecifier : CaseSpecifier,
-        _regexPattern : string,
-        _regex : Regex,
-        _includesNewLine : bool
+        _vimPattern: string,
+        _caseSpecifier: CaseSpecifier,
+        _regexPattern: string,
+        _regex: Regex,
+        _includesNewLine: bool
     ) =
 
     member x.CaseSpecifier = _caseSpecifier
@@ -222,7 +222,7 @@ type VimRegex
     member x.Regex = _regex
     member x.IncludesNewLine = _includesNewLine
     member x.IsMatch input = _regex.IsMatch(input)
-    member x.Replace (input : string) (replacement : string) (replaceData : VimRegexReplaceData) (registerMap : IRegisterMap) = 
+    member x.Replace (input: string) (replacement: string) (replaceData: VimRegexReplaceData) (registerMap: IRegisterMap) = 
         let collection = _regex.Matches(input)
         if collection.Count > 0 then
             let util = VimRegexReplaceUtil(input, collection, registerMap)
@@ -254,10 +254,10 @@ type MagicKind =
 /// one.  
 type VimRegexBuilder 
     (
-        _pattern : string,
-        _magicKind : MagicKind,
-        _matchCase : bool,
-        _options : VimRegexOptions
+        _pattern: string,
+        _magicKind: MagicKind,
+        _matchCase: bool,
+        _options: VimRegexOptions
     ) =
 
     let mutable _index = 0
@@ -434,7 +434,7 @@ module VimRegexFactory =
     /// In Vim if a collection is unmatched then it is appended literally into the match 
     /// stream.  Can't determine if it's unmatched though until the string is fully 
     /// processed.  At this point we just go backwards and esacpe it
-    let FixOpenCollection (data : VimRegexBuilder) = 
+    let FixOpenCollection (data: VimRegexBuilder) = 
         let builder = data.Builder
         let mutable i = builder.Length - 1
         while i >= 0 do
@@ -445,7 +445,7 @@ module VimRegexFactory =
                 i <- i - 1
 
     // Create the actual Vim regex
-    let CreateVimRegex (data : VimRegexBuilder) =
+    let CreateVimRegex (data: VimRegexBuilder) =
 
         let regexOptions = 
             let regexOptions = 
@@ -483,7 +483,7 @@ module VimRegexFactory =
 
     /// Try and parse out the name of a named collection.  This is called when the 
     /// index points to ':' assuming this is a valid named collection
-    let TryParseNamedCollectionName (data : VimRegexBuilder) = 
+    let TryParseNamedCollectionName (data: VimRegexBuilder) = 
         let index = data.Index
         if data.CharAtOrDefault index = ':' then
             let mutable endIndex = index + 1
@@ -501,7 +501,7 @@ module VimRegexFactory =
             None
 
     /// Try and append one of the named collections.  These are covered in :help E769.  
-    let TryAppendNamedCollection (data : VimRegexBuilder) c = 
+    let TryAppendNamedCollection (data: VimRegexBuilder) c = 
         if data.IsCollectionOpen && c = '[' then
             match TryParseNamedCollectionName data with
             | None -> false
@@ -517,14 +517,14 @@ module VimRegexFactory =
             false
 
     /// Convert a normal unescaped char. This still needs to consider open patterns.
-    let ConvertCharAsNormal (data : VimRegexBuilder) c = 
+    let ConvertCharAsNormal (data: VimRegexBuilder) c = 
         if not (TryAppendNamedCollection data c) then
             data.AppendEscapedChar c
             data.IsStartOfPattern <- false
 
     /// Convert the given character as a special character.  This is done independent of any 
     /// magic setting.
-    let ConvertCharAsSpecial (data : VimRegexBuilder) c = 
+    let ConvertCharAsSpecial (data: VimRegexBuilder) c = 
         match c with
         | '.' -> data.AppendChar '.'
         | '+' -> data.AppendChar '+'
@@ -626,7 +626,7 @@ module VimRegexFactory =
     /// Convert the given escaped char in the magic and no magic settings.  The 
     /// differences here are minimal so it's convenient to put them in one method
     /// here
-    let ConvertEscapedCharAsMagicAndNoMagic (data : VimRegexBuilder) c =
+    let ConvertEscapedCharAsMagicAndNoMagic (data: VimRegexBuilder) c =
         let isMagic = data.MagicKind = MagicKind.Magic || data.MagicKind = MagicKind.VeryMagic
         match c with 
         | '.' -> if isMagic then data.AppendEscapedChar c else ConvertCharAsSpecial data c
@@ -691,13 +691,13 @@ module VimRegexFactory =
             if CharUtil.IsDigit c then ConvertCharAsSpecial data c
             else data.AppendEscapedChar c
 
-    let ConvertCore (data : VimRegexBuilder) c isEscaped = 
+    let ConvertCore (data: VimRegexBuilder) c isEscaped = 
 
         let convertVeryNoMagic data c isEscaped =
             if isEscaped then ConvertCharAsSpecial data c
             else ConvertCharAsNormal data c
 
-        let convertVeryMagic (data : VimRegexBuilder) c isEscaped = 
+        let convertVeryMagic (data: VimRegexBuilder) c isEscaped = 
             // In VeryMagic mode all characters except a select few ar treated as special
             // characters. This will return true for characters which should not be treated 
             // specially in very magic
@@ -740,8 +740,8 @@ module VimRegexFactory =
         | MagicKind.Magic -> convertMagic data c isEscaped
         | MagicKind.VeryMagic -> convertVeryMagic data c isEscaped
 
-    let Convert (data : VimRegexBuilder) = 
-        let rec inner () : VimResult<VimRegex> =
+    let Convert (data: VimRegexBuilder) = 
+        let rec inner (): VimResult<VimRegex> =
             if data.IsBroken then 
                 VimResult.Error Resources.Regex_Unknown 
             else
@@ -797,7 +797,7 @@ module VimRegexFactory =
         | VimResult.Result vimRegex -> Some vimRegex
         | VimResult.Error _ -> None
 
-    let CreateCaseOptions (globalSettings : IVimGlobalSettings) =
+    let CreateCaseOptions (globalSettings: IVimGlobalSettings) =
         let options = VimRegexOptions.Default
 
         let options = 
@@ -810,7 +810,7 @@ module VimRegexFactory =
 
         options
 
-    let CreateRegexOptions (globalSettings : IVimGlobalSettings) =
+    let CreateRegexOptions (globalSettings: IVimGlobalSettings) =
         let options = VimRegexOptions.Default
         let options =
             if globalSettings.Magic then options
@@ -818,7 +818,7 @@ module VimRegexFactory =
 
         options ||| CreateCaseOptions globalSettings
 
-    let CreateForSubstituteFlags pattern globalSettings (flags : SubstituteFlags) =
+    let CreateForSubstituteFlags pattern globalSettings (flags: SubstituteFlags) =
 
         let options = VimRegexOptions.Default
 

--- a/Src/VimCore/VimRegex.fsi
+++ b/Src/VimCore/VimRegex.fsi
@@ -8,40 +8,40 @@ open System.Text.RegularExpressions
 type VimRegex =
 
     /// The Case Specified for this VimRegex
-    member CaseSpecifier : CaseSpecifier
+    member CaseSpecifier: CaseSpecifier
 
     /// The pattern includes a new line reference (\n not $).  
-    member IncludesNewLine : bool
+    member IncludesNewLine: bool
 
     /// Pattern of the BCL version of the regular expression
-    member RegexPattern : string
+    member RegexPattern: string
 
     /// The underlying BCL Regex expression.  
-    member Regex : Regex
+    member Regex: Regex
 
     /// Vim Pattern of the Regular expression
-    member VimPattern : string
+    member VimPattern: string
 
     /// Does the string match the text
-    member IsMatch : pattern : string -> bool
+    member IsMatch: pattern: string -> bool
 
     /// Matches the regex against the specified input and does the replacement 
     /// as specified.  If there is currently no regex then None will be returned
-    member Replace : input : string -> replacement : string -> replaceData : VimRegexReplaceData -> registerMap : IRegisterMap -> string 
+    member Replace: input: string -> replacement: string -> replaceData: VimRegexReplaceData -> registerMap: IRegisterMap -> string 
 
 module VimRegexFactory = 
 
-    val Create : pattern : string -> options : VimRegexOptions -> VimRegex option
+    val Create: pattern: string -> options: VimRegexOptions -> VimRegex option
 
-    val CreateEx : pattern : string -> options : VimRegexOptions -> VimResult<VimRegex>
+    val CreateEx: pattern: string -> options: VimRegexOptions -> VimResult<VimRegex>
 
-    val CreateForSettings : pattern : string -> globalSettings : IVimGlobalSettings -> VimRegex option
+    val CreateForSettings: pattern: string -> globalSettings: IVimGlobalSettings -> VimRegex option
 
-    val CreateForSubstituteFlags : pattern : string -> globalSettings : IVimGlobalSettings -> flags : SubstituteFlags -> VimRegex option
+    val CreateForSubstituteFlags: pattern: string -> globalSettings: IVimGlobalSettings -> flags: SubstituteFlags -> VimRegex option
 
-    val CreateRegexOptions : globalSettings : IVimGlobalSettings -> VimRegexOptions
+    val CreateRegexOptions: globalSettings: IVimGlobalSettings -> VimRegexOptions
 
-    val CreateBcl : pattern : string -> regexOptions : RegexOptions -> Regex option
+    val CreateBcl: pattern: string -> regexOptions: RegexOptions -> Regex option
 
 
 

--- a/Src/VimCore/VimRegexOptions.fs
+++ b/Src/VimCore/VimRegexOptions.fs
@@ -51,13 +51,13 @@ type VimRegexReplaceData = {
 
     /// When the '\r' replace sequence is used what should the replace string be.  This
     /// is usually contextual to the point in the IVimBuffer
-    NewLine : string
+    NewLine: string
 
     /// Whether or not magic should apply
-    Magic : bool
+    Magic: bool
 
     /// The 'count' times it should be replaced.  Not considered in a replace all
-    Count : VimRegexReplaceCount
+    Count: VimRegexReplaceCount
 
 } with
 

--- a/Src/VimCore/VimSettings.fs
+++ b/Src/VimCore/VimSettings.fs
@@ -21,7 +21,7 @@ type SettingValueParseFunc = string -> SettingValue option
 
 type internal SettingsMap
     (
-        _rawData : Setting seq
+        _rawData: Setting seq
     ) as this =
 
     let _settingChangedEvent = StandardEvent<SettingEventArgs>()
@@ -45,7 +45,7 @@ type internal SettingsMap
 
     member x.SettingChanged = _settingChangedEvent.Publish
 
-    member x.AddSetting (setting : Setting) =
+    member x.AddSetting (setting: Setting) =
         _settingMap.Add(setting.Name, setting)
         _shortToFullNameMap.Add(setting.Abbreviation, setting.Name)
 
@@ -66,7 +66,7 @@ type internal SettingsMap
         | Some fullName -> fullName
         | None -> settingNameOrAbbrev
 
-    member x.TrySetValue settingNameOrAbbrev (value : SettingValue) =
+    member x.TrySetValue settingNameOrAbbrev (value: SettingValue) =
         let name = x.GetFullName settingNameOrAbbrev
         match _settingMap.TryGetValueEx name with
         | None -> false
@@ -88,7 +88,7 @@ type internal SettingsMap
             | None -> false
             | Some value -> x.TrySetValue setting.Name value
 
-    member x.GetSetting settingNameOrAbbrev : Setting option =
+    member x.GetSetting settingNameOrAbbrev: Setting option =
         let name = x.GetFullName settingNameOrAbbrev
         _settingMap.TryGetValueEx name
 
@@ -116,7 +116,7 @@ type internal SettingsMap
         | SettingValue.String _ -> failwith "invalid"
         | SettingValue.Toggle _ -> failwith "invalid"
 
-    member x.ConvertStringToValue (setting : Setting) (str : string) = 
+    member x.ConvertStringToValue (setting: Setting) (str: string) = 
         match _customParseMap.TryGetValueEx setting.Name with
         | None -> x.ConvertStringToValueCore str setting.Kind
         | Some func ->
@@ -238,7 +238,7 @@ type internal GlobalSettings() =
     member x.GetCommaOptions name mappingList emptyOption combineFunc = 
         _map.GetStringValue name 
         |> StringUtil.Split ',' 
-        |> Seq.fold (fun (options : 'a) (current : string)->
+        |> Seq.fold (fun (options: 'a) (current: string)->
             match List.tryFind (fun (name, _) -> name = current) mappingList with
             | None -> options
             | Some (_, value) -> combineFunc options value) emptyOption
@@ -468,7 +468,7 @@ type internal GlobalSettings() =
 
 type internal LocalSettings
     ( 
-        _globalSettings : IVimGlobalSettings
+        _globalSettings: IVimGlobalSettings
     ) =
 
     static let LocalSettingInfoList =
@@ -491,7 +491,7 @@ type internal LocalSettings
 
     member x.Map = _map
 
-    static member Copy (settings : IVimLocalSettings) = 
+    static member Copy (settings: IVimLocalSettings) = 
         let copy = LocalSettings(settings.GlobalSettings)
         settings.Settings
         |> Seq.filter (fun s -> not s.IsValueCalculated)
@@ -564,8 +564,8 @@ type internal LocalSettings
 
 type internal WindowSettings
     ( 
-        _globalSettings : IVimGlobalSettings,
-        _textView : ITextView option
+        _globalSettings: IVimGlobalSettings,
+        _textView: ITextView option
     ) as this =
 
     static let WindowSettingInfoList =
@@ -588,7 +588,7 @@ type internal WindowSettings
         _map.ReplaceSetting setting
 
     new (settings) = WindowSettings(settings, None)
-    new (settings, textView : ITextView) = WindowSettings(settings, Some textView)
+    new (settings, textView: ITextView) = WindowSettings(settings, Some textView)
 
     member x.Map = _map
 
@@ -600,7 +600,7 @@ type internal WindowSettings
         | None -> defaultValue
         | Some textView -> int (textView.ViewportHeight / textView.LineHeight / 2.0 + 0.5)
 
-    static member Copy (settings : IVimWindowSettings) = 
+    static member Copy (settings: IVimWindowSettings) = 
         let copy = WindowSettings(settings.GlobalSettings)
         settings.Settings
         |> Seq.filter (fun s -> not s.IsValueCalculated)
@@ -704,7 +704,7 @@ type internal EditorToSettingSynchronizer
                 IsLocal = false
             })
 
-    member x.StartSynchronizing (vimBuffer : IVimBuffer) settingSyncSource = 
+    member x.StartSynchronizing (vimBuffer: IVimBuffer) settingSyncSource = 
         let properties = vimBuffer.TextView.Properties
         if not (properties.ContainsProperty _key) then
             properties.AddProperty(_key, _key)
@@ -714,7 +714,7 @@ type internal EditorToSettingSynchronizer
             | SettingSyncSource.Editor -> x.CopyEditorToVimSettings vimBuffer
             | SettingSyncSource.Vim -> x.CopyVimToEditorSettings vimBuffer
 
-    member x.SetupSynchronization (vimBuffer : IVimBuffer) = 
+    member x.SetupSynchronization (vimBuffer: IVimBuffer) = 
         let editorOptions = vimBuffer.TextView.Options
         if editorOptions <> null then
 
@@ -756,11 +756,11 @@ type internal EditorToSettingSynchronizer
                 bag.DisposeAll())
 
     /// Is this a local setting of note
-    member x.IsTrackedLocalSetting (setting : Setting) = 
+    member x.IsTrackedLocalSetting (setting: Setting) = 
         _settingList |> Seq.exists (fun x -> x.IsLocal && x.VimSettingName = setting.Name)
 
     /// Is this a window setting of note
-    member x.IsTrackedWindowSetting (setting : Setting) = 
+    member x.IsTrackedWindowSetting (setting: Setting) = 
         _settingList |> Seq.exists (fun x -> not x.IsLocal && x.VimSettingName = setting.Name)
 
     /// Is this an editor setting of note
@@ -768,7 +768,7 @@ type internal EditorToSettingSynchronizer
         _settingList |> Seq.exists (fun x -> x.EditorOptionKey = optionId) 
 
     /// Synchronize the settings if needed.  Prevent recursive sync's here
-    member x.TrySync (vimBuffer : IVimBuffer) syncFunc = 
+    member x.TrySync (vimBuffer: IVimBuffer) syncFunc = 
         let editorOptions = vimBuffer.TextView.Options
         if editorOptions <> null then
             let localSettings = vimBuffer.LocalSettings
@@ -789,7 +789,7 @@ type internal EditorToSettingSynchronizer
 
     /// Synchronize the settings from the local settings to the editor.  Do not
     /// call this directly but instead call through SynchronizeSettings
-    member x.CopyEditorToVimSettings (vimBuffer : IVimBuffer) = 
+    member x.CopyEditorToVimSettings (vimBuffer: IVimBuffer) = 
         x.TrySync vimBuffer (fun vimBuffer editorOptions ->
             for data in _settingList do 
                 match data.GetEditorValue editorOptions with

--- a/Src/VimCore/VimSettings.fsi
+++ b/Src/VimCore/VimSettings.fsi
@@ -7,19 +7,19 @@ open Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods
 
 type internal GlobalSettings = 
     interface IVimGlobalSettings
-    new : unit -> GlobalSettings
+    new: unit -> GlobalSettings
 
 type internal LocalSettings = 
     interface IVimLocalSettings
-    new : IVimGlobalSettings -> LocalSettings
+    new: IVimGlobalSettings -> LocalSettings
 
-    static member Copy : IVimLocalSettings -> IVimLocalSettings
+    static member Copy: IVimLocalSettings -> IVimLocalSettings
 
 type internal WindowSettings = 
     interface IVimWindowSettings
-    new : IVimGlobalSettings -> WindowSettings
-    new : IVimGlobalSettings * ITextView -> WindowSettings
+    new: IVimGlobalSettings -> WindowSettings
+    new: IVimGlobalSettings * ITextView -> WindowSettings
 
-    static member Copy : IVimWindowSettings -> IVimWindowSettings
+    static member Copy: IVimWindowSettings -> IVimWindowSettings
 
 

--- a/Src/VimCore/VimSettingsInterface.fs
+++ b/Src/VimCore/VimSettingsInterface.fs
@@ -145,11 +145,11 @@ type SettingValue =
 /// add custom settings
 type IVimCustomSettingSource =
 
-    abstract GetDefaultSettingValue: name : string -> SettingValue
+    abstract GetDefaultSettingValue: name: string -> SettingValue
 
-    abstract GetSettingValue: name : string -> SettingValue
+    abstract GetSettingValue: name: string -> SettingValue
 
-    abstract SetSettingValue: name : string -> settingValue : SettingValue -> unit
+    abstract SetSettingValue: name: string -> settingValue: SettingValue -> unit
 
 /// This pairs both the current setting value and the default value into a single type safe
 /// value.  The first value in every tuple is the current value while the second is the 
@@ -217,10 +217,10 @@ type LiveSettingValue =
 
 [<DebuggerDisplay("{Name}={Value}")>]
 type Setting = {
-    Name : string
-    Abbreviation : string
-    LiveSettingValue : LiveSettingValue
-    IsGlobal : bool
+    Name: string
+    Abbreviation: string
+    LiveSettingValue: LiveSettingValue
+    IsGlobal: bool
 } with 
 
     member x.Value = x.LiveSettingValue.Value
@@ -235,7 +235,7 @@ type Setting = {
     /// Is the setting value currently set to the default value
     member x.IsValueDefault = x.LiveSettingValue.IsValueDefault
 
-type SettingEventArgs(_setting : Setting, _isValueChanged : bool) =
+type SettingEventArgs(_setting: Setting, _isValueChanged: bool) =
     inherit System.EventArgs()
 
     /// The affected setting
@@ -252,218 +252,218 @@ type SettingEventArgs(_setting : Setting, _isValueChanged : bool) =
 type IVimSettings =
 
     /// Collection of settings owned by this IVimSettings instance
-    abstract Settings : Setting list
+    abstract Settings: Setting list
 
     /// Try and set a setting to the passed in value.  This can fail if the value does not 
     /// have the correct type.  The provided name can be the full name or abbreviation
-    abstract TrySetValue : settingNameOrAbbrev : string -> value : SettingValue -> bool
+    abstract TrySetValue: settingNameOrAbbrev: string -> value: SettingValue -> bool
 
     /// Try and set a setting to the passed in value which originates in string form.  This 
     /// will fail if the setting is not found or the value cannot be converted to the appropriate
     /// value
-    abstract TrySetValueFromString : settingNameOrAbbrev : string -> strValue : string -> bool
+    abstract TrySetValueFromString: settingNameOrAbbrev: string -> strValue: string -> bool
 
     /// Get the value for the named setting.  The name can be the full setting name or an 
     /// abbreviation
-    abstract GetSetting : settingNameOrAbbrev : string -> Setting option
+    abstract GetSetting: settingNameOrAbbrev: string -> Setting option
 
     /// Raised when a Setting changes
     [<CLIEvent>]
-    abstract SettingChanged : IDelegateEvent<System.EventHandler<SettingEventArgs>>
+    abstract SettingChanged: IDelegateEvent<System.EventHandler<SettingEventArgs>>
 
 and IVimGlobalSettings = 
 
     /// Add a custom setting to the current collection
-    abstract AddCustomSetting : name : string -> abbrevation : string -> customSettingSource : IVimCustomSettingSource -> unit
+    abstract AddCustomSetting: name: string -> abbrevation: string -> customSettingSource: IVimCustomSettingSource -> unit
 
     /// When set, don't break inserts into multiple inserts when moving the cursor. Applies to all kinds of cursor movements, arrow keys,
     /// automatic movements from intellisense for example or mouse movements.
-    abstract AtomicInsert : bool with get, set
+    abstract AtomicInsert: bool with get, set
 
     /// The multi-value option for determining backspace behavior.  Valid values include 
     /// indent, eol, start.  Usually accessed through the IsBackSpace helpers
-    abstract Backspace : string with get, set
+    abstract Backspace: string with get, set
 
     /// Opacity of the caret.  This must be an integer between values 0 and 100 which
     /// will be converted into a double for the opacity of the caret
-    abstract CaretOpacity : int with get, set
+    abstract CaretOpacity: int with get, set
 
     /// List of paths which will be searched by the :cd and :ld commands
-    abstract CurrentDirectoryPath : string with get, set
+    abstract CurrentDirectoryPath: string with get, set
 
     /// Strongly typed list of paths which will be searched by the :cd and :ld commands
-    abstract CurrentDirectoryPathList : PathOption list 
+    abstract CurrentDirectoryPathList: PathOption list 
 
     /// The clipboard option.  Use the IsClipboard helpers for finding out if specific options 
     /// are set
-    abstract Clipboard : string with get, set
+    abstract Clipboard: string with get, set
 
     /// The parsed set of clipboard options
-    abstract ClipboardOptions : ClipboardOptions with get, set
+    abstract ClipboardOptions: ClipboardOptions with get, set
 
     /// Whether or not 'gdefault' is set
-    abstract GlobalDefault : bool with get, set
+    abstract GlobalDefault: bool with get, set
 
     /// Whether or not to highlight previous search patterns matching cases
-    abstract HighlightSearch : bool with get, set
+    abstract HighlightSearch: bool with get, set
 
     /// The number of items to keep in the history lists
-    abstract History : int with get, set
+    abstract History: int with get, set
 
     /// Whether or not the magic option is set
-    abstract Magic : bool with get, set
+    abstract Magic: bool with get, set
 
     /// Maximum number of recursive depths which occur for a mapping
-    abstract MaxMapDepth : int with get, set
+    abstract MaxMapDepth: int with get, set
 
     /// Whether or not we should be ignoring case in the ITextBuffer
-    abstract IgnoreCase : bool with get, set
+    abstract IgnoreCase: bool with get, set
 
     /// Whether or not incremental searches should be highlighted and focused 
     /// in the ITextBuffer
-    abstract IncrementalSearch : bool with get, set
+    abstract IncrementalSearch: bool with get, set
 
     /// Is the 'indent' option inside of Backspace set
-    abstract IsBackspaceIndent : bool with get
+    abstract IsBackspaceIndent: bool with get
 
     /// Is the 'eol' option inside of Backspace set
-    abstract IsBackspaceEol : bool with get
+    abstract IsBackspaceEol: bool with get
 
     /// Is the 'start' option inside of Backspace set
-    abstract IsBackspaceStart : bool with get
+    abstract IsBackspaceStart: bool with get
 
     /// Is the 'onemore' option inside of VirtualEdit set
-    abstract IsVirtualEditOneMore : bool with get
+    abstract IsVirtualEditOneMore: bool with get
 
     /// Is the 'b' option inside of WhichWrap set
-    abstract IsWhichWrapSpaceLeft : bool with get
+    abstract IsWhichWrapSpaceLeft: bool with get
 
     /// Is the 's' option inside of WhichWrap set
-    abstract IsWhichWrapSpaceRight : bool with get
+    abstract IsWhichWrapSpaceRight: bool with get
 
     /// Is the 'h' option inside of WhichWrap set
-    abstract IsWhichWrapCharLeft : bool with get
+    abstract IsWhichWrapCharLeft: bool with get
 
     /// Is the 'l' option inside of WhichWrap set
-    abstract IsWhichWrapCharRight : bool with get
+    abstract IsWhichWrapCharRight: bool with get
 
     /// Is the '<' option inside of WhichWrap set
-    abstract IsWhichWrapArrowLeft : bool with get
+    abstract IsWhichWrapArrowLeft: bool with get
 
     /// Is the '>' option inside of WhichWrap set
-    abstract IsWhichWrapArrowRight : bool with get
+    abstract IsWhichWrapArrowRight: bool with get
 
     /// Is the '~' option inside of WhichWrap set
-    abstract IsWhichWrapTilde : bool with get
+    abstract IsWhichWrapTilde: bool with get
 
     /// Is the '[' option inside of WhichWrap set
-    abstract IsWhichWrapArrowLeftInsert : bool with get
+    abstract IsWhichWrapArrowLeftInsert: bool with get
 
     /// Is the ']' option inside of WhichWrap set
-    abstract IsWhichWrapArrowRightInsert : bool with get
+    abstract IsWhichWrapArrowRightInsert: bool with get
 
     /// Is the Selection setting set to a value which calls for inclusive 
     /// selection.  This does not directly track if Setting = "inclusive" 
     /// although that would cause this value to be true
-    abstract IsSelectionInclusive : bool with get
+    abstract IsSelectionInclusive: bool with get
 
     /// Is the Selection setting set to a value which permits the selection
     /// to extend past the line
-    abstract IsSelectionPastLine : bool with get
+    abstract IsSelectionPastLine: bool with get
 
     /// Whether or not to insert two spaces after certain constructs in a 
     /// join operation
-    abstract JoinSpaces : bool with get, set
+    abstract JoinSpaces: bool with get, set
 
     /// The 'keymodel' setting
-    abstract KeyModel : string with get, set
+    abstract KeyModel: string with get, set
 
     /// The 'keymodel' in a type safe form
-    abstract KeyModelOptions : KeyModelOptions with get, set
+    abstract KeyModelOptions: KeyModelOptions with get, set
 
     /// The value of this option influences when a window will have a status line
-    abstract LastStatus : int with get, set
+    abstract LastStatus: int with get, set
 
     /// The 'mousemodel' setting
-    abstract MouseModel : string with get, set
+    abstract MouseModel: string with get, set
 
     /// The nrooff macros that separate paragraphs
-    abstract Paragraphs : string with get, set
+    abstract Paragraphs: string with get, set
 
     /// List of paths which will be searched by the 'gf' :find, etc ... commands
-    abstract Path : string with get, set
+    abstract Path: string with get, set
 
     /// Strongly typed list of path entries
-    abstract PathList : PathOption list 
+    abstract PathList: PathOption list 
 
     /// The nrooff macros that separate sections
-    abstract Sections : string with get, set
+    abstract Sections: string with get, set
 
     /// The name of the shell to use for shell commands
-    abstract Shell : string with get, set
+    abstract Shell: string with get, set
 
     /// The flag which is passed to the shell when executing shell commands
-    abstract ShellFlag : string with get, set
+    abstract ShellFlag: string with get, set
 
-    abstract StartOfLine : bool with get, set
+    abstract StartOfLine: bool with get, set
 
     /// This option determines the content of the status line.
-    abstract StatusLine : string with get, set
+    abstract StatusLine: string with get, set
     
     /// Controls the behavior of ~ in normal mode
-    abstract TildeOp : bool with get, set
+    abstract TildeOp: bool with get, set
 
     /// Part of the control for key mapping and code timeout
-    abstract Timeout : bool with get, set
+    abstract Timeout: bool with get, set
 
     /// Part of the control for key mapping and code timeout
-    abstract TimeoutEx : bool with get, set
+    abstract TimeoutEx: bool with get, set
 
     /// Timeout for a key mapping in milliseconds
-    abstract TimeoutLength : int with get, set
+    abstract TimeoutLength: int with get, set
 
     /// Timeout control for key mapping / code
-    abstract TimeoutLengthEx : int with get, set
+    abstract TimeoutLengthEx: int with get, set
 
     /// Holds the scroll offset value which is the number of lines to keep visible
     /// above the cursor after a move operation
-    abstract ScrollOffset : int with get, set
+    abstract ScrollOffset: int with get, set
 
     /// Holds the Selection option
-    abstract Selection : string with get, set
+    abstract Selection: string with get, set
 
     /// Get the SelectionKind for the current settings
-    abstract SelectionKind : SelectionKind
+    abstract SelectionKind: SelectionKind
 
     /// Options for how select mode is entered
-    abstract SelectMode : string with get, set 
+    abstract SelectMode: string with get, set 
 
     /// The options which are set via select mode
-    abstract SelectModeOptions : SelectModeOptions with get, set
+    abstract SelectModeOptions: SelectModeOptions with get, set
 
     /// Overrides the IgnoreCase setting in certain cases if the pattern contains
     /// any upper case letters
-    abstract SmartCase : bool with get, set
+    abstract SmartCase: bool with get, set
 
     /// Retrieves the location of the loaded VimRC file.  Will be the empty string if the load 
     /// did not succeed or has not been tried
-    abstract VimRc : string with get, set
+    abstract VimRc: string with get, set
 
     /// Set of paths considered when looking for a .vimrc file.  Will be the empty string if the 
     /// load has not been attempted yet
-    abstract VimRcPaths : string with get, set
+    abstract VimRcPaths: string with get, set
 
     /// Holds the VirtualEdit string.  
-    abstract VirtualEdit : string with get, set
+    abstract VirtualEdit: string with get, set
 
     /// Whether or not to use a visual indicator of errors instead of a beep
-    abstract VisualBell : bool with get, set
+    abstract VisualBell: bool with get, set
 
     /// Which operations should wrap in the buffer
-    abstract WhichWrap : string with get, set
+    abstract WhichWrap: string with get, set
 
     /// Whether or not searches should wrap at the end of the file
-    abstract WrapScan : bool with get, set
+    abstract WrapScan: bool with get, set
 
     /// The key binding which will cause all IVimBuffer instances to enter disabled mode
     abstract DisableAllCommand: KeyInput;
@@ -474,34 +474,34 @@ and IVimGlobalSettings =
 /// global settings with non-global ones
 and IVimLocalSettings =
 
-    abstract AutoIndent : bool with get, set
+    abstract AutoIndent: bool with get, set
 
     /// Whether or not to expand tabs into spaces
-    abstract ExpandTab : bool with get, set
+    abstract ExpandTab: bool with get, set
 
     /// Return the handle to the global IVimSettings instance
-    abstract GlobalSettings : IVimGlobalSettings
+    abstract GlobalSettings: IVimGlobalSettings
 
     /// Whether or not to put the numbers on the left column of the display
-    abstract Number : bool with get, set
+    abstract Number: bool with get, set
 
     /// Formats that vim considers a number for CTRL-A and CTRL-X
-    abstract NumberFormats : string with get, set
+    abstract NumberFormats: string with get, set
 
     /// The number of spaces a << or >> command will shift by 
-    abstract ShiftWidth : int with get, set
+    abstract ShiftWidth: int with get, set
 
     /// Number of spaces a tab counts for when doing edit operations
-    abstract SoftTabStop : int with get, set
+    abstract SoftTabStop: int with get, set
 
     /// How many spaces a tab counts for 
-    abstract TabStop : int with get, set
+    abstract TabStop: int with get, set
 
     /// Which characters escape quotes for certain motion types
-    abstract QuoteEscape : string with get, set
+    abstract QuoteEscape: string with get, set
 
     /// Is the provided NumberFormat supported by the current options
-    abstract IsNumberFormatSupported : NumberFormat -> bool
+    abstract IsNumberFormatSupported: NumberFormat -> bool
 
     inherit IVimSettings
 
@@ -509,15 +509,15 @@ and IVimLocalSettings =
 and IVimWindowSettings = 
 
     /// Whether or not to highlight the line the cursor is on
-    abstract CursorLine : bool with get, set
+    abstract CursorLine: bool with get, set
 
     /// Return the handle to the global IVimSettings instance
-    abstract GlobalSettings : IVimGlobalSettings
+    abstract GlobalSettings: IVimGlobalSettings
 
     /// The scroll size 
-    abstract Scroll : int with get, set
+    abstract Scroll: int with get, set
 
     /// Whether or not the window should be wrapping
-    abstract Wrap : bool with get, set
+    abstract Wrap: bool with get, set
 
     inherit IVimSettings

--- a/Src/VimCore/VimTextBuffer.fs
+++ b/Src/VimCore/VimTextBuffer.fs
@@ -10,22 +10,22 @@ open Microsoft.VisualStudio.Utilities
 
 type internal VimTextBuffer 
     (
-        _textBuffer : ITextBuffer,
-        _localSettings : IVimLocalSettings,
-        _wordNavigator : ITextStructureNavigator,
-        _bufferTrackingService : IBufferTrackingService,
-        _undoRedoOperations : IUndoRedoOperations,
-        _vim : IVim
+        _textBuffer: ITextBuffer,
+        _localSettings: IVimLocalSettings,
+        _wordNavigator: ITextStructureNavigator,
+        _bufferTrackingService: IBufferTrackingService,
+        _undoRedoOperations: IUndoRedoOperations,
+        _vim: IVim
     ) =
 
     let _vimHost = _vim.VimHost
     let _globalSettings = _localSettings.GlobalSettings
     let _switchedModeEvent = StandardEvent<SwitchModeKindEventArgs>()
     let mutable _modeKind = ModeKind.Normal
-    let mutable _lastVisualSelection : ITrackingVisualSelection option = None
-    let mutable _insertStartPoint : ITrackingLineColumn option = None
-    let mutable _lastInsertExitPoint : ITrackingLineColumn option = None
-    let mutable _lastEditPoint : ITrackingLineColumn option = None
+    let mutable _lastVisualSelection: ITrackingVisualSelection option = None
+    let mutable _insertStartPoint: ITrackingLineColumn option = None
+    let mutable _lastInsertExitPoint: ITrackingLineColumn option = None
+    let mutable _lastEditPoint: ITrackingLineColumn option = None
     let mutable _isSoftTabStopValidForBackspace = true
 
     member x.LastVisualSelection 

--- a/Src/VimCore/VimTextBuffer.fsi
+++ b/Src/VimCore/VimTextBuffer.fsi
@@ -10,6 +10,6 @@ open Microsoft.VisualStudio.Utilities
 
 type internal VimTextBuffer =
 
-    new : ITextBuffer * IVimLocalSettings * ITextStructureNavigator * IBufferTrackingService * IUndoRedoOperations * IVim -> VimTextBuffer
+    new: ITextBuffer * IVimLocalSettings * ITextStructureNavigator * IBufferTrackingService * IUndoRedoOperations * IVim -> VimTextBuffer
 
     interface IVimTextBuffer

--- a/Src/VimCore/VimTrace.fs
+++ b/Src/VimCore/VimTrace.fs
@@ -13,28 +13,28 @@ type VimTrace() =
     static member TraceSwitch = _traceSwitch
 
     [<Conditional("TRACE")>]
-    static member TraceInfo(msg : string) = 
+    static member TraceInfo(msg: string) = 
         let msg = _prefixInfo + msg
         Trace.WriteLineIf(VimTrace.TraceSwitch.TraceInfo, msg)
 
     [<Conditional("TRACE")>]
-    static member TraceInfo(format : string, [<ParamArrayAttribute>] args : obj []) = 
+    static member TraceInfo(format: string, [<ParamArrayAttribute>] args: obj []) = 
         let msg = String.Format(format, args)
         let msg = _prefixInfo + msg
         Trace.WriteLineIf(VimTrace.TraceSwitch.TraceInfo, msg)
 
     [<Conditional("TRACE")>]
-    static member TraceError(ex : Exception) = 
+    static member TraceError(ex: Exception) = 
         let msg = ex.Message + Environment.NewLine + ex.StackTrace
         VimTrace.TraceError(msg)
 
     [<Conditional("TRACE")>]
-    static member TraceError(msg : string) = 
+    static member TraceError(msg: string) = 
         let msg = _prefixError + msg
         Trace.WriteLineIf(VimTrace.TraceSwitch.TraceError, msg)
 
     [<Conditional("TRACE")>]
-    static member TraceError(format : string, [<ParamArrayAttribute>] args : obj []) = 
+    static member TraceError(format: string, [<ParamArrayAttribute>] args: obj []) = 
         let msg = String.Format(format, args)
         let msg = _prefixError + msg
         Trace.WriteLineIf(VimTrace.TraceSwitch.TraceError, msg)


### PR DESCRIPTION
Changed the coding style of locals / parameters to remove the space
between the variable name and the colon. This has long bothered me and
decided to fix it (after a helpful hint from a coworker).