### PR TITLE
Fix command/search history

### DIFF
--- a/Src/VimCore/HistoryUtil.fs
+++ b/Src/VimCore/HistoryUtil.fs
@@ -155,7 +155,8 @@ type internal HistorySession<'TData, 'TResult>
             _historyClient.Beep()
         | HistoryState.Index (list, index) -> 
             if index = 0 then
-                _clientData <- _historyClient.ProcessCommand _clientData ""
+                _command <- ""
+                _clientData <- _historyClient.ProcessCommand _clientData _command
                 _historyState <- HistoryState.Empty
             else
                 x.DoHistoryScroll list (index - 1)

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -333,7 +333,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         /// </summary>
         private bool HandleHistoryNavigation(KeyInput keyInput)
         {
-            var handled = _vimBuffer.Process(KeyInputUtil.VimKeyToKeyInput(VimKey.Up)).IsAnyHandled;
+            var handled = _vimBuffer.Process(keyInput).IsAnyHandled;
             var prefixChar = GetPrefixChar(_editKind);
             if (handled && _editKind != EditKind.None && prefixChar.HasValue)
             {
@@ -375,7 +375,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     e.Handled = HandleHistoryNavigation(KeyInputUtil.VimKeyToKeyInput(VimKey.Up));
                     break;
                 case Key.Down:
-                    e.Handled = HandleHistoryNavigation(KeyInputUtil.VimKeyToKeyInput(VimKey.Up));
+                    e.Handled = HandleHistoryNavigation(KeyInputUtil.VimKeyToKeyInput(VimKey.Down));
                     break;
                 case Key.Home:
                     if ((e.KeyboardDevice.Modifiers & ModifierKeys.Shift) == 0)
@@ -393,8 +393,12 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     break;
                 case Key.Left:
                 case Key.Back:
-                    // Ignore backspace if at start position
-                    e.Handled = _margin.IsCaretAtStart();
+                    if (_margin.IsCaretAtStart())
+                    {
+                        _vimBuffer.Process(KeyInputUtil.EscapeKey);
+                        ChangeEditKind(EditKind.None);
+                        e.Handled = true;
+                    }
                     break;
                 case Key.R:
                     if (e.KeyboardDevice.Modifiers == ModifierKeys.Control)
@@ -423,6 +427,18 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                         textBox.Text = text;
 
                         UpdateVimBufferStateWithCommandText(text);
+                    }
+                    break;
+                case Key.P:
+                    if (e.KeyboardDevice.Modifiers == ModifierKeys.Control)
+                    {
+                        e.Handled = HandleHistoryNavigation(KeyInputUtil.ApplyKeyModifiersToChar('p', VimKeyModifiers.Control));
+                    }
+                    break;
+                case Key.N:
+                    if (e.KeyboardDevice.Modifiers == ModifierKeys.Control)
+                    {
+                        e.Handled = HandleHistoryNavigation(KeyInputUtil.ApplyKeyModifiersToChar('n', VimKeyModifiers.Control));
                     }
                     break;
             }

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -535,6 +535,15 @@ namespace Vim.UnitTest
             }
 
             [WpfFact]
+            public void PreviousCommandAfterEmptyHistory()
+            {
+                Create("");
+                _commandHistoryList.AddRange("dog", "cat");
+                _vimBuffer.ProcessNotation(":<C-p><C-n><C-p><C-p>");
+                Assert.Equal("dog", _commandMode.Command);
+            }
+
+            [WpfFact]
             public void Backspace()
             {
                 Create("");


### PR DESCRIPTION
- Fix accidental handling of Down same as Up
- Add Ctrl-N and Ctrl-P as synonyms for Down and Up
- Fix backspacing past the beginning of command/search isn't like Escape
- Fix history previous after history next to an empty command (with test)