### PR TITLE
Fix left arrow at beginning and backspace with non-empty text

### DIFF
--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -392,8 +392,12 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     }
                     break;
                 case Key.Left:
+                    // Ignore left arrow if at start position
+                    e.Handled = _margin.IsCaretAtStart();
+                    break;
                 case Key.Back:
-                    if (_margin.IsCaretAtStart())
+                    // Backspacing past the beginning aborts the command/search.
+                    if (_margin.CommandLineTextBox.Text.Length <= 1)
                     {
                         _vimBuffer.Process(KeyInputUtil.EscapeKey);
                         ChangeEditKind(EditKind.None);


### PR DESCRIPTION
I did a little more experimenting with vim and found that `Left` and `Backspace` behave slightly differently at the beginning of a command/search and that `Backspace` doesn't abort the command/search if the text isn't empty.