### PR TITLE
Fix '$' line and '%' line range in buffers with a trailing linebreak

### DIFF
--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -1501,7 +1501,17 @@ module SnapshotLineRangeUtil =
 
     /// Create a range for the entire ItextSnapshot
     let CreateForSnapshot (snapshot: ITextSnapshot) = 
-        SnapshotLineRange.CreateForExtent snapshot
+        let line = SnapshotUtil.GetLastLine snapshot
+        if snapshot.LineCount >= 2 && line.Start.Position = line.EndIncludingLineBreak.Position then
+
+            // The last (but not only) "line" is empty, which means that the
+            // end of the previous line including its linebreak is the
+            // end of the entire buffer.
+            let firstLine = snapshot.GetLineFromLineNumber(0)
+            let lastLine = snapshot.GetLineFromLineNumber(snapshot.LineCount - 2)
+            SnapshotLineRange.CreateForLineRange firstLine lastLine
+        else
+            SnapshotLineRange.CreateForExtent snapshot
 
     /// Create a range for the provided ITextSnapshotLine
     let CreateForLine (line: ITextSnapshotLine) =

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -322,7 +322,15 @@ type VimInterpreter
 
         | LineSpecifier.LastLine ->
             let line = SnapshotUtil.GetLastLine x.CurrentSnapshot
-            line |> getLineAndNumber |> Some
+            if x.CurrentSnapshot.LineCount >= 2 && line.Start.Position = line.EndIncludingLineBreak.Position then
+
+                // The last (but not only) "line" is empty, which means that the
+                // end of the previous line including its linebreak is the
+                // end of the entire buffer.
+                SnapshotUtil.GetLine x.CurrentSnapshot (x.CurrentSnapshot.LineCount - 2)
+            else
+                line
+            |> getLineAndNumber |> Some
 
         | LineSpecifier.MarkLine mark ->
             // Get the line containing the mark in the context of this IVimTextBuffer

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -838,6 +838,44 @@ namespace Vim.UnitTest
                     Assert.Equal("foo bar", _textBuffer.GetLine(0).GetText());
                 }
 
+                [WpfFact]
+                public void FirstThroughLastWithTrailingLineBreak()
+                {
+                    Create("cat", "dog", "");
+                    RunCommand("1,$s/^/x/");
+                    Assert.Equal("xcat", _textBuffer.GetLine(0).GetText());
+                    Assert.Equal("xdog", _textBuffer.GetLine(1).GetText());
+                    Assert.Equal("", _textBuffer.GetLine(2).GetText());
+                }
+
+                [WpfFact]
+                public void FirstThroughLastWithoutTrailingLineBreak()
+                {
+                    Create("cat", "dog");
+                    RunCommand("1,$s/^/x/");
+                    Assert.Equal("xcat", _textBuffer.GetLine(0).GetText());
+                    Assert.Equal("xdog", _textBuffer.GetLine(1).GetText());
+                }
+
+                [WpfFact]
+                public void EntireBufferWithTrailingLineBreak()
+                {
+                    Create("cat", "dog", "");
+                    RunCommand("%s/^/x/");
+                    Assert.Equal("xcat", _textBuffer.GetLine(0).GetText());
+                    Assert.Equal("xdog", _textBuffer.GetLine(1).GetText());
+                    Assert.Equal("", _textBuffer.GetLine(2).GetText());
+                }
+
+                [WpfFact]
+                public void EntireBufferWithoutTrailingLineBreak()
+                {
+                    Create("cat", "dog");
+                    RunCommand("%s/^/x/");
+                    Assert.Equal("xcat", _textBuffer.GetLine(0).GetText());
+                    Assert.Equal("xdog", _textBuffer.GetLine(1).GetText());
+                }
+
                 /// <summary>
                 /// Covers #763 where the default search for substitute uses the last substitute
                 /// instead of the last search

--- a/Test/VimCoreTest/SnapshotLineRangeTest.cs
+++ b/Test/VimCoreTest/SnapshotLineRangeTest.cs
@@ -27,6 +27,15 @@ namespace Vim.UnitTest
             }
 
             [WpfFact]
+            public void ForExtentWithTrailingLineBreak()
+            {
+                Create("cat", "dog", "");
+                var lineRange = SnapshotLineRange.CreateForExtent(_textBuffer.CurrentSnapshot);
+                Assert.Equal(2, lineRange.Count);
+                Assert.Equal(_textBuffer.CurrentSnapshot.Length, lineRange.ExtentIncludingLineBreak.Length);
+            }
+
+            [WpfFact]
             public void ForLine()
             {
                 Create("cat", "dog");


### PR DESCRIPTION
Fixes #2101