### PR TITLE
Fix undo for inserts with corrections

### DIFF
--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -1007,17 +1007,11 @@ type internal InsertMode
             | ModeArgument.InsertBlock (blockSpan, transaction) ->
                 Some transaction, InsertKind.Block blockSpan
             | ModeArgument.InsertWithCount count ->
-                if count > 1 then
-                    let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Insert with count" LinkedUndoTransactionFlags.CanBeEmpty
-                    Some transaction, InsertKind.Repeat (count, false, TextChange.Insert StringUtil.Empty)
-                else
-                    None, InsertKind.Normal
+                let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Insert with count" LinkedUndoTransactionFlags.CanBeEmpty
+                Some transaction, InsertKind.Repeat (count, false, TextChange.Insert StringUtil.Empty)
             | ModeArgument.InsertWithCountAndNewLine count ->
-                if count > 1 then
-                    let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Insert with count and new line" LinkedUndoTransactionFlags.CanBeEmpty
-                    Some transaction, InsertKind.Repeat (count, true, TextChange.Insert StringUtil.Empty)
-                else
-                    None, InsertKind.Normal
+                let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Insert with count and new line" LinkedUndoTransactionFlags.CanBeEmpty
+                Some transaction, InsertKind.Repeat (count, true, TextChange.Insert StringUtil.Empty)
             | ModeArgument.InsertWithTransaction transaction ->
                 Some transaction, InsertKind.Normal
             | _ -> 

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -709,6 +709,14 @@ type internal InsertMode
             let args = CommandRunDataEventArgs(data)
             _commandRanEvent.Trigger x args
 
+            // If there is an existing undo transaction, close it out and start a new one.
+            match _sessionData.Transaction with
+            | None -> ()
+            | Some transaction ->
+                transaction.Complete()
+                let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Insert after motion" LinkedUndoTransactionFlags.CanBeEmpty
+                _sessionData <- { _sessionData with Transaction = Some transaction }
+
         ProcessResult.OfCommandResult result
 
     /// Paste the contents of the specified register with the given flags 

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -2734,6 +2734,61 @@ namespace Vim.UnitTest
             }
         }
 
+        public sealed class UndoTest : NormalModeIntegrationTest
+        {
+            /// <summary>
+            /// Undo of insert
+            /// </summary>
+            [WpfFact]
+            public void Undo_Insert()
+            {
+                Create("aaa bbb ccc");
+                _vimBuffer.ProcessNotation("1Gwiddd <Esc>");
+                Assert.Equal("aaa ddd bbb ccc", _textView.GetLine(0).GetText());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa bbb ccc", _textView.GetLine(0).GetText());
+            }
+
+            /// <summary>
+            /// Undo of insert with backspaces
+            /// </summary>
+            [WpfFact]
+            public void Undo_InsertWithBackspaces()
+            {
+                Create("aaa bbb ccc");
+                _vimBuffer.ProcessNotation("1Gwiddd<BS><BS>ef <Esc>");
+                Assert.Equal("aaa def bbb ccc", _textView.GetLine(0).GetText());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa bbb ccc", _textView.GetLine(0).GetText());
+            }
+
+            /// <summary>
+            /// Undo of change word
+            /// </summary>
+            [WpfFact]
+            public void Undo_ChangeWord()
+            {
+                Create("aaa bbb ccc");
+                _vimBuffer.ProcessNotation("1Gwcwddd<Esc>");
+                Assert.Equal("aaa ddd ccc", _textView.GetLine(0).GetText());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa bbb ccc", _textView.GetLine(0).GetText());
+            }
+
+            /// <summary>
+            /// Undo of change word with backspaces
+            /// </summary>
+            [WpfFact]
+            public void Undo_ChangeWordWithBackspaces()
+            {
+                Create("aaa bbb ccc");
+                _vimBuffer.ProcessNotation("1Gwcwddd<BS><BS>ef<Esc>");
+                Assert.Equal("aaa def ccc", _textView.GetLine(0).GetText());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa bbb ccc", _textView.GetLine(0).GetText());
+            }
+        }
+
         public sealed class UndoLineTest : NormalModeIntegrationTest
         {
             /// <summary>

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -2763,6 +2763,21 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
+            /// Undo of insert with arrow keys
+            /// </summary>
+            [WpfFact]
+            public void Undo_InsertWithArrowKeys()
+            {
+                Create("aaa bbb ccc");
+                _vimBuffer.ProcessNotation("1Gwieee <Left><Left><Left><Left>ddd <Esc>");
+                Assert.Equal("aaa ddd eee bbb ccc", _textView.GetLine(0).GetText());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa eee bbb ccc", _textView.GetLine(0).GetText());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa bbb ccc", _textView.GetLine(0).GetText());
+            }
+
+            /// <summary>
             /// Undo of change word
             /// </summary>
             [WpfFact]

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -2763,10 +2763,10 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
-            /// Undo of insert with arrow keys
+            /// Undo of insert with horizontal arrow keys
             /// </summary>
             [WpfFact]
-            public void Undo_InsertWithArrowKeys()
+            public void Undo_InsertWithHorizontalArrowKeys()
             {
                 Create("aaa bbb ccc");
                 _vimBuffer.ProcessNotation("1Gwieee <Left><Left><Left><Left>ddd <Esc>");
@@ -2775,6 +2775,36 @@ namespace Vim.UnitTest
                 Assert.Equal("aaa eee bbb ccc", _textView.GetLine(0).GetText());
                 _vimBuffer.ProcessNotation("u");
                 Assert.Equal("aaa bbb ccc", _textView.GetLine(0).GetText());
+            }
+
+            /// <summary>
+            /// Undo of insert with by word arrow keys
+            /// </summary>
+            [WpfFact]
+            public void Undo_InsertWithByWordArrowKeys()
+            {
+                Create("aaa bbb ccc");
+                _vimBuffer.ProcessNotation("1Gwieee <C-Left>ddd <Esc>");
+                Assert.Equal("aaa ddd eee bbb ccc", _textView.GetLine(0).GetText());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa eee bbb ccc", _textView.GetLine(0).GetText());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa bbb ccc", _textView.GetLine(0).GetText());
+            }
+
+            /// <summary>
+            /// Undo of insert with vertical arrow keys
+            /// </summary>
+            [WpfFact]
+            public void Undo_InsertWithVerticalArrowKeys()
+            {
+                Create("aaa bbb ccc", "fff ggg hhh");
+                _vimBuffer.ProcessNotation("1Gwieee <Down>ddd <Esc>");
+                Assert.Equal(new[] { "aaa eee bbb ccc", "fff ggg ddd hhh" }, _textBuffer.GetLines());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal(new[] { "aaa eee bbb ccc", "fff ggg hhh" }, _textBuffer.GetLines());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal(new[] { "aaa bbb ccc", "fff ggg hhh" }, _textBuffer.GetLines());
             }
 
             /// <summary>

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -2778,6 +2778,21 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
+            /// Undo of insert with a break in the undo sequence
+            /// </summary>
+            [WpfFact]
+            public void Undo_InsertWithBreakUndoSequence()
+            {
+                Create("aaa bbb ccc");
+                _vimBuffer.ProcessNotation("1Gwiddd <C-g>ueee <Esc>");
+                Assert.Equal("aaa ddd eee bbb ccc", _textView.GetLine(0).GetText());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa ddd bbb ccc", _textView.GetLine(0).GetText());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa bbb ccc", _textView.GetLine(0).GetText());
+            }
+
+            /// <summary>
             /// Undo of change word
             /// </summary>
             [WpfFact]


### PR DESCRIPTION
This change fixes undoing all changes from a single insertion with a single undo.

Previously the presence of backspace or other non-text insertion actions during an ordinary insert would cause the insert to be completely undone only after multiple undo steps.

* Fixes #771
* Fixes #1096
