### PR TITLE
Fix 'G' in a buffer that ends with a linebreak

### DIFF
--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -2293,7 +2293,7 @@ type internal MotionUtil
             match numberOpt with
             | Some number ->  SnapshotUtil.GetLineOrLast x.CurrentSnapshot (Util.VimLineToTssLine number)
             | None -> SnapshotUtil.GetLastLine x.CurrentSnapshot 
-        x.LineToLineFirstNonBlankMotion (MotionResultFlags.MaintainCaretColumn ||| MotionResultFlags.IncludeEmptyLastLine) x.CaretLine endLine
+        x.LineToLineFirstNonBlankMotion MotionResultFlags.MaintainCaretColumn x.CaretLine endLine
 
     /// Go to the last non-blank character on the 'count - 1' line
     member x.LastNonBlankOnLine count = 

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -555,10 +555,27 @@ namespace Vim.UnitTest
                 Assert.Equal(8, _textView.GetCaretPoint().Position);
             }
 
+            /// <summary>
+            /// Issuing 'G' in a buffer that ends with a linebreak should
+            /// go to the last line, i.e. the line that contains that linebreak
+            /// </summary>
             [WpfFact]
             public void LastLineWhenEmpty()
             {
                 Create("dog", "cat", "");
+                Assert.Equal(3, _textBuffer.CurrentSnapshot.LineCount);
+                _vimBuffer.Process("G");
+                Assert.Equal(_textBuffer.GetPointInLine(line: 1, column: 0), _textView.GetCaretPoint());
+            }
+
+            /// <summary>
+            /// Issuing 'G' in a buffer that does not end in a linebreak should
+            /// go to the last line, i.e. the line without a linebreak
+            /// </summary>
+            [WpfFact]
+            public void LastLineWhenNonempty()
+            {
+                Create("dog", "cat", "bat");
                 Assert.Equal(3, _textBuffer.CurrentSnapshot.LineCount);
                 _vimBuffer.Process("G");
                 Assert.Equal(_textBuffer.GetPointInLine(line: 2, column: 0), _textView.GetCaretPoint());


### PR DESCRIPTION
This PR reverts "Fix G on blank last line" but keeps and fixes the corresponding test.

The incorrect behavior was introduced in commit 98b6da61ff2f4cf46eab6b9c74cc23ededb72022 and is not yet visible in the released version.

The issue that commit was intended to fix, #1852, should indeed stay closed because the reported behavior is not a bug.