### PR TITLE
Implement filter ('!') command and associated operations

### DIFF
--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -172,7 +172,7 @@ type internal CommonOperations
             |> String.concat ""
 
         // Filter the input to the output.
-        let output = input.ToUpper()
+        let output = _vimHost.RunCommand _globalSettings.Shell program input _vimData
 
         // Prepare the replacement.
         let replacement = output

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -169,7 +169,7 @@ type internal CommonOperations
             range.Lines
             |> Seq.map SnapshotLineUtil.GetText
             |> Seq.map (fun line -> line + newLine)
-            |> String.concat ""
+            |> String.concat StringUtil.Empty
 
         // Filter the input to the output.
         let results = _vimHost.RunCommand _globalSettings.Shell program input _vimData

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -187,19 +187,29 @@ type internal CommonOperations
         // Prepare the replacement.
         let replacement = results.Output
 
-        // Remove final linebreak.
-        let replacement = Regex.Replace(replacement, @"\r?\n$", "")
+        if replacement.Length = 0 then
 
-        // Normalize linebreaks.
-        let replacement = Regex.Replace(replacement, @"\r?\n", newLine)
+            // Forward to delete lines to handle special cases.
+            let startLine = range.StartLine
+            let count = range.Count
+            let registerName = None
+            x.DeleteLines startLine count registerName
 
-        // Replace the old lines with the filtered lines.
-        _textBuffer.Replace(range.Extent.Span, replacement) |> ignore
+        else
 
-        // Place the cursor on the first non-blank character of the first line filtered.
-        let firstLine = SnapshotUtil.GetLine _textView.TextSnapshot range.StartLineNumber
-        TextViewUtil.MoveCaretToPoint _textView firstLine.Start
-        _editorOperations.MoveToStartOfLineAfterWhiteSpace(false)
+            // Remove final linebreak.
+            let replacement = EditUtil.RemoveEndingNewLine replacement
+
+            // Normalize linebreaks.
+            let replacement = Regex.Replace(replacement, @"\r?\n", newLine)
+
+            // Replace the old lines with the filtered lines.
+            _textBuffer.Replace(range.Extent.Span, replacement) |> ignore
+
+            // Place the cursor on the first non-blank character of the first line filtered.
+            let firstLine = SnapshotUtil.GetLine _textView.TextSnapshot range.StartLineNumber
+            TextViewUtil.MoveCaretToPoint _textView firstLine.Start
+            _editorOperations.MoveToStartOfLineAfterWhiteSpace(false)
 
     /// Format the specified line range
     member x.FormatLines range =

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -172,10 +172,10 @@ type internal CommonOperations
             |> String.concat ""
 
         // Filter the input to the output.
-        let output = _vimHost.RunCommand _globalSettings.Shell program input _vimData
+        let results = _vimHost.RunCommand _globalSettings.Shell program input _vimData
 
         // Prepare the replacement.
-        let replacement = output
+        let replacement = results.Output
 
         // Remove final linebreak.
         let replacement = Regex.Replace(replacement, @"\r?\n$", "")

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -182,6 +182,7 @@ type internal CommonOperations
                 message + newLine + error
             else
                 error
+        let error = EditUtil.RemoveEndingNewLine error
         _statusUtil.OnStatus error
 
         // Prepare the replacement.

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -174,6 +174,16 @@ type internal CommonOperations
         // Filter the input to the output.
         let results = _vimHost.RunCommand _globalSettings.Shell program input _vimData
 
+        // Display error output and error code, if any.
+        let error = results.Error
+        let error =
+            if results.ExitCode <> 0 then
+                let message = "Command returned " + results.ExitCode.ToString() + newLine
+                message + error
+            else
+                error
+        _statusUtil.OnStatus error
+
         // Prepare the replacement.
         let replacement = results.Output
 

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -160,6 +160,10 @@ type internal CommonOperations
             _textBuffer.Insert(x.CaretPoint.Position, blanks) |> ignore
             TextViewUtil.MoveCaretToPosition _textView position
 
+    /// Filter the specified line range through the specified program
+    member x.FilterLines range program =
+        ()
+
     /// Format the specified line range
     member x.FormatLines range =
         _vimHost.FormatLines _textView range
@@ -1577,6 +1581,7 @@ type internal CommonOperations
         member x.EnsureAtCaret viewFlags = x.EnsureAtPoint x.CaretPoint viewFlags
         member x.EnsureAtPoint point viewFlags = x.EnsureAtPoint point viewFlags
         member x.FillInVirtualSpace() = x.FillInVirtualSpace()
+        member x.FilterLines range command = x.FilterLines range command
         member x.FormatLines range = x.FormatLines range
         member x.GetRegister registerName = x.GetRegister registerName
         member x.GetNewLineText point = x.GetNewLineText point

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -178,8 +178,8 @@ type internal CommonOperations
         let error = results.Error
         let error =
             if results.ExitCode <> 0 then
-                let message = "Command returned " + results.ExitCode.ToString() + newLine
-                message + error
+                let message = Resources.Filter_CommandReturned results.ExitCode
+                message + newLine + error
             else
                 error
         _statusUtil.OnStatus error

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2299,6 +2299,9 @@ type ModeArgument =
     /// match to process and the range is the full range to consider for a replace
     | Substitute of SnapshotSpan * SnapshotLineRange * SubstituteData
 
+    /// Enter normal mode with a partially entered command
+    | PartialCommand of string
+
 with
 
     // Running linked commands will throw away the ModeSwitch value.  This can contain
@@ -2307,13 +2310,13 @@ with
     member x.CompleteAnyTransaction =
         match x with
         | ModeArgument.None -> ()
-        | ModeArgument.FromVisual -> ()
         | ModeArgument.InitialVisualSelection _ -> ()
         | ModeArgument.InsertBlock (_, transaction) -> transaction.Complete()
         | ModeArgument.InsertWithCount _ -> ()
         | ModeArgument.InsertWithCountAndNewLine (_, transaction) -> transaction.Complete()
         | ModeArgument.InsertWithTransaction transaction -> transaction.Complete()
         | ModeArgument.Substitute _ -> ()
+        | ModeArgument.PartialCommand _ -> ()
 
 [<RequireQualifiedAccess>]
 [<NoComparison>]

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2296,7 +2296,7 @@ type ModeArgument =
     /// match to process and the range is the full range to consider for a replace
     | Substitute of SnapshotSpan * SnapshotLineRange * SubstituteData
 
-    /// Enter normal mode with a partially entered command
+    /// Enter command mode with a partially entered command and then return to normal mode
     | PartialCommand of string
 
 with

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4011,6 +4011,19 @@ type DefaultSettings =
     | GVim73 = 0
     | GVim74 = 1
 
+type RunCommandResults
+    (
+        _exitCode: int,
+        _output: string,
+        _error: string
+    ) =
+
+    member x.ExitCode = _exitCode
+
+    member x.Output = _output
+
+    member x.Error = _error
+
 type IVimHost =
 
     /// Should vim automatically start synchronization of IVimBuffer instances when they are 
@@ -4132,7 +4145,7 @@ type IVimHost =
 
     /// Run the specified command with the given arguments and return the textual
     /// output
-    abstract RunCommand: file: string -> arguments: string -> input: string -> vimHost: IVimData -> string
+    abstract RunCommand: file: string -> arguments: string -> input: string -> vimHost: IVimData -> RunCommandResults
 
     /// Run the Visual studio command in the context of the given ITextView
     abstract RunHostCommand: textView: ITextView -> commandName: string -> argument: string -> unit

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2270,9 +2270,6 @@ type TextObjectKind =
 type ModeArgument =
     | None
 
-    /// Used for transitions from Visual Mode directly to Command mode
-    | FromVisual 
-
     /// Passed to visual mode to indicate what the initial selection should be.  The SnapshotPoint
     /// option provided is meant to be the initial caret point.  If not provided the actual 
     /// caret point is used

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2526,6 +2526,12 @@ type NormalCommand =
     /// Fold 'count' lines in the ITextBuffer
     | FoldLines
 
+    /// Filter the specified lines
+    | FilterLines
+
+    /// Filter the specified motion
+    | FilterMotion of MotionData
+
     /// Create a fold over the specified motion 
     | FoldMotion of MotionData
 
@@ -2747,6 +2753,7 @@ type NormalCommand =
         match x with
         | NormalCommand.ChangeMotion motion -> Some (NormalCommand.ChangeMotion, motion)
         | NormalCommand.DeleteMotion motion -> Some (NormalCommand.DeleteMotion, motion)
+        | NormalCommand.FilterMotion motion -> Some (NormalCommand.FilterMotion, motion)
         | NormalCommand.FoldMotion motion -> Some (NormalCommand.FoldMotion, motion)
         | NormalCommand.FormatMotion motion -> Some (NormalCommand.FormatMotion, motion)
         | NormalCommand.ShiftMotionLinesLeft motion -> Some (NormalCommand.ShiftMotionLinesLeft, motion)
@@ -2773,6 +2780,7 @@ type NormalCommand =
         | NormalCommand.DeleteLines -> None
         | NormalCommand.DeleteTillEndOfLine -> None
         | NormalCommand.DisplayCharacterBytes
+        | NormalCommand.FilterLines -> None
         | NormalCommand.FoldLines -> None
         | NormalCommand.FormatLines -> None
         | NormalCommand.GoToDefinition -> None
@@ -2875,6 +2883,9 @@ type VisualCommand =
 
     /// Delete the selected text and put it into a register
     | DeleteSelection
+
+    /// Filter the selected text
+    | FilterLines
 
     /// Fold the current selected lines
     | FoldSelection

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4132,7 +4132,7 @@ type IVimHost =
 
     /// Run the specified command with the given arguments and return the textual
     /// output
-    abstract RunCommand: file: string -> arguments: string -> vimHost: IVimData -> string
+    abstract RunCommand: file: string -> arguments: string -> input: string -> vimHost: IVimData -> string
 
     /// Run the Visual studio command in the context of the given ITextView
     abstract RunHostCommand: textView: ITextView -> commandName: string -> argument: string -> unit

--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -648,8 +648,8 @@ and [<RequireQualifiedAccess>] LineCommand =
     /// Process the '/' and '?' commands
     | Search of LineRangeSpecifier * SearchPath * string
 
-    /// Execute the given shell command
-    | ShellCommand of string
+    /// Filter the given line range through shell command
+    | ShellCommand of LineRangeSpecifier * string
 
     /// Process the '<' shift left command
     | ShiftLeft of LineRangeSpecifier

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1478,7 +1478,7 @@ type VimInterpreter
 
             if lineRange = LineRangeSpecifier.None then
                 let file = _globalSettings.Shell
-                let output = _vimHost.RunCommand _globalSettings.Shell command null _vimData
+                let output = _vimHost.RunCommand _globalSettings.Shell command "" _vimData
                 _statusUtil.OnStatus output
             else
                 x.RunWithLineRangeOrDefault lineRange DefaultLineRange.None (fun lineRange ->

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1488,7 +1488,7 @@ type VimInterpreter
 
             if lineRange = LineRangeSpecifier.None then
                 let file = _globalSettings.Shell
-                let results = _vimHost.RunCommand _globalSettings.Shell command "" _vimData
+                let results = _vimHost.RunCommand _globalSettings.Shell command StringUtil.Empty _vimData
                 let status = results.Output + results.Error
                 _statusUtil.OnStatus status
             else

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1478,8 +1478,8 @@ type VimInterpreter
 
             if lineRange = LineRangeSpecifier.None then
                 let file = _globalSettings.Shell
-                let output = _vimHost.RunCommand _globalSettings.Shell command "" _vimData
-                _statusUtil.OnStatus output
+                let results = _vimHost.RunCommand _globalSettings.Shell command "" _vimData
+                _statusUtil.OnStatus results.Output
             else
                 x.RunWithLineRangeOrDefault lineRange DefaultLineRange.None (fun lineRange ->
                     _commonOperations.FilterLines lineRange command)

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1490,6 +1490,7 @@ type VimInterpreter
                 let file = _globalSettings.Shell
                 let results = _vimHost.RunCommand _globalSettings.Shell command StringUtil.Empty _vimData
                 let status = results.Output + results.Error
+                let status = EditUtil.RemoveEndingNewLine status
                 _statusUtil.OnStatus status
             else
                 x.RunWithLineRangeOrDefault lineRange DefaultLineRange.None (fun lineRange ->

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1478,7 +1478,7 @@ type VimInterpreter
 
             if lineRange = LineRangeSpecifier.None then
                 let file = _globalSettings.Shell
-                let output = _vimHost.RunCommand _globalSettings.Shell command _vimData
+                let output = _vimHost.RunCommand _globalSettings.Shell command null _vimData
                 _statusUtil.OnStatus output
             else
                 x.RunWithLineRangeOrDefault lineRange DefaultLineRange.None (fun lineRange ->

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1479,7 +1479,8 @@ type VimInterpreter
             if lineRange = LineRangeSpecifier.None then
                 let file = _globalSettings.Shell
                 let results = _vimHost.RunCommand _globalSettings.Shell command "" _vimData
-                _statusUtil.OnStatus results.Output
+                let status = results.Output + results.Error
+                _statusUtil.OnStatus status
             else
                 x.RunWithLineRangeOrDefault lineRange DefaultLineRange.None (fun lineRange ->
                     _commonOperations.FilterLines lineRange command)

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1468,10 +1468,10 @@ type Parser
         LineCommand.ShiftRight (lineRange)
 
     /// Parse out the shell command
-    member x.ParseShellCommand () =
+    member x.ParseShellCommand lineRange =
         use resetFlags = _tokenizer.SetTokenizerFlagsScoped TokenizerFlags.AllowDoubleQuote
         let command = x.ParseRestOfLine()
-        LineCommand.ShellCommand command
+        LineCommand.ShellCommand (lineRange, command)
 
     /// Parse out a string constant from the token stream.  Loads of special characters are
     /// possible here.  A complete list is available at :help expr-string
@@ -2256,7 +2256,7 @@ type Parser
                 | ">" -> x.ParseShiftRight lineRange
                 | "&" -> x.ParseSubstituteRepeat lineRange SubstituteFlags.None
                 | "~" -> x.ParseSubstituteRepeat lineRange SubstituteFlags.UsePreviousSearchPattern
-                | "!" -> noRange (fun () -> x.ParseShellCommand())
+                | "!" -> x.ParseShellCommand lineRange
                 | _ -> LineCommand.ParseError Resources.Parser_Error
 
             handleParseResult parseResult

--- a/Src/VimCore/MefInterfaces.fs
+++ b/Src/VimCore/MefInterfaces.fs
@@ -345,6 +345,9 @@ type ICommonOperations =
     /// Ensure the view properties are met at the point
     abstract EnsureAtPoint: point: SnapshotPoint -> viewFlags: ViewFlags -> unit
 
+    /// Filter the specified line range through the specified command
+    abstract FilterLines: SnapshotLineRange -> command: string -> unit
+
     /// Format the specified line range
     abstract FormatLines: SnapshotLineRange -> unit
 

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -152,6 +152,7 @@ type internal CommandMode
         _historySession <- None
         _bindData <- BindDataError
         _keepSelection <- false
+        _isPartialCommand <- false
 
     /// Called externally to update the command.  Do this by modifying the history 
     /// session.  If we aren't in command mode currently then this is a no-op 

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -18,9 +18,6 @@ type internal CommandMode
     let _parser = Parser(_buffer.Vim.GlobalSettings, _vimData)
     let _vimHost = _buffer.Vim.VimHost
 
-    // Command to show when entering command from Visual Mode
-    static let FromVisualModeString = "'<,'>"
-
     static let BindDataError: BindData<int> = {
         KeyRemapMode = KeyRemapMode.None;
         BindFunction = fun _ -> BindResult.Error

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -138,7 +138,7 @@ type internal CommandMode
         arg.CompleteAnyTransaction
         let commandText = 
             match arg with
-            | ModeArgument.FromVisual -> FromVisualModeString
+            | ModeArgument.PartialCommand command -> command
             | _ -> StringUtil.Empty
 
         if not (StringUtil.IsNullOrEmpty commandText) then

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -147,6 +147,7 @@ type internal NormalMode
                 yield ("<lt><lt>", CommandFlags.Repeatable, NormalCommand.ShiftLinesLeft)
                 yield (">>", CommandFlags.Repeatable, NormalCommand.ShiftLinesRight)
                 yield ("==", CommandFlags.Repeatable, NormalCommand.FormatLines)
+                yield ("!!", CommandFlags.Repeatable, NormalCommand.FilterLines)
                 yield (":", CommandFlags.Special, NormalCommand.SwitchMode (ModeKind.Command, ModeArgument.None))
             } |> Seq.map (fun (str, flags, command) -> 
                 let keyInputSet = KeyNotationUtil.StringToKeyInputSet str
@@ -164,6 +165,7 @@ type internal NormalMode
                 yield ("zf", CommandFlags.None, NormalCommand.FoldMotion)
                 yield ("<lt>", CommandFlags.Repeatable ||| CommandFlags.ShiftLeft, NormalCommand.ShiftMotionLinesLeft)
                 yield (">", CommandFlags.Repeatable ||| CommandFlags.ShiftRight, NormalCommand.ShiftMotionLinesRight)
+                yield ("!", CommandFlags.Repeatable, NormalCommand.FilterMotion)
                 yield ("=", CommandFlags.Repeatable, NormalCommand.FormatMotion)
             } |> Seq.map (fun (str, flags, command) -> 
                 let keyInputSet = KeyNotationUtil.StringToKeyInputSet str

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -29,6 +29,9 @@ type internal VisualMode
         | VisualKind.Line -> (OperationKind.LineWise, ModeKind.VisualLine)
         | VisualKind.Block -> (OperationKind.CharacterWise, ModeKind.VisualBlock)
 
+    // Command to show when entering command from Visual Mode
+    static let CommandFromVisualModeString = "'<,'>"
+
     /// Get a mark and use the provided 'func' to create a Motion value
     static let BindMark func = 
         let bindFunc (keyInput: KeyInput) =
@@ -112,7 +115,7 @@ type internal VisualMode
                 yield ("[P", CommandFlags.Repeatable, NormalCommand.PutBeforeCaretWithIndent)
                 yield ("]p", CommandFlags.Repeatable, NormalCommand.PutAfterCaretWithIndent)
                 yield ("]P", CommandFlags.Repeatable, NormalCommand.PutBeforeCaretWithIndent)
-                yield (":", CommandFlags.Special, NormalCommand.SwitchMode (ModeKind.Command, ModeArgument.FromVisual))
+                yield (":", CommandFlags.Special, NormalCommand.SwitchMode (ModeKind.Command, (ModeArgument.PartialCommand CommandFromVisualModeString)))
             } |> Seq.map (fun (str, flags, command) -> 
                 let keyInputSet = KeyNotationUtil.StringToKeyInputSet str
                 CommandBinding.NormalBinding (keyInputSet, flags, command))

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -89,6 +89,7 @@ type internal VisualMode
                 yield (">", CommandFlags.Repeatable, VisualCommand.ShiftLinesRight)
                 yield ("~", CommandFlags.Repeatable, VisualCommand.ChangeCase ChangeCharacterKind.ToggleCase)
                 yield ("=", CommandFlags.Repeatable, VisualCommand.FormatLines)
+                yield ("!", CommandFlags.Repeatable, VisualCommand.FilterLines)
             } |> Seq.map (fun (str, flags, command) -> 
                 let keyInputSet = KeyNotationUtil.StringToKeyInputSet str
                 CommandBinding.VisualBinding (keyInputSet, flags, command))

--- a/Src/VimCore/Resources.fs
+++ b/Src/VimCore/Resources.fs
@@ -117,4 +117,4 @@ module internal Resources =
     let Regex_UnmatchedParen = "Unmatched ("
     let Regex_UnmatchedBrace = "Unmatched {"
 
-
+    let Filter_CommandReturned exitCode = sprintf "Command returned %d" exitCode

--- a/Src/VimTestUtils/Mock/MockVimHost.cs
+++ b/Src/VimTestUtils/Mock/MockVimHost.cs
@@ -40,7 +40,7 @@ namespace Vim.UnitTest.Mock
         public Func<ITextView, InsertCommand, bool> TryCustomProcessFunc { get; set; }
         public Func<ITextView> CreateHiddenTextViewFunc { get; set; }
         public Func<ITextBuffer, bool> IsDirtyFunc { get; set; }
-        public Func<string, string, IVimData, string> RunCommandFunc { get; set; }
+        public Func<string, string, string, IVimData, string> RunCommandFunc { get; set; }
         public Action<ITextView, string, string> RunHostCommandFunc { get; set; }
         public Action<QuickFix, int, bool> RunQuickFixFunc { get; set; }
         public Action OpenQuickFixWindowFunc { get; set; }
@@ -236,9 +236,9 @@ namespace Vim.UnitTest.Mock
             GoToTabData = index;
         }
 
-        string IVimHost.RunCommand(string command, string arguments, IVimData vimData)
+        string IVimHost.RunCommand(string command, string arguments, string input, IVimData vimData)
         {
-            return RunCommandFunc(command, arguments, vimData);
+            return RunCommandFunc(command, arguments, input, vimData);
         }
 
         void IVimHost.RunHostCommand(ITextView textView, string command, string argument)

--- a/Src/VimTestUtils/Mock/MockVimHost.cs
+++ b/Src/VimTestUtils/Mock/MockVimHost.cs
@@ -40,7 +40,7 @@ namespace Vim.UnitTest.Mock
         public Func<ITextView, InsertCommand, bool> TryCustomProcessFunc { get; set; }
         public Func<ITextView> CreateHiddenTextViewFunc { get; set; }
         public Func<ITextBuffer, bool> IsDirtyFunc { get; set; }
-        public Func<string, string, string, IVimData, string> RunCommandFunc { get; set; }
+        public Func<string, string, string, IVimData, RunCommandResults> RunCommandFunc { get; set; }
         public Action<ITextView, string, string> RunHostCommandFunc { get; set; }
         public Action<QuickFix, int, bool> RunQuickFixFunc { get; set; }
         public Action OpenQuickFixWindowFunc { get; set; }
@@ -236,7 +236,7 @@ namespace Vim.UnitTest.Mock
             GoToTabData = index;
         }
 
-        string IVimHost.RunCommand(string command, string arguments, string input, IVimData vimData)
+        RunCommandResults IVimHost.RunCommand(string command, string arguments, string input, IVimData vimData)
         {
             return RunCommandFunc(command, arguments, input, vimData);
         }

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -275,16 +275,15 @@ namespace Vim.UI.Wpf
                 var stdout = process.StandardOutput;
                 var stderr = process.StandardError;
                 var stdinTask = Task.Run(() => { stdin.Write(input); stdin.Close(); });
-                var stdoutTask = Task<string>.Run(() => stdout.ReadToEnd());
-                var stderrTask = Task<string>.Run(() => stderr.ReadToEnd());
+                var stdoutTask = Task.Run(() => stdout.ReadToEnd());
+                var stderrTask = Task.Run(() => stderr.ReadToEnd());
                 if (process.WaitForExit(timeout))
                 {
                     return new RunCommandResults(process.ExitCode, stdoutTask.Result, stderrTask.Result);
                 }
                 else
                 {
-                    var message = new TimeoutException().Message;
-                    return new RunCommandResults(-1, "", message);
+                    throw new TimeoutException();
                 }
             }
             catch (Exception ex)

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -247,7 +247,7 @@ namespace Vim.UI.Wpf
         /// <summary>
         /// Run the specified command, capture it's output and return it to the caller
         /// </summary>
-        public virtual string RunCommand(string command, string arguments, IVimData vimdata)
+        public virtual string RunCommand(string command, string arguments, string input, IVimData vimdata)
         {
             var startInfo = new ProcessStartInfo
             {
@@ -625,9 +625,9 @@ namespace Vim.UI.Wpf
             return Reload(textView);
         }
 
-        string IVimHost.RunCommand(string command, string arguments, IVimData vimData)
+        string IVimHost.RunCommand(string command, string arguments, string input, IVimData vimData)
         {
-            return RunCommand(command, arguments, vimData);
+            return RunCommand(command, arguments, input, vimData);
         }
 
         void IVimHost.RunHostCommand(ITextView textView, string command, string argument)

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -283,12 +283,13 @@ namespace Vim.UI.Wpf
                 }
                 else
                 {
-                    return new RunCommandResults(-1, "", "Process timed out");
+                    var message = new TimeoutException().Message;
+                    return new RunCommandResults(-1, "", message);
                 }
             }
             catch (Exception ex)
             {
-                return new RunCommandResults(-1, "", "Exception: " + ex.Message);
+                return new RunCommandResults(-1, "", ex.Message);
             }
         }
 

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -251,7 +251,10 @@ namespace Vim.UI.Wpf
         /// </summary>
         public virtual RunCommandResults RunCommand(string command, string arguments, string input, IVimData vimdata)
         {
+            // Use a (generous) timeout since we have no way to interrupt it.
             var timeout = 30 * 1000;
+
+            // Populate the start info.
             var startInfo = new ProcessStartInfo
             {
                 FileName = command,
@@ -263,6 +266,8 @@ namespace Vim.UI.Wpf
                 CreateNoWindow = true,
                 WorkingDirectory = vimdata.CurrentDirectory
             };
+
+            // Start the process and tasks to manage the I/O.
             try
             {
                 var process = Process.Start(startInfo);

--- a/Test/VimCoreTest/CommandModeTest.cs
+++ b/Test/VimCoreTest/CommandModeTest.cs
@@ -116,8 +116,9 @@ namespace Vim.UnitTest
         [WpfFact]
         public void OnEnter2()
         {
-            _mode.OnEnter(ModeArgument.FromVisual);
-            Assert.Equal(CommandMode.FromVisualModeString, _modeRaw.Command);
+            var partialCommand = "'<,'>";
+            _mode.OnEnter(ModeArgument.NewPartialCommand(partialCommand));
+            Assert.Equal(partialCommand, _modeRaw.Command);
         }
 
         [WpfFact]

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -2270,6 +2270,7 @@ namespace Vim.UnitTest
                         return new RunCommandResults(0, "", "");
                     };
                 ParseAndRun(@"!git status !");
+                Assert.Equal(Vim.VimData.LastShellCommand, FSharpOption.Create("git status cat"));
                 Assert.True(didRun);
             }
 
@@ -2289,6 +2290,25 @@ namespace Vim.UnitTest
                         return new RunCommandResults(0, "", "");
                     };
                 ParseAndRun(@"!git status \!");
+                Assert.True(didRun);
+            }
+
+            /// <summary>
+            /// Don't replace a ! which occurs after an \\
+            /// </summary>
+            [WpfFact]
+            public void ShellCommand_BangNoReplace_DoubleEscape()
+            {
+                Create("");
+                var didRun = false;
+                VimHost.RunCommandFunc =
+                    (command, args, input, _) =>
+                    {
+                        Assert.Equal(@"/c git status \!", args);
+                        didRun = true;
+                        return new RunCommandResults(0, "", "");
+                    };
+                ParseAndRun(@"!git status \\!");
                 Assert.True(didRun);
             }
 

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -458,7 +458,7 @@ namespace Vim.UnitTest
                         _arguments = arguments;
                         _input = input;
 
-                        return string.Empty;
+                        return new RunCommandResults(0, string.Empty, string.Empty);
                     };
                 Create();
             }
@@ -502,7 +502,8 @@ namespace Vim.UnitTest
                             .Split(new[] { newLine }, StringSplitOptions.None)
                             .Reverse()
                             .Skip(1);
-                        return String.Join(newLine, reversedLines) + newLine;
+                        var output = String.Join(newLine, reversedLines) + newLine;
+                        return new RunCommandResults(0, output, "");
                     };
             }
 
@@ -2246,7 +2247,7 @@ namespace Vim.UnitTest
                     {
                         Assert.Equal("/c git status", args);
                         didRun = true;
-                        return "";
+                        return new RunCommandResults(0, "", "");
                     };
                 ParseAndRun(@"!git status");
                 Assert.True(didRun);
@@ -2266,7 +2267,7 @@ namespace Vim.UnitTest
                     {
                         Assert.Equal("/c git status cat", args);
                         didRun = true;
-                        return "";
+                        return new RunCommandResults(0, "", "");
                     };
                 ParseAndRun(@"!git status !");
                 Assert.True(didRun);
@@ -2285,7 +2286,7 @@ namespace Vim.UnitTest
                     {
                         Assert.Equal("/c git status !", args);
                         didRun = true;
-                        return "";
+                        return new RunCommandResults(0, "", "");
                     };
                 ParseAndRun(@"!git status \!");
                 Assert.True(didRun);
@@ -2300,7 +2301,7 @@ namespace Vim.UnitTest
             {
                 Create("");
                 var didRun = false;
-                VimHost.RunCommandFunc = delegate { didRun = true; return ""; };
+                VimHost.RunCommandFunc = delegate { didRun = true; return new RunCommandResults(0, "", ""); };
                 ParseAndRun(@"!git status !");
                 Assert.False(didRun);
                 Assert.Equal(Resources.Common_NoPreviousShellCommand, _statusUtil.LastError);

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -448,13 +448,15 @@ namespace Vim.UnitTest
         {
             private string _command;
             private string _arguments;
+            private string _input;
 
             public RunCommandTest()
             {
-                VimHost.RunCommandFunc = (command, arguments, vimData) =>
+                VimHost.RunCommandFunc = (command, arguments, input, vimData) =>
                     {
                         _command = command;
                         _arguments = arguments;
+                        _input = input;
 
                         return string.Empty;
                     };
@@ -2179,7 +2181,7 @@ namespace Vim.UnitTest
                 Create("");
                 var didRun = false;
                 VimHost.RunCommandFunc =
-                    (command, args, _) =>
+                    (command, args, input, _) =>
                     {
                         Assert.Equal("/c git status", args);
                         didRun = true;
@@ -2199,7 +2201,7 @@ namespace Vim.UnitTest
                 Vim.VimData.LastShellCommand = FSharpOption.Create("cat");
                 var didRun = false;
                 VimHost.RunCommandFunc =
-                    (command, args, _) =>
+                    (command, args, input, _) =>
                     {
                         Assert.Equal("/c git status cat", args);
                         didRun = true;
@@ -2218,7 +2220,7 @@ namespace Vim.UnitTest
                 Create("");
                 var didRun = false;
                 VimHost.RunCommandFunc =
-                    (command, args, _) =>
+                    (command, args, input, _) =>
                     {
                         Assert.Equal("/c git status !", args);
                         didRun = true;

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -1617,6 +1617,9 @@ namespace Vim.UnitTest
                     };
             }
 
+            /// <summary>
+            /// Use filter combined with a motion
+            /// </summary>
             [WpfFact]
             public void Motion()
             {
@@ -1626,6 +1629,9 @@ namespace Vim.UnitTest
                 Assert.Equal(new[] { "DOG", "CAT", "BEAR", "FISH" }, _textBuffer.GetLines());
             }
 
+            /// <summary>
+            /// Use filter combined with a reverse motion (inverted line range)
+            /// </summary>
             [WpfFact]
             public void ReverseMotion()
             {
@@ -1635,6 +1641,9 @@ namespace Vim.UnitTest
                 Assert.Equal(new[] { "dog", "CAT", "BEAR", "fish" }, _textBuffer.GetLines());
             }
 
+            /// <summary>
+            /// Use filter operating on the current line
+            /// </summary>
             [WpfFact]
             public void Line()
             {
@@ -1644,6 +1653,9 @@ namespace Vim.UnitTest
                 Assert.Equal(new[] { "dog", "CAT", "bear", "fish" }, _textBuffer.GetLines());
             }
 
+            /// <summary>
+            /// Use filter operating on multiple lines
+            /// </summary>
             [WpfFact]
             public void Lines()
             {
@@ -1653,6 +1665,9 @@ namespace Vim.UnitTest
                 Assert.Equal(new[] { "dog", "CAT", "BEAR", "fish" }, _textBuffer.GetLines());
             }
 
+            /// <summary>
+            /// Use filter from visual line mode, returning to normal mode
+            /// </summary>
             [WpfFact]
             public void VisualLines()
             {
@@ -1660,6 +1675,7 @@ namespace Vim.UnitTest
                 _vimBuffer.ProcessNotation("2GV<Return>!upper<Return>");
                 Assert.Equal("/c upper", _arguments);
                 Assert.Equal(new[] { "dog", "CAT", "BEAR", "fish" }, _textBuffer.GetLines());
+                Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
             }
         }
 

--- a/Test/VimCoreTest/VisualModeTest.cs
+++ b/Test/VimCoreTest/VisualModeTest.cs
@@ -425,7 +425,7 @@ namespace Vim.UnitTest
         public void Bind_SwitchMode_Command()
         {
             Create("");
-            _commandUtil.SetupCommandNormal(NormalCommand.NewSwitchMode(ModeKind.Command, ModeArgument.FromVisual));
+            _commandUtil.SetupCommandNormal(NormalCommand.NewSwitchMode(ModeKind.Command, ModeArgument.NewPartialCommand("'<,'>")));
             _mode.Process(":");
             _commandUtil.Verify();
         }

--- a/Test/VimWpfTest/VimHostTests.cs
+++ b/Test/VimWpfTest/VimHostTests.cs
@@ -153,7 +153,7 @@ namespace Vim.UI.Wpf.UnitTest
                 { CallBase = true }.Object;
                 var vimData = Mock.Of<IVimData>(x => x.CurrentDirectory == cwd);
 
-                vimHost.RunCommand("pwd", "", vimData);
+                vimHost.RunCommand("pwd", "", null, vimData);
 
                 // Not sure if we can do anything besides verify that it used the getter
                 Mock.Get(vimData).VerifyGet(x => x.CurrentDirectory);

--- a/Test/VimWpfTest/VimHostTests.cs
+++ b/Test/VimWpfTest/VimHostTests.cs
@@ -153,7 +153,7 @@ namespace Vim.UI.Wpf.UnitTest
                 { CallBase = true }.Object;
                 var vimData = Mock.Of<IVimData>(x => x.CurrentDirectory == cwd);
 
-                vimHost.RunCommand("pwd", "", null, vimData);
+                vimHost.RunCommand("pwd", "", "", vimData);
 
                 // Not sure if we can do anything besides verify that it used the getter
                 Mock.Get(vimData).VerifyGet(x => x.CurrentDirectory);


### PR DESCRIPTION
Changes:

- Implement the filter command `:[range]!command` to filter lines through external program
- Implement the filter lines operation `!!`
- Implement the filter motion operation `![motion]`
- Implement the filter operation from visual mode `V[motions]!`
- Enhance the `RunCommand` interface to return the exit code and standard error output
- Add timeout when running external programs to prevent hanging the editor
- Hide console window associated with shell/filter commands
- Fix `:` command from visual mode doesn't return to command mode
- Fix expansion of last command using `!`
- Fix double-escaping of `!` character in filter and shell commands
- Fix recording of previous shell/filter command

Issues:

- Fixes #1540
- Fixes #1987
- Fixes #2033
- Fixes #2078
- Fixes #2120 
