### PR TITLE
Open undo fixes

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -885,7 +885,7 @@ type internal CommandUtil
 
     /// Used for the several commands which make an edit here and need the edit to be linked
     /// with the next insert mode change.
-    member x.OpenTransactionForLinkedChange name action =
+    member x.CreateTransactionForLinkedChange name action =
         let transaction = _undoRedoOperations.CreateLinkedUndoTransaction name
 
         try
@@ -900,21 +900,21 @@ type internal CommandUtil
 
         transaction
 
-    /// Create a undo transaction, perform an action, and switch to normal insert mode
+    /// Create an undo transaction, perform an action, and switch to normal insert mode
     member x.EditWithLinkedChange name action =
-        let transaction = x.OpenTransactionForLinkedChange name action
+        let transaction = x.CreateTransactionForLinkedChange name action
         let arg = ModeArgument.InsertWithTransaction transaction
         CommandResult.Completed (ModeSwitch.SwitchModeWithArgument (ModeKind.Insert, arg))
 
-    /// Create a undo transaction, perform an action, and switch to insert mode with a count
+    /// Create an undo transaction, perform an action, and switch to insert mode with a count
     member x.EditCountWithLinkedChange name count action =
-        let transaction = x.OpenTransactionForLinkedChange name action
+        let transaction = x.CreateTransactionForLinkedChange name action
         let arg = ModeArgument.InsertWithCountAndNewLine (count, transaction)
         CommandResult.Completed (ModeSwitch.SwitchModeWithArgument (ModeKind.Insert, arg))
 
-    /// Create a undo transaction, perform an action, and switch to block insert mode
+    /// Create an undo transaction, perform an action, and switch to block insert mode
     member x.EditBlockWithLinkedChange name blockSpan action =
-        let transaction = x.OpenTransactionForLinkedChange name action
+        let transaction = x.CreateTransactionForLinkedChange name action
         let arg = ModeArgument.InsertBlock (blockSpan, transaction)
         CommandResult.Completed (ModeSwitch.SwitchModeWithArgument (ModeKind.Insert, arg))
 
@@ -2001,7 +2001,7 @@ type internal CommandUtil
             | CommandResult.Completed modeSwitch ->
                 match modeSwitch with
                 | ModeSwitch.SwitchModeWithArgument (_, modeArgument) ->
-                    modeArgument.CloseAnyTransaction
+                    modeArgument.CompleteAnyTransaction
                 | _ -> ()
                 runNextCommand ()
 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2289,7 +2289,7 @@ type ModeArgument =
     /// Begins insert mode with a specified count.  This means the text inserted should
     /// be repeated a total of 'count - 1' times when insert mode exits.  Each extra time
     /// should be on a new line
-    | InsertWithCountAndNewLine of int
+    | InsertWithCountAndNewLine of int * ILinkedUndoTransaction
 
     /// Begins insert mode with an existing UndoTransaction.  This is used to link 
     /// change commands with text changes.  For example C, c, etc ...
@@ -2298,6 +2298,22 @@ type ModeArgument =
     /// Passing the substitute to confirm to Confirm mode.  The SnapshotSpan is the first
     /// match to process and the range is the full range to consider for a replace
     | Substitute of SnapshotSpan * SnapshotLineRange * SubstituteData
+
+with
+
+    // Running linked commands will throw away the ModeSwitch value.  This can contain
+    // an open IUndoTransaction.  This must be completed here or it will break undo in the
+    // ITextBuffer
+    member x.CloseAnyTransaction =
+        match x with
+        | ModeArgument.None -> ()
+        | ModeArgument.FromVisual -> ()
+        | ModeArgument.InitialVisualSelection _ -> ()
+        | ModeArgument.InsertBlock (_, transaction) -> transaction.Complete()
+        | ModeArgument.InsertWithCount _ -> ()
+        | ModeArgument.InsertWithCountAndNewLine (_, transaction) -> transaction.Complete()
+        | ModeArgument.InsertWithTransaction transaction -> transaction.Complete()
+        | ModeArgument.Substitute _ -> ()
 
 [<RequireQualifiedAccess>]
 [<NoComparison>]

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2304,7 +2304,7 @@ with
     // Running linked commands will throw away the ModeSwitch value.  This can contain
     // an open IUndoTransaction.  This must be completed here or it will break undo in the
     // ITextBuffer
-    member x.CloseAnyTransaction =
+    member x.CompleteAnyTransaction =
         match x with
         | ModeArgument.None -> ()
         | ModeArgument.FromVisual -> ()

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -127,7 +127,7 @@ type internal CommandMode
             }
         HistoryUtil.CreateHistorySession historyClient 0 _command (Some _buffer)
 
-    member x.OnEnter arg = 
+    member x.OnEnter (arg: ModeArgument) = 
         let historySession = x.CreateHistorySession()
 
         _command <- ""
@@ -135,16 +135,11 @@ type internal CommandMode
         _bindData <- historySession.CreateBindDataStorage().CreateBindData()
         _keepSelection <- false
 
+        arg.CloseAnyTransaction
         let commandText = 
             match arg with
-            | ModeArgument.None -> StringUtil.Empty
             | ModeArgument.FromVisual -> FromVisualModeString
-            | ModeArgument.Substitute _ -> StringUtil.Empty
-            | ModeArgument.InitialVisualSelection _ -> StringUtil.Empty
-            | ModeArgument.InsertBlock (_, transaction) -> transaction.Complete(); StringUtil.Empty
-            | ModeArgument.InsertWithCount _ -> StringUtil.Empty
-            | ModeArgument.InsertWithCountAndNewLine _ -> StringUtil.Empty
-            | ModeArgument.InsertWithTransaction transaction -> transaction.Complete(); StringUtil.Empty
+            | _ -> StringUtil.Empty
 
         if not (StringUtil.IsNullOrEmpty commandText) then
             x.ChangeCommand commandText

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -135,7 +135,7 @@ type internal CommandMode
         _bindData <- historySession.CreateBindDataStorage().CreateBindData()
         _keepSelection <- false
 
-        arg.CloseAnyTransaction
+        arg.CompleteAnyTransaction
         let commandText = 
             match arg with
             | ModeArgument.FromVisual -> FromVisualModeString

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -1047,12 +1047,10 @@ type internal InsertMode
                 else
                     let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Insert" LinkedUndoTransactionFlags.CanBeEmpty
                     Some transaction, InsertKind.Normal
-            | ModeArgument.InsertWithCountAndNewLine count ->
+            | ModeArgument.InsertWithCountAndNewLine (count, transaction) ->
                 if count > 1 then
-                    let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Insert with count and new line" LinkedUndoTransactionFlags.CanBeEmpty
                     Some transaction, InsertKind.Repeat (count, true, TextChange.Insert StringUtil.Empty)
                 else
-                    let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Insert with new line" LinkedUndoTransactionFlags.CanBeEmpty
                     Some transaction, InsertKind.Normal
             | ModeArgument.InsertWithTransaction transaction ->
                 Some transaction, InsertKind.Normal

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -353,7 +353,7 @@ type internal NormalMode
             x.Reset()
             ProcessResult.Handled ModeSwitch.NoSwitch
 
-    member x.OnEnter arg =
+    member x.OnEnter (arg: ModeArgument) =
         x.EnsureCommands()
         x.Reset()
 
@@ -362,15 +362,7 @@ type internal NormalMode
             _operations.EnsureAtCaret ViewFlags.VirtualEdit
 
         // Process the argument if it's applicable
-        match arg with 
-        | ModeArgument.None -> ()
-        | ModeArgument.FromVisual -> ()
-        | ModeArgument.Substitute(_) -> ()
-        | ModeArgument.InitialVisualSelection _ -> ()
-        | ModeArgument.InsertBlock (_, transaction) -> transaction.Complete()
-        | ModeArgument.InsertWithCount _ -> ()
-        | ModeArgument.InsertWithCountAndNewLine _ -> ()
-        | ModeArgument.InsertWithTransaction transaction -> transaction.Complete()
+        arg.CloseAnyTransaction
 
     interface INormalMode with 
         member x.KeyRemapMode = x.KeyRemapMode

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -362,7 +362,7 @@ type internal NormalMode
             _operations.EnsureAtCaret ViewFlags.VirtualEdit
 
         // Process the argument if it's applicable
-        arg.CloseAnyTransaction
+        arg.CompleteAnyTransaction
 
     interface INormalMode with 
         member x.KeyRemapMode = x.KeyRemapMode

--- a/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
+++ b/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
@@ -206,15 +206,9 @@ type internal SubstituteConfirmMode
 
         member x.OnClose() = ()
         member x.OnEnter arg =
+            arg.CloseAnyTransaction
             x.ConfirmData <- 
                 match arg with
-                | ModeArgument.None -> None
-                | ModeArgument.FromVisual -> None
-                | ModeArgument.InitialVisualSelection _ -> None
-                | ModeArgument.InsertBlock (_, transaction) -> transaction.Complete(); None
-                | ModeArgument.InsertWithCount _ -> None
-                | ModeArgument.InsertWithCountAndNewLine _ -> None
-                | ModeArgument.InsertWithTransaction transaction -> transaction.Complete(); None
                 | ModeArgument.Substitute(span, range, data) ->
                     match VimRegexFactory.CreateForSubstituteFlags data.SearchPattern _globalSettings data.Flags with
                     | None -> None
@@ -222,6 +216,7 @@ type internal SubstituteConfirmMode
                         let isReplaceAll = Util.IsFlagSet data.Flags SubstituteFlags.ReplaceAll
                         let data = { Regex=regex; SubstituteText=data.Substitute; CurrentMatch = span; LastLineNumber = range.LastLineNumber; IsReplaceAll=isReplaceAll}
                         Some data
+                | _ -> None
 
         member x.OnLeave () = 
             x.ConfirmData <- None

--- a/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
+++ b/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
@@ -206,7 +206,7 @@ type internal SubstituteConfirmMode
 
         member x.OnClose() = ()
         member x.OnEnter arg =
-            arg.CloseAnyTransaction
+            arg.CompleteAnyTransaction
             x.ConfirmData <- 
                 match arg with
                 | ModeArgument.Substitute(span, range, data) ->

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -4511,6 +4511,35 @@ namespace Vim.UnitTest
                 _vimBuffer.Process('.');
                 Assert.Equal("};", _textView.GetLine(1).GetText());
             }
+
+            /// <summary>
+            /// A simple insert line above should be undone all at once
+            /// </summary>
+            [WpfFact]
+            public void UndoInsertLineAbove()
+            {
+                Create("cat", "dog", "tree");
+                _textView.MoveCaretToLine(2);
+                _vimBuffer.Process("O  fish");
+                _vimBuffer.Process(VimKey.Escape);
+                Assert.Equal(new[] { "cat", "dog", "  fish", "tree" }, _textBuffer.GetLines());
+                _vimBuffer.Process("u");
+                Assert.Equal(new[] { "cat", "dog", "tree" }, _textBuffer.GetLines());
+            }
+
+            /// <summary>
+            /// A simple insert line below should be undone all at once
+            /// </summary>
+            [WpfFact]
+            public void UndoInsertLineBelow()
+            {
+                Create("cat", "dog", "tree");
+                _vimBuffer.Process("o  fish");
+                _vimBuffer.Process(VimKey.Escape);
+                Assert.Equal(new[] { "cat", "  fish", "dog", "tree" }, _textBuffer.GetLines());
+                _vimBuffer.Process("u");
+                Assert.Equal(new[] { "cat", "dog", "tree" }, _textBuffer.GetLines());
+            }
             /// <summary>
             /// The insert line above command should be linked the the following text change
             /// </summary>


### PR DESCRIPTION
Changes:

- Create a linked undo for the 'O' (insert line above) and 'o' (insert line below) operations
- Centralize completing an undo transaction during a discarded mode switch
- Add undo tests for 'O' and 'o'

Fixes:

- Fixes #2122
