### PR TITLE
Support <C-j> and <C-m> as a synonyms for <Enter> in command margin

### DIFF
--- a/Src/VimTestUtils/Mock/MockKeyboardDevice.cs
+++ b/Src/VimTestUtils/Mock/MockKeyboardDevice.cs
@@ -136,6 +136,10 @@ namespace Vim.UnitTest.Mock
                 case VimKey.End:
                     key = Key.End;
                     return true;
+                case VimKey.LineFeed:
+                    key = Key.J;
+                    modKeys = ModifierKeys.Control;
+                    return true;
             }
 
             if (char.IsLetter(keyInput.Char))

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -371,6 +371,14 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     ExecuteCommand(_margin.CommandLineTextBox.Text);
                     e.Handled = true;
                     break;
+                case Key.J:
+                case Key.M:
+                    if (e.KeyboardDevice.Modifiers == ModifierKeys.Control)
+                    {
+                        ExecuteCommand(_margin.CommandLineTextBox.Text);
+                        e.Handled = true;
+                    }
+                    break;
                 case Key.Up:
                     e.Handled = HandleHistoryNavigation(KeyInputUtil.VimKeyToKeyInput(VimKey.Up));
                     break;

--- a/Test/VimWpfTest/CommandLineEditIntegrationTest.cs
+++ b/Test/VimWpfTest/CommandLineEditIntegrationTest.cs
@@ -271,6 +271,30 @@ namespace Vim.UI.Wpf.UnitTest
                     ProcessNotation(@"/og<Home>d<Enter>");
                     Assert.Equal(_textBuffer.GetLine(1).Start, _textView.GetCaretPoint());
                 }
+
+                /// <summary>
+                /// When the Ctrl-M key is run it should complete the search and cause the cursor
+                /// to be placed at the start of the successful find
+                /// </summary>
+                [WpfFact]
+                public void CtrlMToCompleteFind()
+                {
+                    Create("cat", "dog", "fish");
+                    ProcessNotation(@"/og<Home>d<C-m>");
+                    Assert.Equal(_textBuffer.GetLine(1).Start, _textView.GetCaretPoint());
+                }
+
+                /// <summary>
+                /// When the Ctrl-J key is run it should complete the search and cause the cursor
+                /// to be placed at the start of the successful find
+                /// </summary>
+                [WpfFact]
+                public void CtrlJToCompleteFind()
+                {
+                    Create("cat", "dog", "fish");
+                    ProcessNotation(@"/og<Home>d<C-j>");
+                    Assert.Equal(_textBuffer.GetLine(1).Start, _textView.GetCaretPoint());
+                }
             }
         }
 


### PR DESCRIPTION
- Fixes #2059