### PR TITLE
Clean up line ranges

### DIFF
--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -189,9 +189,6 @@ type LineSpecifier =
     /// The current line: '.'
     | CurrentLine
 
-    /// The current line with and end count 
-    | CurrentLineWithEndCount of int
-
     /// The last line: '$'
     | LastLine
 
@@ -215,10 +212,6 @@ type LineSpecifier =
 
     /// LineSpecifier with the given line adjustment
     | LineSpecifierWithAdjustment of LineSpecifier * int
-
-    /// Adjust the current line with the adjustment.  Current depends on whether this is
-    /// the first or second specifier in a range
-    | AdjustmentOnCurrent of int
 
 /// A line range in the file 
 [<RequireQualifiedAccess>]

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -410,7 +410,7 @@ type VimInterpreter
                     TextViewUtil.MoveCaretToPoint _textView leftLine.Start
 
                 // Get the right line and combine the results
-                match x.GetLineCore rightLineSpecifier leftLine with
+                match x.GetLine rightLineSpecifier with
                 | None -> None
                 | Some rightLine -> SnapshotLineRangeUtil.CreateForLineRange leftLine rightLine |> Some
         | LineRangeSpecifier.WithEndCount (lineRange, count) ->

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -315,11 +315,6 @@ type VimInterpreter
         | LineSpecifier.CurrentLine -> 
             x.CaretLine |> getLineAndNumber |> Some
 
-        | LineSpecifier.CurrentLineWithEndCount count ->
-            let lineNumber = x.CaretLineNumber + count
-            let line = SnapshotUtil.GetLineOrLast x.CurrentSnapshot lineNumber
-            line |> getLineAndNumber |> Some
-
         | LineSpecifier.LastLine ->
             let line = SnapshotUtil.GetLastLine x.CurrentSnapshot
             if x.CurrentSnapshot.LineCount >= 2 && line.Start.Position = line.EndIncludingLineBreak.Position then
@@ -347,9 +342,6 @@ type VimInterpreter
 
         | LineSpecifier.LineSpecifierWithAdjustment (lineSpecifier, adjustment) ->
             x.GetLine lineSpecifier |> OptionUtil.map2 (getAdjustment adjustment)
-
-        | LineSpecifier.AdjustmentOnCurrent adjustment -> 
-            getAdjustment adjustment currentLine
 
         | LineSpecifier.NextLineWithPattern pattern ->
             // TODO: Implement

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1342,7 +1342,16 @@ type Parser
             _tokenizer.MoveNextToken()
             LineRangeSpecifier.EntireBuffer
         else
-            match x.ParseLineSpecifier() with
+            let startLine = x.ParseLineSpecifier()
+            let startLine =
+                match startLine with
+                | None ->
+                    if _tokenizer.CurrentChar = ',' || _tokenizer.CurrentChar = ';' then
+                        Some LineSpecifier.CurrentLine
+                    else
+                        None
+                | Some left -> startLine
+            match startLine with
             | None -> LineRangeSpecifier.None
             | Some left ->
 
@@ -1350,7 +1359,7 @@ type Parser
                     let isSemicolon = _tokenizer.CurrentChar = ';'
                     _tokenizer.MoveNextToken()
                     match x.ParseLineSpecifier() with
-                    | None -> LineRangeSpecifier.SingleLine left
+                    | None -> LineRangeSpecifier.Range (left, LineSpecifier.CurrentLine, isSemicolon)
                     | Some right -> LineRangeSpecifier.Range (left, right, isSemicolon)
                 else
                     LineRangeSpecifier.SingleLine left 

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1247,10 +1247,10 @@ type Parser
                 _tokenizer.MoveNextToken()
                 match _tokenizer.CurrentTokenKind with
                 | TokenKind.Number _ ->
-                    x.ParseNumber() |> Option.map (LineSpecifier.CurrentLineWithEndCount)
-                | TokenKind.Character '+' ->
-                    _tokenizer.MoveNextToken()
-                    x.ParseNumber() |> Option.map (LineSpecifier.CurrentLineWithEndCount)
+                    x.ParseNumber()
+                    |> OptionUtil.getOrDefault 1
+                    |> (fun number -> LineSpecifier.LineSpecifierWithAdjustment (LineSpecifier.CurrentLine, number))
+                    |> Some
                 | _ ->
                     Some LineSpecifier.CurrentLine
             elif _tokenizer.CurrentChar = '\'' then
@@ -1299,12 +1299,8 @@ type Parser
                     _tokenizer.MoveToMark mark
                     None
 
-            elif _tokenizer.CurrentChar = '+' then
-                _tokenizer.MoveNextToken()
-                x.ParseNumber() |> Option.map LineSpecifier.AdjustmentOnCurrent
-            elif _tokenizer.CurrentChar = '-' then
-                _tokenizer.MoveNextToken()
-                x.ParseNumber() |> Option.map (fun number -> LineSpecifier.AdjustmentOnCurrent -number)
+            elif _tokenizer.CurrentChar = '+' || _tokenizer.CurrentChar = '-' then
+                Some LineSpecifier.CurrentLine
             else 
                 match x.ParseNumber() with
                 | None -> None

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -359,6 +359,7 @@ namespace Vim.UnitTest
             return (LineSpecifier.PreviousLineWithPattern)lineSpecifier;
         }
 
+#if false
         public static LineSpecifier.CurrentLineWithEndCount AsCurrentLineWithEndCount(this LineSpecifier lineSpecifier)
         {
             return (LineSpecifier.CurrentLineWithEndCount)lineSpecifier;
@@ -368,6 +369,7 @@ namespace Vim.UnitTest
         {
             return lineSpecifier.IsCurrentLineWithEndCount && lineSpecifier.AsCurrentLineWithEndCount().Item == count;
         }
+#endif
 
         #endregion
 

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -359,17 +359,17 @@ namespace Vim.UnitTest
             return (LineSpecifier.PreviousLineWithPattern)lineSpecifier;
         }
 
-#if false
-        public static LineSpecifier.CurrentLineWithEndCount AsCurrentLineWithEndCount(this LineSpecifier lineSpecifier)
+        public static LineSpecifier.LineSpecifierWithAdjustment AsLineSpecifierWithAdjustment(this LineSpecifier lineSpecifier)
         {
-            return (LineSpecifier.CurrentLineWithEndCount)lineSpecifier;
+            return (LineSpecifier.LineSpecifierWithAdjustment)lineSpecifier;
         }
 
-        public static bool IsCurrentLineWithEndCount(this LineSpecifier lineSpecifier, int count)
+        public static bool IsCurrentLineWithAdjustment(this LineSpecifier lineSpecifier, int count)
         {
-            return lineSpecifier.IsCurrentLineWithEndCount && lineSpecifier.AsCurrentLineWithEndCount().Item == count;
+            return lineSpecifier.IsLineSpecifierWithAdjustment &&
+                lineSpecifier.AsLineSpecifierWithAdjustment().Item1.IsCurrentLine &&
+                lineSpecifier.AsLineSpecifierWithAdjustment().Item2 == count;
         }
-#endif
 
         #endregion
 

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -1364,7 +1364,7 @@ namespace Vim.UnitTest
         public sealed class RangeTest : CommandModeIntegrationTest
         {
             [WpfFact]
-            public void CurrentLineWithEndCount()
+            public void CurrentLineWithAdjustment()
             {
                 Create("dog", "cat");
                 _vimBuffer.LocalSettings.ShiftWidth = 2;
@@ -1373,7 +1373,7 @@ namespace Vim.UnitTest
             }
 
             [WpfFact]
-            public void CurrentLineWithEndCountRange()
+            public void CurrentLineWithAdjustmentRange()
             {
                 Create("dog", "cat", "tree");
                 _vimBuffer.LocalSettings.ShiftWidth = 2;

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -1709,9 +1709,37 @@ namespace Vim.UnitTest
             [WpfFact]
             public void LineRange_CurrentLine()
             {
-                Create("foo", "bar");
+                Create("foo", "bar", "baz");
+                _textView.MoveCaretToLine(1);
                 var lineRange = ParseAndGetLineRange(".");
-                Assert.Equal(_textBuffer.GetLineRange(0), lineRange);
+                Assert.Equal(_textBuffer.GetLineRange(1), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_OmittedStartLine()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(1);
+                var lineRange = ParseAndGetLineRange(",3");
+                Assert.Equal(_textBuffer.GetLineRange(1, 2), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_OmittedEndLine()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange("2,");
+                Assert.Equal(_textBuffer.GetLineRange(1, 2), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_OmittedStartAndEndLines()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(1);
+                var lineRange = ParseAndGetLineRange(",");
+                Assert.Equal(_textBuffer.GetLineRange(1), lineRange);
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -1725,6 +1725,96 @@ namespace Vim.UnitTest
             }
 
             [WpfFact]
+            public void LineRange_MinusRelativeToDot()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange(".-1");
+                Assert.Equal(_textBuffer.GetLineRange(1), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_PlusRelativeToDot()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(1);
+                var lineRange = ParseAndGetLineRange(".+1");
+                Assert.Equal(_textBuffer.GetLineRange(2), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_MinusRelativeToDollar()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(0);
+                var lineRange = ParseAndGetLineRange("$-1");
+                Assert.Equal(_textBuffer.GetLineRange(2), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_MinusImplicitDot()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange("-1");
+                Assert.Equal(_textBuffer.GetLineRange(1), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_MinusImplicitDotRange()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange("-2,-1");
+                Assert.Equal(_textBuffer.GetLineRange(0, 1), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_PlusImplicitDot()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(1);
+                var lineRange = ParseAndGetLineRange("+1");
+                Assert.Equal(_textBuffer.GetLineRange(2), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_PlusImplicitDotRange()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(1);
+                var lineRange = ParseAndGetLineRange("+1,+2");
+                Assert.Equal(_textBuffer.GetLineRange(2, 3), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_LonePlus()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(1);
+                var lineRange = ParseAndGetLineRange("+");
+                Assert.Equal(_textBuffer.GetLineRange(2), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_LoneMinus()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(1);
+                var lineRange = ParseAndGetLineRange("-");
+                Assert.Equal(_textBuffer.GetLineRange(2), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_MinusPlusRange()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(1);
+                var lineRange = ParseAndGetLineRange("-,+");
+                Assert.Equal(_textBuffer.GetLineRange(0, 2), lineRange);
+            }
+
+            [WpfFact]
             public void LineRange_OmittedEndLine()
             {
                 Create("foo", "bar", "baz", "qux");

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -1686,17 +1686,6 @@ namespace Vim.UnitTest
                 Assert.Equal("bar" + Environment.NewLine, UnnamedRegister.StringValue);
             }
 
-            /// <summary>
-            /// Handle the case where the adjustment simply occurs on the current line 
-            /// </summary>
-            [WpfFact]
-            public void GetLine_AdjustmentOnCurrent()
-            {
-                Create("cat", "dog", "bear");
-                var range = _interpreter.GetLine(LineSpecifier.NewAdjustmentOnCurrent(1));
-                Assert.Equal(_textBuffer.GetLine(1).LineNumber, range.Value.LineNumber);
-            }
-
             [WpfFact]
             public void LineRange_FullFile()
             {
@@ -1788,6 +1777,24 @@ namespace Vim.UnitTest
             }
 
             [WpfFact]
+            public void LineRange_DotPlus()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(1);
+                var lineRange = ParseAndGetLineRange(".+");
+                Assert.Equal(_textBuffer.GetLineRange(2), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_DotMinus()
+            {
+                Create("foo", "bar", "baz", "qux");
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange(".-");
+                Assert.Equal(_textBuffer.GetLineRange(1), lineRange);
+            }
+
+            [WpfFact]
             public void LineRange_LonePlus()
             {
                 Create("foo", "bar", "baz", "qux");
@@ -1800,9 +1807,9 @@ namespace Vim.UnitTest
             public void LineRange_LoneMinus()
             {
                 Create("foo", "bar", "baz", "qux");
-                _textView.MoveCaretToLine(1);
+                _textView.MoveCaretToLine(2);
                 var lineRange = ParseAndGetLineRange("-");
-                Assert.Equal(_textBuffer.GetLineRange(2), lineRange);
+                Assert.Equal(_textBuffer.GetLineRange(1), lineRange);
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/ParserTest.cs
+++ b/Test/VimCoreTest/ParserTest.cs
@@ -692,6 +692,7 @@ let x = 42
                 Assert.True(range.AsSingleLine().Item.IsCurrentLine);
             }
 
+#if false
             [Fact]
             public void CurrentLineWithEndCount()
             {
@@ -723,6 +724,7 @@ let x = 42
                 Assert.True(range.Item1.IsCurrentLineWithEndCount(2));
                 Assert.True(range.Item2.IsCurrentLineWithEndCount(3));
             }
+#endif
 
             [Fact]
             public void CurrentLineAndCurrentLine()

--- a/Test/VimCoreTest/ParserTest.cs
+++ b/Test/VimCoreTest/ParserTest.cs
@@ -692,39 +692,37 @@ let x = 42
                 Assert.True(range.AsSingleLine().Item.IsCurrentLine);
             }
 
-#if false
             [Fact]
-            public void CurrentLineWithEndCount()
+            public void CurrentLineWithAdjustment()
             {
                 var range = ParseLineRange(".2");
                 Assert.True(range.IsSingleLine);
-                Assert.True(range.AsSingleLine().Item.IsCurrentLineWithEndCount(2));
+                Assert.True(range.AsSingleLine().Item.IsCurrentLineWithAdjustment(2));
             }
 
             [Fact]
-            public void CurrentLineWithEndCountUsingPlus()
+            public void CurrentLineWithAdjustmentUsingPlus()
             {
                 var range = ParseLineRange(".+3");
                 Assert.True(range.IsSingleLine);
-                Assert.True(range.AsSingleLine().Item.IsCurrentLineWithEndCount(3));
+                Assert.True(range.AsSingleLine().Item.IsCurrentLineWithAdjustment(3));
             }
 
             [Fact]
-            public void CurrentLineWithEndCountRange()
+            public void CurrentLineWithAdjustmentRange()
             {
                 var range = ParseLineRange(".2,.3").AsRange();
-                Assert.True(range.Item1.IsCurrentLineWithEndCount(2));
-                Assert.True(range.Item2.IsCurrentLineWithEndCount(3));
+                Assert.True(range.Item1.IsCurrentLineWithAdjustment(2));
+                Assert.True(range.Item2.IsCurrentLineWithAdjustment(3));
             }
 
             [Fact]
-            public void CurrentLineWithEndCountRangeUsingPlus()
+            public void CurrentLineWithAdjustmentRangeUsingPlus()
             {
                 var range = ParseLineRange(".+2,.+3").AsRange();
-                Assert.True(range.Item1.IsCurrentLineWithEndCount(2));
-                Assert.True(range.Item2.IsCurrentLineWithEndCount(3));
+                Assert.True(range.Item1.IsCurrentLineWithAdjustment(2));
+                Assert.True(range.Item2.IsCurrentLineWithAdjustment(3));
             }
-#endif
 
             [Fact]
             public void CurrentLineAndCurrentLine()


### PR DESCRIPTION
Changes:

- Fix default lhs and rhs for ',' and ';' line ranges
- Fix interpretation of `<line-specifier><number>`, e.g. `.2` after `,` or `;`
- Fix interpretation of `[line-specifier]-[number]` and `[line-specifier]+[number]`
- Add tests for a variety of line range variants

Fixes:

- Fixes #1958
- Fixes #1976
