### PR TITLE
Fix switching visual mode after inverting selection with 'o'

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1201,10 +1201,15 @@ type internal CommandUtil
             match visualSpan with
             | VisualSpan.Character characterSpan ->
                 if characterSpan.Length > 1 then
-                    let last = Option.get characterSpan.Last
                     if x.CaretPoint.Position > characterSpan.Start.Position then
                         changeSelection x.CaretPoint characterSpan.Start
                     else
+                        let last =
+                            match _globalSettings.SelectionKind with
+                            | SelectionKind.Inclusive ->
+                                Option.get characterSpan.Last
+                            | SelectionKind.Exclusive ->
+                                characterSpan.End
                         changeSelection characterSpan.Start last
             | VisualSpan.Line _ ->
                 changeSelection x.CaretPoint anchorPoint

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -2968,7 +2968,7 @@ type internal CommandUtil
 
         // The anchor point is the original anchor point of the visual session
         let anchorPoint =
-            _vimBufferData.VisualCaretStartPoint
+            _vimBufferData.VisualAnchorPoint
             |> OptionUtil.map2 (TrackingPointUtil.GetPoint x.CurrentSnapshot)
         match anchorPoint with
         | None -> badOperation ()

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -730,6 +730,36 @@ namespace Vim.UnitTest
                 _vimBuffer.Process("v");
                 Assert.Equal(0, _textView.GetSelectionSpan().Length);
             }
+
+            /// <summary>
+            /// The visual 'o' command should not modify what is selected
+            /// </summary>
+            [WpfFact]
+            public void SwapAnchor()
+            {
+                Create("cat dog");
+                _vimBuffer.Process("v   ");
+                Assert.Equal("cat", _textView.GetSelectionSpan().GetText());
+                _vimBuffer.Process("o");
+                Assert.Equal("cat", _textView.GetSelectionSpan().GetText());
+                _vimBuffer.Process("o");
+                Assert.Equal("cat", _textView.GetSelectionSpan().GetText());
+            }
+
+            /// <summary>
+            /// Switch from character to line mode after 'o' should expand the selection
+            /// </summary>
+            [WpfFact]
+            public void Issue1395()
+            {
+                Create("cat", "dog", "bear", "bat");
+                _vimBuffer.Process(" vj");
+                Assert.Equal("at\r\nd", _textView.GetSelectionSpan().GetText());
+                _vimBuffer.Process("o");
+                Assert.Equal("at\r\nd", _textView.GetSelectionSpan().GetText());
+                _vimBuffer.Process("V");
+                Assert.Equal("cat\r\ndog\r\n", _textView.GetSelectionSpan().GetText());
+            }
         }
 
         public abstract class BlockInsertTest : VisualModeIntegrationTest


### PR DESCRIPTION
- Fixes #1395

Also fixes an unreported bug where repeated use of `o` from visual character mode with exclusive selection shrinks selection by one character for each two times `o` is pressed.