### PR TITLE
Record last visual selection before modifying text buffer

### DIFF
--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -188,8 +188,8 @@ type internal VisualMode
         let lastVisualSelection = VisualSelection.CreateForSelection _textView _visualKind _globalSettings.SelectionKind _vimBufferData.LocalSettings.TabStop
 
         // We can't wait until after the command to record the last visual selection
-        // because if the command modified the text buffer, the snapshot will be newer
-        // than the one that was active when we created it, which would interfere
+        // because if the command modifies the text buffer, the snapshot will be newer
+        // than the one that was active when we created it which would interfere
         // with the tracking service.
         _vimTextBuffer.LastVisualSelection <- Some lastVisualSelection
 

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -193,6 +193,15 @@ type internal VisualMode
         // with the tracking service.
         _vimTextBuffer.LastVisualSelection <- Some lastVisualSelection
 
+        // Save the last visual selection at the global level for use with [count]V|v except
+        // in the case of <Esc>. This <Esc> exception is not a documented behavior but exists
+        // experimentally. 
+        if ki <> KeyInputUtil.EscapeKey then
+            let vimData = _vimBufferData.Vim.VimData
+            match StoredVisualSelection.CreateFromVisualSpan lastVisualSelection.VisualSpan with
+            | None -> ()
+            | Some v -> vimData.LastVisualSelection <- Some v
+
         let result = 
             if ki = KeyInputUtil.EscapeKey && x.ShouldHandleEscape then
                 ProcessResult.Handled ModeSwitch.SwitchPreviousMode
@@ -244,16 +253,6 @@ type internal VisualMode
             // On teardown we will get calls to Stop when the view is closed.  It's invalid to access 
             // the selection at that point
             if not _textView.IsClosed then
-
-                // Save the last visual selection at the global level for use with [count]V|v except
-                // in the case of <Esc>. This <Esc> exception is not a documented behavior but exists
-                // experimentally. 
-                if ki <> KeyInputUtil.EscapeKey then
-                    let vimData = _vimBufferData.Vim.VimData
-                    match StoredVisualSelection.CreateFromVisualSpan lastVisualSelection.VisualSpan with
-                    | None -> ()
-                    | Some v -> vimData.LastVisualSelection <- Some v
-
                 if result.IsAnySwitchToVisual then
                     _selectionTracker.UpdateSelection()
                 elif not result.IsAnySwitchToCommand then

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -187,6 +187,12 @@ type internal VisualMode
         // to the selection before the command executed so save it now
         let lastVisualSelection = VisualSelection.CreateForSelection _textView _visualKind _globalSettings.SelectionKind _vimBufferData.LocalSettings.TabStop
 
+        // We can't wait until after the command to record the last visual selection
+        // because if the command modified the text buffer, the snapshot will be newer
+        // than the one that was active when we created it, which would interfere
+        // with the tracking service.
+        _vimTextBuffer.LastVisualSelection <- Some lastVisualSelection
+
         let result = 
             if ki = KeyInputUtil.EscapeKey && x.ShouldHandleEscape then
                 ProcessResult.Handled ModeSwitch.SwitchPreviousMode
@@ -238,9 +244,6 @@ type internal VisualMode
             // On teardown we will get calls to Stop when the view is closed.  It's invalid to access 
             // the selection at that point
             if not _textView.IsClosed then
-
-                // Before resetting the selection save it
-                _vimTextBuffer.LastVisualSelection <- Some lastVisualSelection
 
                 // Save the last visual selection at the global level for use with [count]V|v except
                 // in the case of <Esc>. This <Esc> exception is not a documented behavior but exists

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -2926,7 +2926,7 @@ namespace Vim.UnitTest
                 }
 
                 /// <summary>
-                /// After undo, we should be able to restoring the visual selection
+                /// After deletion and undo, we should be able to restore the visual selection
                 /// </summary>
                 [WpfFact]
                 public void RestoreVisualSelectionAfterUndo()

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -2924,6 +2924,30 @@ namespace Vim.UnitTest
                     Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
                     Assert.True(_textView.Selection.IsEmpty);
                 }
+
+                /// <summary>
+                /// After undo, we should be able to restoring the visual selection
+                /// </summary>
+                [WpfFact]
+                public void RestoreVisualSelectionAfterUndo()
+                {
+                    // Reported in issue #2079.
+                    Create("foo", "bar", "baz", "qux");
+                    Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+                    _vimBuffer.ProcessNotation("2GV+");
+                    Assert.Equal(ModeKind.VisualLine, _vimBuffer.ModeKind);
+                    Assert.Equal("bar\r\nbaz\r\n", _textView.GetSelectionSpan().GetText());
+                    _vimBuffer.ProcessNotation("d");
+                    Assert.True(_textView.Selection.IsEmpty);
+                    Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+                    Assert.Equal(new[] { "foo", "qux" }, _textBuffer.GetLines());
+                    _vimBuffer.ProcessNotation("u");
+                    Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+                    Assert.Equal(new[] { "foo", "bar", "baz", "qux" }, _textBuffer.GetLines());
+                    _vimBuffer.ProcessNotation("gv");
+                    Assert.Equal(ModeKind.VisualLine, _vimBuffer.ModeKind);
+                    Assert.Equal("bar\r\nbaz\r\n", _textView.GetSelectionSpan().GetText());
+                }
             }
         }
     }


### PR DESCRIPTION
- Fixes #2079

An alternative solution to this bug is much more invasive: modify the `IBufferTrackingService` API so that it accepts an `ITextSnapshot` instead of an `ITextBuffer`. This would allow the creation of tracking points and spans for a snaphot prior to the current snapshot of the text buffer.  However it would require changing all callers.