### PR TITLE
Undo tests and fixes

### DIFF
--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -596,12 +596,14 @@ type internal InsertUtil
         let newColumn = max (column + offset) 0
         let spaces = StringUtil.RepeatChar newColumn ' '
         let indent = _operations.NormalizeBlanks spaces
-        _textBuffer.Replace(indentSpan.Span, indent) |> ignore
 
-        // If the line is all spaces, move it to the end and
-        // the caret will no longer be in virtual space
-        if isBlankLine then
-            TextViewUtil.MoveCaretToPoint _textView x.CaretLine.End
+        x.EditWithUndoTransaction "Shift line" (fun () ->
+            _textBuffer.Replace(indentSpan.Span, indent) |> ignore
+
+            // If the line is all spaces, move it to the end and
+            // the caret will no longer be in virtual space
+            if isBlankLine then
+                TextViewUtil.MoveCaretToPoint _textView x.CaretLine.End)
 
         CommandResult.Completed ModeSwitch.NoSwitch
 

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -131,7 +131,6 @@ type WordCompletionUtil
         |> Seq.distinct
         |> List.ofSeq
 
-
 [<RequireQualifiedAccess>]
 type InsertKind =
 
@@ -713,8 +712,14 @@ type internal InsertMode
             let args = CommandRunDataEventArgs(data)
             _commandRanEvent.Trigger x args
 
-            // If there is an existing undo transaction, close it out and start a new one.
-            x.BreakUndoSequence "Insert after motion" 
+            match command with
+            | InsertCommand.ShiftLineLeft -> ()
+            | InsertCommand.ShiftLineRight -> ()
+            | InsertCommand.InsertCharacterAboveCaret -> ()
+            | InsertCommand.InsertCharacterBelowCaret -> ()
+            | _ -> 
+                // All other commands break the undo sequence
+                x.BreakUndoSequence "Insert after motion" 
 
         ProcessResult.OfCommandResult result
 

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -971,6 +971,12 @@ namespace Vim.UnitTest
             }
         }
 
+        public static string GetLineText(this ITextBuffer textBuffer, int lineNumber, bool includeLineBreak = false)
+        {
+            var line = textBuffer.GetLine(lineNumber);
+            return includeLineBreak ? line.GetTextIncludingLineBreak() : line.GetText();
+        }
+
         public static SnapshotSpan GetLineSpan(this ITextBuffer buffer, int lineNumber, int column, int length)
         {
             var line = buffer.GetLine(lineNumber);


### PR DESCRIPTION
Added tests for almost all of the remaining InsertCommand values. Fixed
up a bug around shifting and inserting character above / below the
caret.