### PR TITLE
Goto definition fixes

### DIFF
--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -712,19 +712,9 @@ type internal CommonOperations
             Magic = _globalSettings.Magic
             Count = VimRegexReplaceCount.One }
 
-    /// Adjust caret position for target by moving to the beginning
-    /// of the word behind the caret
-    member x.AdjustCaretForTarget () =
-        let startPoint = x.CaretLine.Start
-        let mutable point = x.CaretPoint
-        while point.Position > startPoint.Position && CharUtil.IsWordChar (point.Subtract(1).GetChar()) do
-            point <- point.Subtract(1)
-        x.MoveCaretToPoint point ViewFlags.Standard
-
     member x.GoToDefinition() =
         let before = TextViewUtil.GetCaretPoint _textView
         if _vimHost.GoToDefinition() then
-            x.AdjustCaretForTarget()
             _jumpList.Add before
             Result.Succeeded
         else
@@ -737,7 +727,6 @@ type internal CommonOperations
     member x.GoToLocalDeclaration() = 
         let caretPoint = x.CaretPoint
         if _vimHost.GoToLocalDeclaration _textView x.WordUnderCursorOrEmpty then
-            x.AdjustCaretForTarget()
             _jumpList.Add caretPoint
         else
             _vimHost.Beep()
@@ -745,7 +734,6 @@ type internal CommonOperations
     member x.GoToGlobalDeclaration () = 
         let caretPoint = x.CaretPoint
         if _vimHost.GoToGlobalDeclaration _textView x.WordUnderCursorOrEmpty then 
-            x.AdjustCaretForTarget()
             _jumpList.Add caretPoint
         else
             _vimHost.Beep()

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -712,9 +712,19 @@ type internal CommonOperations
             Magic = _globalSettings.Magic
             Count = VimRegexReplaceCount.One }
 
+    /// Adjust caret position for target by moving to the beginning
+    /// of the word behind the caret
+    member x.AdjustCaretForTarget () =
+        let startPoint = x.CaretLine.Start
+        let mutable point = x.CaretPoint
+        while point.Position > startPoint.Position && CharUtil.IsWordChar (point.Subtract(1).GetChar()) do
+            point <- point.Subtract(1)
+        x.MoveCaretToPoint point ViewFlags.Standard
+
     member x.GoToDefinition() =
         let before = TextViewUtil.GetCaretPoint _textView
         if _vimHost.GoToDefinition() then
+            x.AdjustCaretForTarget()
             _jumpList.Add before
             Result.Succeeded
         else
@@ -727,6 +737,7 @@ type internal CommonOperations
     member x.GoToLocalDeclaration() = 
         let caretPoint = x.CaretPoint
         if _vimHost.GoToLocalDeclaration _textView x.WordUnderCursorOrEmpty then
+            x.AdjustCaretForTarget()
             _jumpList.Add caretPoint
         else
             _vimHost.Beep()
@@ -734,6 +745,7 @@ type internal CommonOperations
     member x.GoToGlobalDeclaration () = 
         let caretPoint = x.CaretPoint
         if _vimHost.GoToGlobalDeclaration _textView x.WordUnderCursorOrEmpty then 
+            x.AdjustCaretForTarget()
             _jumpList.Add caretPoint
         else
             _vimHost.Beep()

--- a/Src/VsVimShared/ICommandTarget.cs
+++ b/Src/VsVimShared/ICommandTarget.cs
@@ -29,7 +29,7 @@ namespace Vim.VisualStudio
     {
         CommandStatus QueryStatus(EditCommand editCommand);
 
-        bool Exec(EditCommand editCommand, out Func<Func<int>, int> wrapper);
+        bool Exec(EditCommand editCommand, out Action preAction, out Action postAction);
     }
 
     internal interface ICommandTargetFactory

--- a/Src/VsVimShared/ICommandTarget.cs
+++ b/Src/VsVimShared/ICommandTarget.cs
@@ -29,7 +29,7 @@ namespace Vim.VisualStudio
     {
         CommandStatus QueryStatus(EditCommand editCommand);
 
-        bool Exec(EditCommand editCommand, out Action action);
+        bool Exec(EditCommand editCommand, out Func<Func<int>, int> wrapper);
     }
 
     internal interface ICommandTargetFactory

--- a/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
+++ b/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
@@ -251,7 +251,8 @@ namespace Vim.VisualStudio.Implementation.Misc
                             // Record which buffers have pre-existing selections.
                             var selected = _textManager
                                 .GetDocumentTextViews(DocumentLoad.RespectLazy)
-                                .Where(x => !x.Selection.IsEmpty).ToList();
+                                .Where(x => !x.Selection.IsEmpty)
+                                .ToList();
 
                             // Perform the action.
                             var result = action();

--- a/Src/VsVimShared/Implementation/ReSharper/ReSharperKeyUtil.cs
+++ b/Src/VsVimShared/Implementation/ReSharper/ReSharperKeyUtil.cs
@@ -49,9 +49,10 @@ namespace Vim.VisualStudio.Implementation.ReSharper
             base.PreviewKeyUp(args);
         }
 
-        private bool Exec(EditCommand editCommand, out Func<Func<int>, int> wrapper)
+        private bool Exec(EditCommand editCommand, out Action preAction, out Action postAction)
         {
-            wrapper = null;
+            preAction = null;
+            postAction = null;
             return false;
         }
 
@@ -145,9 +146,9 @@ namespace Vim.VisualStudio.Implementation.ReSharper
             return QueryStatus(editCommand);
         }
 
-        bool ICommandTarget.Exec(EditCommand editCommand, out Func<Func<int>, int> wrapper)
+        bool ICommandTarget.Exec(EditCommand editCommand, out Action preAction, out Action postAction)
         {
-            return Exec(editCommand, out wrapper);
+            return Exec(editCommand, out preAction, out postAction);
         }
 
         #endregion

--- a/Src/VsVimShared/Implementation/ReSharper/ReSharperKeyUtil.cs
+++ b/Src/VsVimShared/Implementation/ReSharper/ReSharperKeyUtil.cs
@@ -49,9 +49,9 @@ namespace Vim.VisualStudio.Implementation.ReSharper
             base.PreviewKeyUp(args);
         }
 
-        private bool Exec(EditCommand editCommand, out Action action)
+        private bool Exec(EditCommand editCommand, out Func<Func<int>, int> wrapper)
         {
-            action = null;
+            wrapper = null;
             return false;
         }
 
@@ -145,9 +145,9 @@ namespace Vim.VisualStudio.Implementation.ReSharper
             return QueryStatus(editCommand);
         }
 
-        bool ICommandTarget.Exec(EditCommand editCommand, out Action action)
+        bool ICommandTarget.Exec(EditCommand editCommand, out Func<Func<int>, int> wrapper)
         {
-            return Exec(editCommand, out action);
+            return Exec(editCommand, out wrapper);
         }
 
         #endregion

--- a/Src/VsVimShared/OleCommandUtil.cs
+++ b/Src/VsVimShared/OleCommandUtil.cs
@@ -18,7 +18,7 @@ namespace Vim.VisualStudio
         /// <summary>
         /// The command that Ctrl-F12 is bound to in VS2017 for C# and perhaps other language services
         /// </summary>
-        internal static readonly CommandId RosylynGotoDeclarationCommand = new CommandId(new Guid("{b61e1a20-8c13-49a9-a727-a0ec091647dd}"), 512);
+        internal static readonly CommandId RoslynGotoDeclarationCommand = new CommandId(new Guid("{b61e1a20-8c13-49a9-a727-a0ec091647dd}"), 512);
 
         internal static bool TryConvert(Guid commandGroup, uint commandId, IntPtr pVariableIn, VimKeyModifiers modifiers, out EditCommand command)
         {
@@ -61,7 +61,7 @@ namespace Vim.VisualStudio
                 return TryConvert((VSConstants.VSStd2KCmdID)commandId, variantIn, out keyInput, out kind, out isRawText);
             }
 
-            if (commandGroup == RosylynGotoDeclarationCommand.Group && commandId == RosylynGotoDeclarationCommand.Id)
+            if (commandGroup == RoslynGotoDeclarationCommand.Group && commandId == RoslynGotoDeclarationCommand.Id)
             {
                 keyInput = KeyInput.DefaultValue;
                 kind = EditCommandKind.GoToDefinition;

--- a/Src/VsVimShared/OleCommandUtil.cs
+++ b/Src/VsVimShared/OleCommandUtil.cs
@@ -15,6 +15,11 @@ namespace Vim.VisualStudio
         /// </summary>
         internal static readonly CommandId HiddenCommand = new CommandId(new Guid("{5D7E7F65-A63F-46EE-84F1-990B2CAB23F9}"), 6144);
 
+        /// <summary>
+        /// The command that Ctrl-F12 is bound to in VS2017 for C# and perhaps other language services
+        /// </summary>
+        internal static readonly CommandId RosylynGotoDeclarationCommand = new CommandId(new Guid("{b61e1a20-8c13-49a9-a727-a0ec091647dd}"), 512);
+
         internal static bool TryConvert(Guid commandGroup, uint commandId, IntPtr pVariableIn, VimKeyModifiers modifiers, out EditCommand command)
         {
             if (!TryConvert(commandGroup, commandId, pVariableIn, out KeyInput keyInput, out EditCommandKind kind, out bool isRawText))
@@ -54,6 +59,14 @@ namespace Vim.VisualStudio
             if (VSConstants.VSStd2K == commandGroup)
             {
                 return TryConvert((VSConstants.VSStd2KCmdID)commandId, variantIn, out keyInput, out kind, out isRawText);
+            }
+
+            if (commandGroup == RosylynGotoDeclarationCommand.Group && commandId == RosylynGotoDeclarationCommand.Id)
+            {
+                keyInput = KeyInput.DefaultValue;
+                kind = EditCommandKind.GoToDefinition;
+                isRawText = false;
+                return true;
             }
 
             if (commandGroup == HiddenCommand.Group && commandId == HiddenCommand.Id)

--- a/Src/VsVimShared/OleCommandUtil.cs
+++ b/Src/VsVimShared/OleCommandUtil.cs
@@ -416,7 +416,7 @@ namespace Vim.VisualStudio
             switch (editCommand.EditCommandKind)
             {
                 case EditCommandKind.GoToDefinition:
-                    oleCommandData = new OleCommandData(VSConstants.VSStd97CmdID.GotoDecl);
+                    oleCommandData = new OleCommandData(VSConstants.VSStd97CmdID.GotoDefn);
                     return true;
                 case EditCommandKind.Paste:
                     oleCommandData = new OleCommandData(VSConstants.VSStd2KCmdID.PASTE);

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -320,47 +320,16 @@ namespace Vim.VisualStudio
             return SafeExecuteCommand(textView, CommandNameGoToDefinition);
         }
 
-        // Certain language services, VB.Net for example, will select the word after
-        // the go to definition is implemented.  Need to clear that out to prevent the
-        // go to definition from switching us to Visual Mode
-        // 
-        // This selection often occurs in another document but that document won't be 
-        // active when we get back here.  Instead just clear all of the new selections
         private bool GoToDefinitionCore(ITextView textView, string target)
         {
-            // Record which text views have pre-existing selections.
-            var selected = _textManager
-                .GetDocumentTextViews(DocumentLoad.RespectLazy)
-                .Where(x => !x.Selection.IsEmpty).ToList();
-
-            // Go to the definition.
-            bool result;
             if (textView.TextBuffer.ContentType.IsCPlusPlus())
             {
-                result = GoToDefinitionCPlusPlus(textView, target);
+                return GoToDefinitionCPlusPlus(textView, target);
             }
             else
             {
-                result = SafeExecuteCommand(textView, CommandNameGoToDefinition);
+                return SafeExecuteCommand(textView, CommandNameGoToDefinition);
             }
-
-            // If the action succeeded, clear any new selections.
-            if (result)
-            {
-                _textManager
-                    .GetDocumentTextViews(DocumentLoad.RespectLazy)
-                    .Where(x => !x.Selection.IsEmpty && !selected.Contains(x))
-                    .ForEach(x =>
-                    {
-                        // Move the caret to the beginning of the selection.
-                        var startPoint = x.Selection.Start;
-                        x.Selection.Clear();
-                        x.Caret.MoveTo(startPoint);
-                    });
-            }
-
-            // Return the action's result.
-            return result;
         }
 
         /// <summary>

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -344,23 +344,23 @@ namespace Vim.VisualStudio
                 result = SafeExecuteCommand(textView, CommandNameGoToDefinition);
             }
 
-            if (!result)
+            // If the action succeeded, clear any new selections.
+            if (result)
             {
-                return false;
+                _textManager
+                    .GetDocumentTextViews(DocumentLoad.RespectLazy)
+                    .Where(x => !x.Selection.IsEmpty && !selected.Contains(x))
+                    .ForEach(x =>
+                    {
+                        // Move the caret to the beginning of the selection.
+                        var startPoint = x.Selection.Start;
+                        x.Selection.Clear();
+                        x.Caret.MoveTo(startPoint);
+                    });
             }
 
-            // Clear any new selections.
-            _textManager
-                .GetDocumentTextViews(DocumentLoad.RespectLazy)
-                .Where(x => !x.Selection.IsEmpty && !selected.Contains(x))
-                .ForEach(x =>
-                {
-                    var startPoint = x.Selection.Start;
-                    x.Selection.Clear();
-                    x.Caret.MoveTo(startPoint);
-                });
-
-            return true;
+            // Return the action's result.
+            return result;
         }
 
         /// <summary>

--- a/Test/VsVimSharedTest/VsCommandTargetTest.cs
+++ b/Test/VsVimSharedTest/VsCommandTargetTest.cs
@@ -540,7 +540,7 @@ namespace Vim.VisualStudio.UnitTest
             public void GoToDefinition()
             {
                 var editCommand = CreateEditCommand(EditCommandKind.GoToDefinition);
-                Assert.False(_targetRaw.Exec(editCommand, out Func<Func<int>, int> wrapper));
+                Assert.False(_targetRaw.Exec(editCommand, out Action preAction, out Action postAction));
             }
         }
 

--- a/Test/VsVimSharedTest/VsCommandTargetTest.cs
+++ b/Test/VsVimSharedTest/VsCommandTargetTest.cs
@@ -425,12 +425,29 @@ namespace Vim.VisualStudio.UnitTest
             [WpfFact]
             public void GoToDefinitionShouldClearSelection()
             {
-                _textBuffer.SetText("dog", "cat");
-                _textView.Selection.Select(_textBuffer.GetLineSpan(0, 3));
+                _textBuffer.SetText("dog", "cat", "bear");
+                _textView.MoveCaretToLine(0);
+
+                // Return our text view in the list of text views to check for new selections.
                 _textManager.Setup(x => x.GetDocumentTextViews(DocumentLoad.RespectLazy)).Returns(new[] { _textView });
-                _nextTarget.SetupExecAll();
+
+                // Set up a command target to select text in the text buffer.
+                var commandGroup = VSConstants.GUID_VSStandardCommandSet97;
+                _nextTarget.Setup(x => x.Exec(
+                    ref commandGroup,
+                    It.IsAny<uint>(),
+                    It.IsAny<uint>(),
+                    It.IsAny<IntPtr>(),
+                    It.IsAny<IntPtr>())).Returns(() =>
+                    {
+                        _textView.Selection.Select(_textBuffer.GetLineSpan(1, 3));
+                        return VSConstants.S_OK;
+                    });
+
+                Assert.Equal(_textView.GetLine(0).Start, _textView.GetCaretPoint());
                 RunExec(CreateEditCommand(EditCommandKind.GoToDefinition));
                 Assert.True(_textView.Selection.IsEmpty);
+                Assert.Equal(_textView.GetLine(1).Start, _textView.GetCaretPoint());
             }
 
             /// <summary>

--- a/Test/VsVimSharedTest/VsCommandTargetTest.cs
+++ b/Test/VsVimSharedTest/VsCommandTargetTest.cs
@@ -523,7 +523,7 @@ namespace Vim.VisualStudio.UnitTest
             public void GoToDefinition()
             {
                 var editCommand = CreateEditCommand(EditCommandKind.GoToDefinition);
-                Assert.False(_targetRaw.Exec(editCommand, out Action action));
+                Assert.False(_targetRaw.Exec(editCommand, out Func<Func<int>, int> wrapper));
             }
         }
 


### PR DESCRIPTION
Changes:

- Fix clearing selection after F12 and `<C-,>` to only clear new selections
- Remove duplicate selection clearing for `<C-]>`
- When going to a definition, place the cursor at the start of the identifier
- Also clear selection for Ctrl-F12 with VS2017 (e.g. C# language service)

Fixes:

- Fixes #2131
