### PR TITLE
Insert endofline test fixup

### DIFF
--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -2973,7 +2973,7 @@ namespace Vim.UnitTest
                 Create("dog", "");
                 _textView.MoveCaretToLine(1);
                 _vimBuffer.ProcessNotation("il<C-y><C-y><Esc>");
-                Assert.Equal(new[] { "dog", "log" }, _textBuffer.GetLines());
+                Assert.Equal(new[] { "dog", "log", "" }, _textBuffer.GetLines());
                 _vimBuffer.ProcessNotation("u");
                 Assert.Equal(new[] { "dog", "" }, _textBuffer.GetLines());
             }


### PR DESCRIPTION
- Adapt Undo_InsertCharacterAboveCaret test for new 'endofline' management

Any test now obeys the local `endofline` setting. From a practical point of view most tests don't notice any difference because they either have a final newline, e.g:

```c#
    Create("cat", "dog", "");
```

or they don't:

```c#
    Create("cat", "dog");
```
and they stay that way for the rest of the test.

When you create a test with a final new, `endofline` with be set. If the test then inserts text onto the phantom line, the editor with add a new final new line.

That's what happened with `Undo_InsertCharacterAboveCaret`.