### PR TITLE
Edit alternate file and global marks

### DIFF
--- a/Src/VimApp/VimAppHost.cs
+++ b/Src/VimApp/VimAppHost.cs
@@ -10,6 +10,7 @@ using System.Windows.Input;
 using Microsoft.VisualStudio.Utilities;
 using Vim.UI.Wpf;
 using System.Windows.Threading;
+using System.Collections.Generic;
 
 namespace VimApp
 {
@@ -24,6 +25,7 @@ namespace VimApp
         private readonly IFileSystem _fileSystem;
         private readonly IDirectoryUtil _directoryUtil;
         private readonly IContentTypeRegistryService _contentTypeRegistryService;
+        private readonly Dictionary<ITextBuffer, string> _bufferMap;
         private IVimWindowManager _vimWindowManager;
         private IVim _vim;
 
@@ -61,6 +63,7 @@ namespace VimApp
             _contentTypeRegistryService = contentTypeRegistryService;
             _fileSystem = fileSystem;
             _directoryUtil = directoryUtil;
+            _bufferMap = new Dictionary<ITextBuffer, string>();
         }
 
         public override void VimCreated(IVim vim)
@@ -84,9 +87,9 @@ namespace VimApp
 
         }
 
-        public override string GetName(ITextBuffer value)
+        public override string GetName(ITextBuffer textBuffer)
         {
-            return "";
+            return _bufferMap.TryGetValue(textBuffer, out string name) ? name : "";
         }
 
         public override int GetTabIndex(ITextView textView)
@@ -144,6 +147,8 @@ namespace VimApp
                         control.Focus();
                     }),
                     DispatcherPriority.ApplicationIdle);
+
+                _bufferMap.Add(createdTextView.TextBuffer, filePath);
 
                 return true;
             }

--- a/Src/VimApp/VimAppHost.cs
+++ b/Src/VimApp/VimAppHost.cs
@@ -277,6 +277,8 @@ namespace VimApp
                         Dispatcher.CurrentDispatcher.BeginInvoke((Action)(() =>
                             {
                                 var textView = vimViewInfo.TextViewHost.TextView;
+                                textView.Caret.MoveTo(point);
+                                textView.Caret.EnsureVisible();
                                 Keyboard.Focus(textView.VisualElement);
                             }),
                             DispatcherPriority.ApplicationIdle);

--- a/Src/VimApp/VimAppHost.cs
+++ b/Src/VimApp/VimAppHost.cs
@@ -223,6 +223,28 @@ namespace VimApp
 
         public override bool NavigateTo(VirtualSnapshotPoint point)
         {
+            var textBuffer = point.Position.Snapshot.TextBuffer;
+            foreach (var vimWindow in _vimWindowManager.VimWindowList)
+            {
+                foreach (var vimViewInfo in vimWindow.VimViewInfoList)
+                {
+                    if (vimViewInfo.TextView.TextBuffer == textBuffer)
+                    {
+                        Dispatcher.CurrentDispatcher.BeginInvoke((Action)(() =>
+                            {
+                                vimWindow.TabItem.IsSelected = true;
+                            }),
+                            DispatcherPriority.ApplicationIdle);
+                        Dispatcher.CurrentDispatcher.BeginInvoke((Action)(() =>
+                            {
+                                var textView = vimViewInfo.TextViewHost.TextView;
+                                Keyboard.Focus(textView.VisualElement);
+                            }),
+                            DispatcherPriority.ApplicationIdle);
+                        return true;
+                    }
+                }
+            }
             return false;
         }
 

--- a/Src/VimApp/VimAppHost.cs
+++ b/Src/VimApp/VimAppHost.cs
@@ -11,6 +11,8 @@ using Microsoft.VisualStudio.Utilities;
 using Vim.UI.Wpf;
 using System.Windows.Threading;
 using System.Collections.Generic;
+using Microsoft.FSharp.Core;
+using Vim.Extensions;
 
 namespace VimApp
 {
@@ -198,7 +200,7 @@ namespace VimApp
             }
         }
 
-        public override bool LoadFileIntoNewWindow(string filePath, int line, int column)
+        public override bool LoadFileIntoNewWindow(string filePath, FSharpOption<int> line, FSharpOption<int> column)
         {
             foreach (var pair in _viewMap)
             {
@@ -216,17 +218,17 @@ namespace VimApp
                 var wpfTextView = MainWindow.CreateTextView(textDocument.TextBuffer);
                 MainWindow.AddNewTab(System.IO.Path.GetFileName(filePath), wpfTextView);
 
-                if (line != -1)
+                if (line.IsSome())
                 {
                     // Move the caret to its initial position.
-                    if (column != -1)
+                    if (column.IsSome())
                     {
-                        wpfTextView.MoveCaretToLine(line, column);
+                        wpfTextView.MoveCaretToLine(line.Value, column.Value);
                     }
                     else
                     {
                         // Default column implies moving to the first non-blank.
-                        wpfTextView.MoveCaretToLine(line);
+                        wpfTextView.MoveCaretToLine(line.Value);
                         var editorOperations = EditorOperationsFactoryService.GetEditorOperations(wpfTextView);
                         editorOperations.MoveToStartOfLineAfterWhiteSpace(false);
                     }

--- a/Src/VimApp/VimAppHost.cs
+++ b/Src/VimApp/VimAppHost.cs
@@ -153,6 +153,10 @@ namespace VimApp
             if (TryLoadPath(filePath, out IWpfTextView createdTextView))
             {
                 var wpfTextViewHost = MainWindow.CreateTextViewHost(createdTextView);
+                foreach (var viewInfo in vimWindow.VimViewInfoList)
+                {
+                    _viewMap.Remove(viewInfo.TextView);
+                }
                 vimWindow.Clear();
                 vimWindow.AddVimViewInfo(wpfTextViewHost);
                 Dispatcher.CurrentDispatcher.BeginInvoke(

--- a/Src/VimApp/VimAppHost.cs
+++ b/Src/VimApp/VimAppHost.cs
@@ -216,13 +216,20 @@ namespace VimApp
                 var wpfTextView = MainWindow.CreateTextView(textDocument.TextBuffer);
                 MainWindow.AddNewTab(System.IO.Path.GetFileName(filePath), wpfTextView);
 
-                // Move the caret to its initial position.
-                wpfTextView.MoveCaretToLine(line, column);
-                if (column == 0)
+                if (line != -1)
                 {
-                    // Column zero implies moving to the first non-blank.
-                    var editorOperations = EditorOperationsFactoryService.GetEditorOperations(wpfTextView);
-                    editorOperations.MoveToStartOfLineAfterWhiteSpace(false);
+                    // Move the caret to its initial position.
+                    if (column != -1)
+                    {
+                        wpfTextView.MoveCaretToLine(line, column);
+                    }
+                    else
+                    {
+                        // Default column implies moving to the first non-blank.
+                        wpfTextView.MoveCaretToLine(line);
+                        var editorOperations = EditorOperationsFactoryService.GetEditorOperations(wpfTextView);
+                        editorOperations.MoveToStartOfLineAfterWhiteSpace(false);
+                    }
                 }
 
                 // Give the focus to the new buffer.

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1457,8 +1457,8 @@ type internal CommandUtil
                 | None -> markNotSet()
                 | Some (_, name, line, column) ->
                     let vimHost = _vimBufferData.Vim.VimHost
-                    let column = if exact then column else -1
-                    vimHost.LoadFileIntoNewWindow name line column |> ignore
+                    let column = if exact then Some column else None
+                    vimHost.LoadFileIntoNewWindow name (Some line) column |> ignore
                     CommandResult.Completed ModeSwitch.NoSwitch
             | Some virtualPoint ->
                 if virtualPoint.Position.Snapshot.TextBuffer = _textBuffer then

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1455,10 +1455,12 @@ type internal CommandUtil
                 // mark, but the buffer has been unloaded.
                 match markMap.GetMarkInfo mark _vimBufferData with
                 | None -> markNotSet()
-                | Some (_, name, line, column) ->
+                | Some markInfo ->
                     let vimHost = _vimBufferData.Vim.VimHost
-                    let column = if exact then Some column else None
-                    vimHost.LoadFileIntoNewWindow name (Some line) column |> ignore
+                    let name = markInfo.Name
+                    let line = Some markInfo.Line
+                    let column = if exact then Some markInfo.Column else None
+                    vimHost.LoadFileIntoNewWindow name line column |> ignore
                     CommandResult.Completed ModeSwitch.NoSwitch
             | Some virtualPoint ->
                 if virtualPoint.Position.Snapshot.TextBuffer = _textBuffer then

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1460,8 +1460,11 @@ type internal CommandUtil
                     let name = markInfo.Name
                     let line = Some markInfo.Line
                     let column = if exact then Some markInfo.Column else None
-                    vimHost.LoadFileIntoNewWindow name line column |> ignore
-                    CommandResult.Completed ModeSwitch.NoSwitch
+                    if vimHost.LoadFileIntoNewWindow name line column then
+                        CommandResult.Completed ModeSwitch.NoSwitch
+                    else
+                        _statusUtil.OnError (Resources.NormalMode_CantFindFile name)
+                        CommandResult.Error
             | Some virtualPoint ->
                 if virtualPoint.Position.Snapshot.TextBuffer = _textBuffer then
                     jumpLocal virtualPoint

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1182,7 +1182,7 @@ type internal CommandUtil
     /// GoTo the ITextView in the specified direction
     member x.GoToRecentView count =
         let vim = _vimBufferData.Vim
-        match vim.TryGetRecentBuffer 1 with
+        match vim.TryGetRecentBuffer count with
         | None -> ()
         | Some vimBuffer ->
             let textView = vimBuffer.VimBufferData.TextView

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1425,7 +1425,7 @@ type internal CommandUtil
                 if not _globalSettings.IsVirtualEditOneMore
                     && not (SnapshotPointUtil.IsStartOfLine point)
                     && SnapshotPointUtil.IsInsideLineBreak point then
-                    SnapshotPointUtil.SubtractOne point
+                    SnapshotPointUtil.GetPreviousCharacterSpanWithWrap point
                 else
                     point
             else

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1179,6 +1179,16 @@ type internal CommandUtil
         _vimHost.GoToWindow _textView count direction
         CommandResult.Completed ModeSwitch.NoSwitch
 
+    /// GoTo the ITextView in the specified direction
+    member x.GoToRecentView count =
+        let vim = _vimBufferData.Vim
+        match vim.TryGetRecentBuffer 1 with
+        | None -> ()
+        | Some vimBuffer ->
+            let textView = vimBuffer.VimBufferData.TextView
+            _vimHost.NavigateTo(textView.Caret.Position.VirtualBufferPosition) |> ignore
+        CommandResult.Completed ModeSwitch.NoSwitch
+
     /// Join 'count' lines in the buffer
     member x.JoinLines kind count =
 
@@ -2481,6 +2491,7 @@ type internal CommandUtil
         | NormalCommand.GoToLocalDeclaration -> x.GoToLocalDeclaration()
         | NormalCommand.GoToNextTab path -> x.GoToNextTab path data.Count
         | NormalCommand.GoToWindow direction -> x.GoToWindow direction count
+        | NormalCommand.GoToRecentView -> x.GoToRecentView count
         | NormalCommand.InsertAfterCaret -> x.InsertAfterCaret count
         | NormalCommand.InsertBeforeCaret -> x.InsertBeforeCaret count
         | NormalCommand.InsertAtEndOfLine -> x.InsertAtEndOfLine count

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -799,7 +799,7 @@ type internal CommonOperations
 
     /// No need to check for dirty since we are opening a new window
     member x.GoToFileInNewWindow name =
-        if not (_vimHost.LoadFileIntoNewWindow name 0 0) then
+        if not (_vimHost.LoadFileIntoNewWindow name 0 -1) then
             _statusUtil.OnError (Resources.NormalMode_CantFindFile name)
 
     member x.GoToNextTab path count = 

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -799,7 +799,7 @@ type internal CommonOperations
 
     /// No need to check for dirty since we are opening a new window
     member x.GoToFileInNewWindow name =
-        if not (_vimHost.LoadFileIntoNewWindow name) then
+        if not (_vimHost.LoadFileIntoNewWindow name 0 0) then
             _statusUtil.OnError (Resources.NormalMode_CantFindFile name)
 
     member x.GoToNextTab path count = 

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -799,7 +799,7 @@ type internal CommonOperations
 
     /// No need to check for dirty since we are opening a new window
     member x.GoToFileInNewWindow name =
-        if not (_vimHost.LoadFileIntoNewWindow name 0 -1) then
+        if not (_vimHost.LoadFileIntoNewWindow name (Some 0) None) then
             _statusUtil.OnError (Resources.NormalMode_CantFindFile name)
 
     member x.GoToNextTab path count = 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3934,6 +3934,14 @@ type HistoryList () =
             _list <- value :: list
             _totalCount <- _totalCount + 1
 
+    /// Remove an item from the history list
+    member x.Remove value = 
+        if not (StringUtil.IsNullOrEmpty value) then
+            _list <-
+                _list
+                |> Seq.filter (fun x -> not (StringUtil.IsEqual x value))
+                |> List.ofSeq
+
     /// Reset the list back to it's original state
     member x.Reset () = 
         _list <- List.empty

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4516,13 +4516,16 @@ and IMarkMap =
     abstract GetGlobalMark: letter: Letter -> VirtualSnapshotPoint option
 
     /// Set the global mark to the given line and column in the provided IVimTextBuffer
-    abstract SetGlobalMark: letter: Letter -> vimtextBuffer: IVimTextBuffer -> line: int -> column: int -> unit
+    abstract SetGlobalMark: letter: Letter -> vimTextBuffer: IVimTextBuffer -> line: int -> column: int -> unit
 
     /// Set the mark for the given char for the IVimTextBuffer
     abstract SetMark: mark: Mark -> vimBufferData: IVimBufferData -> line: int -> column: int -> bool
 
     /// Unload the buffer recording the last exited position
     abstract UnloadBuffer: vimBufferData: IVimBufferData -> name: string -> line: int -> column: int -> bool
+
+    /// Reload the marks associated with a buffer
+    abstract ReloadBuffer: vimBufferData: IVimBufferData -> name: string -> bool
 
     /// Remove the specified mark and return whether or not a mark was actually
     /// removed

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4449,6 +4449,9 @@ and IVim =
     /// creation in the IVimHost
     abstract TryGetOrCreateVimBufferForHost: textView: ITextView * [<Out>] vimBuffer: IVimBuffer byref -> bool
 
+    /// Get the nth most recent IVimBuffer
+    abstract TryGetRecentBuffer: n: int -> IVimBuffer option
+
 and BeforeSaveEventArgs
     (
         _textBuffer: ITextBuffer

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4518,8 +4518,8 @@ and IMarkMap =
     /// Set the mark for the given char for the IVimTextBuffer
     abstract SetMark: mark: Mark -> vimBufferData: IVimBufferData -> line: int -> column: int -> bool
 
-    /// Set the last exited position before the window is closed
-    abstract SetLastExitedPosition: bufferName: string -> line: int -> column: int -> bool
+    /// Unload the buffer recording the last exited position
+    abstract UnloadBuffer: vimBufferData: IVimBufferData -> line: int -> column: int -> bool
 
     /// Remove the specified mark and return whether or not a mark was actually
     /// removed

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4230,7 +4230,7 @@ type IVimHost =
     abstract LoadFileIntoExistingWindow: filePath: string -> textView: ITextView -> bool
 
     /// Loads the new file into a new existing window
-    abstract LoadFileIntoNewWindow: filePath: string -> bool
+    abstract LoadFileIntoNewWindow: filePath: string -> line: int -> column: int -> bool
 
     /// Run the host specific make operation
     abstract Make: jumpToFirstError: bool -> arguments: string -> unit

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4509,6 +4509,9 @@ and IMarkMap =
     /// Get the mark for the given char for the IVimTextBuffer
     abstract GetMark: mark: Mark -> vimBufferData: IVimBufferData -> VirtualSnapshotPoint option
 
+    /// Get the mark info for the given char for the IVimTextBuffer
+    abstract GetMarkInfo: mark: Mark -> vimBufferData: IVimBufferData -> (char * string * int * int) option
+
     /// Get the current value of the specified global mark
     abstract GetGlobalMark: letter: Letter -> VirtualSnapshotPoint option
 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4023,6 +4023,9 @@ type IVimData =
     /// The history of the: command list
     abstract CommandHistory: HistoryList with get, set
 
+    /// The file history list
+    abstract FileHistory: HistoryList with get, set
+
     /// This is the pattern for which all occurences should be highlighted in the visible
     /// IVimBuffer instances.  When this value is empty then no pattern should be highlighted
     abstract DisplayPattern: string

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4229,8 +4229,9 @@ type IVimHost =
     /// Loads the new file into the existing window
     abstract LoadFileIntoExistingWindow: filePath: string -> textView: ITextView -> bool
 
-    /// Loads the new file into a new existing window
-    abstract LoadFileIntoNewWindow: filePath: string -> line: int -> column: int -> bool
+    /// Loads a file into a new window, optionally moving the caret to the
+    /// first non-blank on a specific line or to a specific line and column
+    abstract LoadFileIntoNewWindow: filePath: string -> line: int option -> column: int option -> bool
 
     /// Run the host specific make operation
     abstract Make: jumpToFirstError: bool -> arguments: string -> unit

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4127,6 +4127,27 @@ type RunCommandResults
 
     member x.Error = _error
 
+/// Information associated with a mark
+type MarkInfo
+    (
+        _ident: char,
+        _name: string,
+        _line: int,
+        _column: int
+    ) =
+
+    /// The character used to identify the mark
+    member x.Ident = _ident
+
+    /// The name of the buffer the mark is in
+    member x.Name = _name
+
+    /// The line of the mark
+    member x.Line = _line
+
+    /// The column of the mark
+    member x.Column = _column
+
 type IVimHost =
 
     /// Should vim automatically start synchronization of IVimBuffer instances when they are 
@@ -4510,8 +4531,8 @@ and IMarkMap =
     /// Get the mark for the given char for the IVimTextBuffer
     abstract GetMark: mark: Mark -> vimBufferData: IVimBufferData -> VirtualSnapshotPoint option
 
-    /// Get the mark info for the given char for the IVimTextBuffer
-    abstract GetMarkInfo: mark: Mark -> vimBufferData: IVimBufferData -> (char * string * int * int) option
+    /// Get the mark info for the given mark for the IVimTextBuffer
+    abstract GetMarkInfo: mark: Mark -> vimBufferData: IVimBufferData -> MarkInfo option
 
     /// Get the current value of the specified global mark
     abstract GetGlobalMark: letter: Letter -> VirtualSnapshotPoint option

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2624,6 +2624,9 @@ type NormalCommand =
     /// Go to the window of the specified kind
     | GoToWindow of WindowKind
 
+    /// Go to the nth most recent view
+    | GoToRecentView
+
     /// Switch to insert after the caret position
     | InsertAfterCaret
 
@@ -2853,6 +2856,7 @@ type NormalCommand =
         | NormalCommand.GoToLocalDeclaration -> None
         | NormalCommand.GoToNextTab _ -> None
         | NormalCommand.GoToWindow _ -> None
+        | NormalCommand.GoToRecentView _ -> None
         | NormalCommand.InsertAfterCaret -> None
         | NormalCommand.InsertBeforeCaret -> None
         | NormalCommand.InsertAtEndOfLine -> None

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4522,7 +4522,7 @@ and IMarkMap =
     abstract SetMark: mark: Mark -> vimBufferData: IVimBufferData -> line: int -> column: int -> bool
 
     /// Unload the buffer recording the last exited position
-    abstract UnloadBuffer: vimBufferData: IVimBufferData -> line: int -> column: int -> bool
+    abstract UnloadBuffer: vimBufferData: IVimBufferData -> name: string -> line: int -> column: int -> bool
 
     /// Remove the specified mark and return whether or not a mark was actually
     /// removed

--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -485,6 +485,9 @@ and [<RequireQualifiedAccess>] LineCommand =
     ///  - The provided file to edit 
     | Edit of bool * FileOption list * CommandOption option * string
 
+    /// List recent files
+    | Files
+
     /// Fold the selected LineRange
     | Fold of LineRangeSpecifier
 

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -732,35 +732,33 @@ type VimInterpreter
         _statusUtil.OnStatusLong list
 
     /// Display the specified marks
-    member x.RunDisplayMarks (marks: Mark list) = 
-        if not (List.isEmpty marks) then
-            _statusUtil.OnError (Resources.Interpreter_OptionNotSupported "Specific marks")
-        else
-            let printMarkInfo info =
-                let ident, name, lineNum, column = info
-                sprintf " %c  %5d%5d %s" ident lineNum column name
-            let getMark (mark: Mark) = _markMap.GetMarkInfo mark _vimBufferData
+    member x.RunDisplayMarks (marks: Mark list) =
+        let printMarkInfo info =
+            let ident, name, line, column = info
+            sprintf " %c  %5d%5d %s" ident line column name
+        let getMark (mark: Mark) = _markMap.GetMarkInfo mark _vimBufferData
 
-            seq {
-                yield Mark.LastJump
-                for letter in Letter.All do
-                    yield Mark.LocalMark (LocalMark.Letter letter)
-                for letter in Letter.All do
-                    yield Mark.GlobalMark letter
-                for number in NumberMark.All do
-                    yield Mark.LocalMark (LocalMark.Number number)
-                yield Mark.LastExitedPosition
-                yield Mark.LocalMark LocalMark.LastInsertExit
-                yield Mark.LocalMark LocalMark.LastEdit
-                yield Mark.LocalMark LocalMark.LastSelectionStart
-                yield Mark.LocalMark LocalMark.LastSelectionEnd
-            }
-            |> Seq.map getMark
-            |> Seq.filter (fun option -> option.IsSome)
-            |> Seq.map (fun option -> option.Value)
-            |> Seq.map (fun info -> printMarkInfo info)
-            |> Seq.append ("mark line  col file/text" |> Seq.singleton)
-            |> _statusUtil.OnStatusLong
+        seq {
+            yield Mark.LastJump
+            for letter in Letter.All do
+                yield Mark.LocalMark (LocalMark.Letter letter)
+            for letter in Letter.All do
+                yield Mark.GlobalMark letter
+            for number in NumberMark.All do
+                yield Mark.LocalMark (LocalMark.Number number)
+            yield Mark.LastExitedPosition
+            yield Mark.LocalMark LocalMark.LastInsertExit
+            yield Mark.LocalMark LocalMark.LastEdit
+            yield Mark.LocalMark LocalMark.LastSelectionStart
+            yield Mark.LocalMark LocalMark.LastSelectionEnd
+        }
+        |> Seq.filter (fun mark -> marks.Length = 0 || List.contains mark marks)
+        |> Seq.map getMark
+        |> Seq.filter (fun option -> option.IsSome)
+        |> Seq.map (fun option -> option.Value)
+        |> Seq.map (fun info -> printMarkInfo info)
+        |> Seq.append ("mark line  col file/text" |> Seq.singleton)
+        |> _statusUtil.OnStatusLong
 
     /// Run the echo command
     member x.RunEcho expression =

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -826,6 +826,19 @@ type VimInterpreter
     member x.RunExpression expr =
         _exprInterpreter.RunExpression expr
 
+    /// Print out the applicable file history information
+    member x.RunFiles () = 
+        let output = List<string>()
+        output.Add("      # file history")
+
+        let historyList = _vimData.FileHistory
+        for i = 0 to historyList.Count - 1 do
+            let item = historyList.Items.[i]
+            let msg = sprintf "%7d %s" i item
+            output.Add(msg)
+
+        _statusUtil.OnStatusLong(output)
+
     /// Fold the specified line range
     member x.RunFold lineRange = 
 
@@ -1753,6 +1766,7 @@ type VimInterpreter
         | LineCommand.DisplayRegisters nameList -> x.RunDisplayRegisters nameList
         | LineCommand.DisplayLet variables -> x.RunDisplayLets variables
         | LineCommand.DisplayMarks marks -> x.RunDisplayMarks marks
+        | LineCommand.Files -> x.RunFiles()
         | LineCommand.Fold lineRange -> x.RunFold lineRange
         | LineCommand.Global (lineRange, pattern, matchPattern, lineCommand) -> x.RunGlobal lineRange pattern matchPattern lineCommand
         | LineCommand.Help -> x.RunHelp()

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -735,7 +735,7 @@ type VimInterpreter
     member x.RunDisplayMarks (marks: Mark list) =
         let printMarkInfo info =
             let ident, name, line, column = info
-            sprintf " %c  %5d%5d %s" ident line column name
+            sprintf " %c  %5d%5d %s" ident (line + 1) column name
         let getMark (mark: Mark) = _markMap.GetMarkInfo mark _vimBufferData
 
         seq {

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1640,7 +1640,7 @@ type VimInterpreter
 
     member x.RunTabNew filePath = 
         let filePath = filePath |> OptionUtil.getOrDefault ""
-        _vimHost.LoadFileIntoNewWindow filePath |> ignore
+        _vimHost.LoadFileIntoNewWindow filePath 0 0 |> ignore
 
     member x.RunOnly() =
         _vimHost.CloseAllOtherWindows _textView

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1640,7 +1640,7 @@ type VimInterpreter
 
     member x.RunTabNew filePath = 
         let filePath = filePath |> OptionUtil.getOrDefault ""
-        _vimHost.LoadFileIntoNewWindow filePath 0 -1 |> ignore
+        _vimHost.LoadFileIntoNewWindow filePath (Some 0) None |> ignore
 
     member x.RunOnly() =
         _vimHost.CloseAllOtherWindows _textView

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -736,7 +736,13 @@ type VimInterpreter
         let printMarkInfo info =
             let ident, name, line, column = info
             sprintf " %c  %5d%5d %s" ident (line + 1) column name
-        let getMark (mark: Mark) = _markMap.GetMarkInfo mark _vimBufferData
+        let getMark (mark: Mark) =
+            match _markMap.GetMarkInfo mark _vimBufferData with
+            | Some markInfo ->
+                (markInfo.Ident, markInfo.Name, markInfo.Line, markInfo.Column)
+                |> Some
+            | None ->
+                None
 
         seq {
             yield Mark.LastJump

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1640,7 +1640,7 @@ type VimInterpreter
 
     member x.RunTabNew filePath = 
         let filePath = filePath |> OptionUtil.getOrDefault ""
-        _vimHost.LoadFileIntoNewWindow filePath 0 0 |> ignore
+        _vimHost.LoadFileIntoNewWindow filePath 0 -1 |> ignore
 
     member x.RunOnly() =
         _vimHost.CloseAllOtherWindows _textView

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -806,6 +806,7 @@ type Parser
             | LineCommand.Else -> noRangeCommand
             | LineCommand.ElseIf _ -> noRangeCommand
             | LineCommand.Execute _ -> noRangeCommand
+            | LineCommand.Files -> noRangeCommand
             | LineCommand.Fold lineRange -> LineCommand.Fold lineRange
             | LineCommand.Function _ -> noRangeCommand
             | LineCommand.FunctionEnd _ -> noRangeCommand

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -386,7 +386,21 @@ type Parser
         if _tokenizer.IsAtEndOfLine then
             None
         else
-            x.ParseRestOfLine() |> Some
+            if _tokenizer.CurrentChar = '#' then
+                _tokenizer.MoveNextChar()
+                let n =
+                    match _tokenizer.CurrentTokenKind with
+                    | TokenKind.Number n ->
+                        _tokenizer.MoveNextToken()
+                        n
+                    | _ -> 1
+                let fileHistory = _vimData.FileHistory
+                if n >= fileHistory.Count then
+                    None
+                else
+                    Some fileHistory.Items.[n]
+            else
+                x.ParseRestOfLine() |> Some
 
     /// Move to the next line of the input.  This will move past blank lines and return true if 
     /// the result is a non-blank line which can be processed

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1876,6 +1876,10 @@ type Parser
 
         LineCommand.Yank (lineRange, registerName, count)
 
+    /// Parse out the files command
+    member x.ParseFiles() =
+        LineCommand.Files
+
     /// Parse out the fold command
     member x.ParseFold lineRange =
         LineCommand.Fold lineRange
@@ -2328,6 +2332,7 @@ type Parser
                 match name with
                 | "autocmd" -> noRange x.ParseAutoCommand
                 | "behave" -> noRange x.ParseBehave
+                | "buffers" -> noRange x.ParseFiles
                 | "call" -> x.ParseCall lineRange
                 | "cd" -> noRange x.ParseChangeDirectory
                 | "chdir" -> noRange x.ParseChangeDirectory
@@ -2351,6 +2356,7 @@ type Parser
                 | "endfunction" -> noRange x.ParseFunctionEnd
                 | "endif" -> noRange x.ParseIfEnd
                 | "exit" -> x.ParseQuitAndWrite lineRange
+                | "files" -> noRange x.ParseFiles
                 | "fold" -> x.ParseFold lineRange
                 | "function" -> noRange x.ParseFunctionStart
                 | "global" -> x.ParseGlobal lineRange
@@ -2367,6 +2373,7 @@ type Parser
                 | "lchdir" -> noRange x.ParseChangeLocalDirectory
                 | "let" -> noRange x.ParseLet
                 | "lmap"-> noRange (fun () -> x.ParseMapKeys false [KeyRemapMode.Language])
+                | "ls" -> noRange x.ParseFiles
                 | "lunmap" -> noRange (fun () -> x.ParseMapUnmap false [KeyRemapMode.Language])
                 | "lnoremap"-> noRange (fun () -> x.ParseMapKeysNoRemap false [KeyRemapMode.Language])
                 | "make" -> noRange x.ParseMake 

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1141,7 +1141,10 @@ type Parser
         let commandOption = x.ParseCommandOption()
 
         x.SkipBlanks()
-        let fileName = x.ParseRestOfLine()
+        let fileName =
+            match x.ParseRestOfLineAsFilePath() with
+            | None -> ""
+            | Some fileName -> fileName
 
         LineCommand.Edit (hasBang, fileOptionList, commandOption, fileName)
 

--- a/Src/VimCore/MarkMap.fs
+++ b/Src/VimCore/MarkMap.fs
@@ -127,7 +127,7 @@ type MarkMap(_bufferTrackingService: IBufferTrackingService) =
             let column = point.Position.Position - textLine.Start.Position
             let column = if point.IsInVirtualSpace then column + point.VirtualSpaces else column
             let name = vimBufferData.Vim.VimHost.GetName point.Position.Snapshot.TextBuffer
-            Some (mark.Char, name, line, column)
+            MarkInfo(mark.Char, name, line, column) |> Some
 
         match mark with
         | Mark.GlobalMark letter ->
@@ -135,7 +135,7 @@ type MarkMap(_bufferTrackingService: IBufferTrackingService) =
             | Some point -> getPointInfo point
             | None ->
                 match _globalUnloadedMarkMap.TryFind letter with
-                | Some (name, line, column) -> Some (mark.Char, name, line, column)
+                | Some (name, line, column) -> MarkInfo(mark.Char, name, line, column) |> Some
                 | None -> None
         |_ ->
             match x.GetMark mark vimBufferData with

--- a/Src/VimCore/MarkMap.fs
+++ b/Src/VimCore/MarkMap.fs
@@ -169,9 +169,8 @@ type MarkMap(_bufferTrackingService: IBufferTrackingService) =
             else
                 false
 
-    member x.UnloadBuffer (vimBufferData: IVimBufferData) line column =
+    member x.UnloadBuffer (vimBufferData: IVimBufferData) bufferName line column =
         let textBuffer = vimBufferData.TextBuffer
-        let bufferName = vimBufferData.Vim.VimHost.GetName textBuffer
 
         let unloadGlobalMark (letter: Letter) =
             let mark = Mark.GlobalMark letter
@@ -226,6 +225,6 @@ type MarkMap(_bufferTrackingService: IBufferTrackingService) =
         member x.GetMarkInfo mark vimBufferData = x.GetMarkInfo mark vimBufferData
         member x.SetGlobalMark letter vimBufferData line column = x.SetGlobalMark letter vimBufferData line column
         member x.SetMark mark vimBufferData line column = x.SetMark mark vimBufferData line column
-        member x.UnloadBuffer vimBufferData line column = x.UnloadBuffer vimBufferData line column
+        member x.UnloadBuffer vimBufferData name line column = x.UnloadBuffer vimBufferData name line column
         member x.RemoveGlobalMark letter = x.RemoveGlobalMark letter
         member x.Clear() = x.Clear()

--- a/Src/VimCore/MarkMap.fs
+++ b/Src/VimCore/MarkMap.fs
@@ -223,6 +223,7 @@ type MarkMap(_bufferTrackingService: IBufferTrackingService) =
         member x.GlobalMarks = x.GlobalMarks
         member x.GetGlobalMark letter = x.GetGlobalMark letter
         member x.GetMark mark vimBufferData = x.GetMark mark vimBufferData
+        member x.GetMarkInfo mark vimBufferData = x.GetMarkInfo mark vimBufferData
         member x.SetGlobalMark letter vimBufferData line column = x.SetGlobalMark letter vimBufferData line column
         member x.SetMark mark vimBufferData line column = x.SetMark mark vimBufferData line column
         member x.UnloadBuffer vimBufferData line column = x.UnloadBuffer vimBufferData line column

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -167,6 +167,7 @@ type internal NormalMode
                 yield ("==", CommandFlags.Repeatable, NormalCommand.FormatLines)
                 yield ("!!", CommandFlags.Repeatable, NormalCommand.FilterLines)
                 yield (":", CommandFlags.Special, NormalCommand.SwitchMode (ModeKind.Command, ModeArgument.None))
+                yield ("<C-^>", CommandFlags.None, NormalCommand.GoToRecentView)
             } |> Seq.map (fun (str, flags, command) -> 
                 let keyInputSet = KeyNotationUtil.StringToKeyInputSet str
                 CommandBinding.NormalBinding (keyInputSet, flags, command))

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -1380,8 +1380,15 @@ type internal MotionUtil
             _jumpList.Add x.CaretPoint
 
             let caretPoint = TextViewUtil.GetCaretPoint _textView
-            let startPoint, endPoint = SnapshotPointUtil.OrderAscending caretPoint virtualPoint.Position
-            let column = SnapshotPointUtil.GetColumn virtualPoint.Position
+            let markPoint = virtualPoint.Position
+            let markPoint =
+                if not _globalSettings.IsVirtualEditOneMore
+                    && not (SnapshotPointUtil.IsStartOfLine markPoint)
+                    && SnapshotPointUtil.IsInsideLineBreak markPoint then
+                    SnapshotPointUtil.SubtractOne markPoint
+                else
+                    markPoint
+            let startPoint, endPoint = SnapshotPointUtil.OrderAscending caretPoint markPoint
             let span = SnapshotSpan(startPoint, endPoint)
             let isForward = caretPoint = startPoint
             MotionResult.Create(span, MotionKind.CharacterWiseExclusive, isForward, motionResultFlags = MotionResultFlags.BigDelete) |> Some

--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -78,6 +78,7 @@ type internal VimData(_globalSettings: IVimGlobalSettings) as this =
     let mutable _previousCurrentDirecotry = _currentDirectory
     let mutable _lastLineCommand: LineCommand option = None
     let mutable _commandHistory = HistoryList()
+    let mutable _fileHistory = HistoryList()
     let mutable _searchHistory = HistoryList()
     let mutable _lastSubstituteData: SubstituteData option = None
     let mutable _lastSearchData = SearchData("", SearchPath.Forward)
@@ -151,6 +152,9 @@ type internal VimData(_globalSettings: IVimGlobalSettings) as this =
         member x.CommandHistory
             with get() = _commandHistory
             and set value = _commandHistory <- value
+        member x.FileHistory
+            with get() = _fileHistory
+            and set value = _fileHistory <- value
         member x.DisplayPattern = _displayPattern
         member x.SearchHistory 
             with get() = _searchHistory
@@ -921,7 +925,7 @@ type internal Vim
         if n >= _recentBufferStack.Length then
             None
         else
-            _recentBufferStack |> Seq.skip n |> Seq.head |> Option.Some
+            _recentBufferStack |> Seq.skip n |> Seq.head |> Some
 
     member x.DisableVimBuffer (vimBuffer: IVimBuffer) =
         vimBuffer.SwitchMode ModeKind.Disabled ModeArgument.None |> ignore

--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -629,8 +629,6 @@ type internal Vim
             _recentBufferStack
             |> Seq.filter (fun item -> item <> vimBuffer)
             |> List.ofSeq
-        let name = _vimHost.GetName vimBuffer.TextBuffer
-        _vimData.FileHistory.Remove name
 
     member x.OnFocus vimBuffer =
         x.RemoveRecentBuffer vimBuffer

--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -629,10 +629,14 @@ type internal Vim
             _recentBufferStack
             |> Seq.filter (fun item -> item <> vimBuffer)
             |> List.ofSeq
+        let name = _vimHost.GetName vimBuffer.TextBuffer
+        _vimData.FileHistory.Remove name
 
     member x.OnFocus vimBuffer =
         x.RemoveRecentBuffer vimBuffer
         _recentBufferStack <- vimBuffer :: _recentBufferStack
+        let name = _vimHost.GetName vimBuffer.TextBuffer
+        _vimData.FileHistory.Add name
 
     /// Create an IVimBuffer for the given ITextView and associated IVimTextBuffer and notify
     /// the IVimBufferCreationListener collection about it

--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -390,6 +390,9 @@ type internal Vim
     /// Holds the active stack of IVimBuffer instances
     let mutable _activeBufferStack: IVimBuffer list = List.empty
 
+    /// Holds the recent stack of IVimBuffer instances
+    let mutable _recentBufferStack: IVimBuffer list = List.empty
+
     /// Whether or not the vimrc file should be automatically loaded before creating the 
     /// first IVimBuffer instance
     let mutable _autoLoadVimRc = true
@@ -604,6 +607,11 @@ type internal Vim
                 | [] -> [] )
         |> eventBag.Add
 
+        // Subscribe to text view focus events.
+        vimBuffer.TextView.GotAggregateFocus
+        |> Observable.subscribe (fun _ -> x.OnFocus vimBuffer)
+        |> eventBag.Add
+
         let vimInterpreter = _interpreterFactory.CreateVimInterpreter vimBuffer _fileSystem
         _vimBufferMap.Add(textView, (vimBuffer, vimInterpreter, eventBag))
 
@@ -611,6 +619,16 @@ type internal Vim
             _editorToSettingSynchronizer.StartSynchronizing vimBuffer SettingSyncSource.Vim
 
         vimBuffer
+
+    member x.RemoveRecentBuffer vimBuffer =
+        _recentBufferStack <-
+            _recentBufferStack
+            |> Seq.filter (fun item -> item <> vimBuffer)
+            |> List.ofSeq
+
+    member x.OnFocus vimBuffer =
+        x.RemoveRecentBuffer vimBuffer
+        _recentBufferStack <- vimBuffer :: _recentBufferStack
 
     /// Create an IVimBuffer for the given ITextView and associated IVimTextBuffer and notify
     /// the IVimBufferCreationListener collection about it
@@ -848,7 +866,8 @@ type internal Vim
     member x.RemoveVimBuffer textView = 
         let found, tuple = _vimBufferMap.TryGetValue(textView)
         if found then 
-            let _, _, bag = tuple
+            let vimBuffer,  _ , bag = tuple
+            x.RemoveRecentBuffer vimBuffer
             bag.DisposeAll()
         _vimBufferMap.Remove textView
 
@@ -896,6 +915,13 @@ type internal Vim
             true
         | None ->
             false
+
+    /// Get the nth most recent vim buffer
+    member x.TryGetRecentBuffer (n: int) =
+        if n >= _recentBufferStack.Length then
+            None
+        else
+            _recentBufferStack |> Seq.skip n |> Seq.head |> Option.Some
 
     member x.DisableVimBuffer (vimBuffer: IVimBuffer) =
         vimBuffer.SwitchMode ModeKind.Disabled ModeArgument.None |> ignore
@@ -962,5 +988,4 @@ type internal Vim
         member x.TryGetOrCreateVimBufferForHost(textView, vimBuffer) = x.TryGetOrCreateVimBufferForHost(textView, &vimBuffer)
         member x.TryGetVimBuffer(textView, vimBuffer) = x.TryGetVimBuffer(textView, &vimBuffer)
         member x.TryGetVimTextBuffer(textBuffer, vimBuffer) = x.TryGetVimTextBuffer(textBuffer, &vimBuffer)
-
-
+        member x.TryGetRecentBuffer n = x.TryGetRecentBuffer n

--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -205,6 +205,7 @@ type internal VimBuffer
         |> _bag.Add
 
         _vim.MarkMap.SetMark Mark.LastJump _vimBufferData 0 0 |> ignore
+        _vim.MarkMap.ReloadBuffer _vimBufferData _bufferName |> ignore
 
         // Subscribe to local settings changed events.
         _vimTextBuffer.LocalSettings.SettingChanged

--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -192,6 +192,7 @@ type internal VimBuffer
     let _statusMessageEvent = StandardEvent<StringEventArgs>()
     let _closingEvent = StandardEvent()
     let _closedEvent = StandardEvent()
+    let _bufferName = _vim.VimHost.GetName _vimBufferData.TextBuffer
 
     do 
         // Adjust local settings.
@@ -354,7 +355,7 @@ type internal VimBuffer
             invalidOp Resources.VimBuffer_AlreadyClosed
 
         let line, column = SnapshotPointUtil.GetLineColumn (TextViewUtil.GetCaretPoint _textView)
-        _vim.MarkMap.UnloadBuffer _vimBufferData line column |> ignore
+        _vim.MarkMap.UnloadBuffer _vimBufferData _bufferName line column |> ignore
 
         // Run the closing event in a separate try / catch.  Don't want anyone to be able
         // to disrupt the necessary actions like removing a buffer from the global list

--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -192,7 +192,6 @@ type internal VimBuffer
     let _statusMessageEvent = StandardEvent<StringEventArgs>()
     let _closingEvent = StandardEvent()
     let _closedEvent = StandardEvent()
-    let bufferName = _vim.VimHost.GetName _vimBufferData.TextBuffer
 
     do 
         // Adjust local settings.
@@ -355,7 +354,7 @@ type internal VimBuffer
             invalidOp Resources.VimBuffer_AlreadyClosed
 
         let line, column = SnapshotPointUtil.GetLineColumn (TextViewUtil.GetCaretPoint _textView)
-        _vim.MarkMap.SetLastExitedPosition bufferName line column |> ignore
+        _vim.MarkMap.UnloadBuffer _vimBufferData line column |> ignore
 
         // Run the closing event in a separate try / catch.  Don't want anyone to be able
         // to disrupt the necessary actions like removing a buffer from the global list

--- a/Src/VimTestUtils/Mock/MockVimHost.cs
+++ b/Src/VimTestUtils/Mock/MockVimHost.cs
@@ -44,7 +44,7 @@ namespace Vim.UnitTest.Mock
         public Func<ITextBuffer, bool> IsDirtyFunc { get; set; }
         public Func<string, string, string, IVimData, RunCommandResults> RunCommandFunc { get; set; }
         public Action<ITextView, string, string> RunHostCommandFunc { get; set; }
-        public Func<string, int, int, bool> LoadIntoNewWindowFunc { get; set; }
+        public Func<string, FSharpOption<int>, FSharpOption<int>, bool> LoadIntoNewWindowFunc { get; set; }
         public Action<QuickFix, int, bool> RunQuickFixFunc { get; set; }
         public Action OpenQuickFixWindowFunc { get; set; }
         public Func<string, string, bool> RunSaveTextAs { get; set; }
@@ -260,7 +260,7 @@ namespace Vim.UnitTest.Mock
             throw new NotImplementedException();
         }
 
-        bool IVimHost.LoadFileIntoNewWindow(string filePath, int line, int column)
+        bool IVimHost.LoadFileIntoNewWindow(string filePath, FSharpOption<int> line, FSharpOption<int> column)
         {
             return LoadIntoNewWindowFunc(filePath, line, column);
         }

--- a/Src/VimTestUtils/Mock/MockVimHost.cs
+++ b/Src/VimTestUtils/Mock/MockVimHost.cs
@@ -44,6 +44,7 @@ namespace Vim.UnitTest.Mock
         public Func<ITextBuffer, bool> IsDirtyFunc { get; set; }
         public Func<string, string, string, IVimData, RunCommandResults> RunCommandFunc { get; set; }
         public Action<ITextView, string, string> RunHostCommandFunc { get; set; }
+        public Func<string, int, int, bool> LoadIntoNewWindowFunc { get; set; }
         public Action<QuickFix, int, bool> RunQuickFixFunc { get; set; }
         public Action OpenQuickFixWindowFunc { get; set; }
         public Func<string, string, bool> RunSaveTextAs { get; set; }
@@ -97,6 +98,7 @@ namespace Vim.UnitTest.Mock
             CreateHiddenTextViewFunc = delegate { throw new NotImplementedException(); };
             RunCommandFunc = delegate { throw new NotImplementedException(); };
             RunHostCommandFunc = delegate { throw new NotImplementedException(); };
+            LoadIntoNewWindowFunc = delegate { throw new NotImplementedException(); };
             RunQuickFixFunc = delegate { throw new NotImplementedException(); };
             OpenQuickFixWindowFunc = delegate { throw new NotImplementedException(); };
             RunSaveTextAs = delegate { throw new NotImplementedException(); };
@@ -260,7 +262,7 @@ namespace Vim.UnitTest.Mock
 
         bool IVimHost.LoadFileIntoNewWindow(string filePath, int line, int column)
         {
-            throw new NotImplementedException();
+            return LoadIntoNewWindowFunc(filePath, line, column);
         }
 
         FSharpOption<ITextView> IVimHost.GetFocusedTextView()

--- a/Src/VimTestUtils/Mock/MockVimHost.cs
+++ b/Src/VimTestUtils/Mock/MockVimHost.cs
@@ -258,7 +258,7 @@ namespace Vim.UnitTest.Mock
             throw new NotImplementedException();
         }
 
-        bool IVimHost.LoadFileIntoNewWindow(string filePath)
+        bool IVimHost.LoadFileIntoNewWindow(string filePath, int line, int column)
         {
             throw new NotImplementedException();
         }

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -41,6 +41,11 @@ namespace Vim.UI.Wpf
             get { return _textEditorFactoryService; }
         }
 
+        public IEditorOperationsFactoryService EditorOperationsFactoryService
+        {
+            get { return _editorOperationsFactoryService; }
+        }
+
         public virtual bool AutoSynchronizeSettings
         {
             get { return true; }
@@ -226,7 +231,7 @@ namespace Vim.UI.Wpf
 
         public abstract bool LoadFileIntoExistingWindow(string filePath, ITextView textView);
 
-        public abstract bool LoadFileIntoNewWindow(string filePath);
+        public abstract bool LoadFileIntoNewWindow(string filePath, int line, int column);
 
         public abstract void Make(bool jumpToFirstError, string arguments);
 
@@ -642,9 +647,9 @@ namespace Vim.UI.Wpf
             return LoadFileIntoExistingWindow(filePath, textView);
         }
 
-        bool IVimHost.LoadFileIntoNewWindow(string filePath)
+        bool IVimHost.LoadFileIntoNewWindow(string filePath, int line, int column)
         {
-            return LoadFileIntoNewWindow(filePath);
+            return LoadFileIntoNewWindow(filePath, line, column);
         }
 
         void IVimHost.Make(bool jumpToFirstError, string arguments)

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -231,7 +231,7 @@ namespace Vim.UI.Wpf
 
         public abstract bool LoadFileIntoExistingWindow(string filePath, ITextView textView);
 
-        public abstract bool LoadFileIntoNewWindow(string filePath, int line, int column);
+        public abstract bool LoadFileIntoNewWindow(string filePath, FSharpOption<int> line, FSharpOption<int> column);
 
         public abstract void Make(bool jumpToFirstError, string arguments);
 
@@ -647,7 +647,7 @@ namespace Vim.UI.Wpf
             return LoadFileIntoExistingWindow(filePath, textView);
         }
 
-        bool IVimHost.LoadFileIntoNewWindow(string filePath, int line, int column)
+        bool IVimHost.LoadFileIntoNewWindow(string filePath, FSharpOption<int> line, FSharpOption<int> column)
         {
             return LoadFileIntoNewWindow(filePath, line, column);
         }

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -448,7 +448,7 @@ namespace Vim.VisualStudio
         /// <summary>
         /// Open up a new document window with the specified file
         /// </summary>
-        public override bool LoadFileIntoNewWindow(string filePath, int line, int column)
+        public override bool LoadFileIntoNewWindow(string filePath, FSharpOption<int> line, FSharpOption<int> column)
         {
             try
             {
@@ -456,7 +456,7 @@ namespace Vim.VisualStudio
                 VsShellUtilities.OpenDocument(_vsAdapter.ServiceProvider, filePath, VSConstants.LOGVIEWID_Primary,
                     out IVsUIHierarchy hierarchy, out uint itemID, out IVsWindowFrame windowFrame);
 
-                if (line != -1)
+                if (line.IsSome())
                 {
                     // Get the VS text view for the window.
                     var vsTextView = VsShellUtilities.GetTextView(windowFrame);
@@ -465,11 +465,11 @@ namespace Vim.VisualStudio
                     var wpfTextView = _editorAdaptersFactoryService.GetWpfTextView(vsTextView);
 
                     // Move the caret to its initial position.
-                    var snapshotLine = wpfTextView.TextSnapshot.GetLineFromLineNumber(line);
+                    var snapshotLine = wpfTextView.TextSnapshot.GetLineFromLineNumber(line.Value);
                     var point = snapshotLine.Start;
-                    if (column != -1)
+                    if (column.IsSome())
                     {
-                        point = point.Add(column);
+                        point = point.Add(column.Value);
                         wpfTextView.Caret.MoveTo(point);
                     }
                     else
@@ -788,7 +788,7 @@ namespace Vim.VisualStudio
         {
             textView = null;
             var vimBufferOption = _vim.TryGetRecentBuffer(n);
-            if (!vimBufferOption.IsNone() && vimBufferOption.Value.TextView is IWpfTextView wpfTextView)
+            if (vimBufferOption.IsSome() && vimBufferOption.Value.TextView is IWpfTextView wpfTextView)
             {
                 textView = wpfTextView;
             }

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -787,14 +787,11 @@ namespace Vim.VisualStudio
         private bool TryGetRecentWindow(int n, out IWpfTextView textView)
         {
             textView = null;
-#if false
-            // TODO: Enable when PR #2139 is merged.
-            var vimBufferOption = _vim.TryGetRecentBuffer(i);
-            if (vimBufferOption.HasValue && vimBufferOption.Value.TextView is IWpfTextView wpfTextView)
+            var vimBufferOption = _vim.TryGetRecentBuffer(n);
+            if (!vimBufferOption.IsNone() && vimBufferOption.Value.TextView is IWpfTextView wpfTextView)
             {
                 textView = wpfTextView;
             }
-#endif
             return false;
         }
 

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -456,21 +456,29 @@ namespace Vim.VisualStudio
                 VsShellUtilities.OpenDocument(_vsAdapter.ServiceProvider, filePath, VSConstants.LOGVIEWID_Primary,
                     out IVsUIHierarchy hierarchy, out uint itemID, out IVsWindowFrame windowFrame);
 
-                // Get the VS text view for the window.
-                var vsTextView = VsShellUtilities.GetTextView(windowFrame);
-
-                // Get the WPF text view for the VS text view.
-                var wpfTextView = _editorAdaptersFactoryService.GetWpfTextView(vsTextView);
-
-                // Move the caret to its initial position.
-                var snapshotLine = wpfTextView.TextSnapshot.GetLineFromLineNumber(line);
-                var point = snapshotLine.Start.Add(column);
-                wpfTextView.Caret.MoveTo(point);
-                if (column == 0)
+                if (line != -1)
                 {
-                    // Column zero implies moving to the first non-blank.
-                    var editorOperations = EditorOperationsFactoryService.GetEditorOperations(wpfTextView);
-                    editorOperations.MoveToStartOfLineAfterWhiteSpace(false);
+                    // Get the VS text view for the window.
+                    var vsTextView = VsShellUtilities.GetTextView(windowFrame);
+
+                    // Get the WPF text view for the VS text view.
+                    var wpfTextView = _editorAdaptersFactoryService.GetWpfTextView(vsTextView);
+
+                    // Move the caret to its initial position.
+                    var snapshotLine = wpfTextView.TextSnapshot.GetLineFromLineNumber(line);
+                    var point = snapshotLine.Start;
+                    if (column != -1)
+                    {
+                        point = point.Add(column);
+                        wpfTextView.Caret.MoveTo(point);
+                    }
+                    else
+                    {
+                        // Default column implies moving to the first non-blank.
+                        wpfTextView.Caret.MoveTo(point);
+                        var editorOperations = EditorOperationsFactoryService.GetEditorOperations(wpfTextView);
+                        editorOperations.MoveToStartOfLineAfterWhiteSpace(false);
+                    }
                 }
 
                 return true;

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -465,7 +465,7 @@ namespace Vim.VisualStudio
                 // Move the caret to its initial position.
                 var snapshotLine = wpfTextView.TextSnapshot.GetLineFromLineNumber(line);
                 var point = snapshotLine.Start.Add(column);
-                wpfTextView.Caret.MoveTo(new SnapshotPoint(wpfTextView.TextSnapshot, point.Position));
+                wpfTextView.Caret.MoveTo(point);
                 if (column == 0)
                 {
                     // Column zero implies moving to the first non-blank.

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -448,7 +448,7 @@ namespace Vim.VisualStudio
         /// <summary>
         /// Open up a new document window with the specified file
         /// </summary>
-        public override bool LoadFileIntoNewWindow(string filePath)
+        public override bool LoadFileIntoNewWindow(string filePath, int line, int column)
         {
             try
             {

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -460,7 +460,7 @@ namespace Vim.VisualStudio
                 var vsTextView = VsShellUtilities.GetTextView(windowFrame);
 
                 // Get the WPF text view for the VS text view.
-                var wpfTextView = _editorAdaptersFactoryService.GetWpfTextViewNoThrow(vsTextView);
+                var wpfTextView = _editorAdaptersFactoryService.GetWpfTextView(vsTextView);
 
                 // Move the caret to its initial position.
                 var snapshotLine = wpfTextView.TextSnapshot.GetLineFromLineNumber(line);

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -1881,6 +1881,50 @@ namespace Vim.UnitTest
             }
         }
 
+        public sealed class EditAlternateFileTest : NormalModeIntegrationTest
+        {
+            private readonly Vim _vimRaw;
+
+            public EditAlternateFileTest()
+            {
+                _vimRaw = (Vim)Vim;
+            }
+
+            [WpfFact]
+            public void MostRecent()
+            {
+                Create("buffer0", "cat", "dog");
+                var vimBuffer0 = _vimBuffer;
+                vimBuffer0.TextView.MoveCaretToLine(0, 1);
+                var vimBuffer1 = CreateVimBuffer("buffer1", "foo", "bar");
+                vimBuffer1.TextView.MoveCaretToLine(1, 2);
+                var vimBuffer2 = CreateVimBuffer("buffer2", "aaa", "bbb");
+                vimBuffer2.TextView.MoveCaretToLine(2, 0);
+                _vimRaw.OnFocus(vimBuffer0);
+                _vimRaw.OnFocus(vimBuffer1);
+                _vimRaw.OnFocus(vimBuffer2);
+                vimBuffer2.ProcessNotation("<C-^>");
+                Assert.Equal(vimBuffer1.TextView.Caret.Position.VirtualBufferPosition, _vimHost.NavigateToData);
+            }
+
+            [WpfFact]
+            public void NextMostRecent()
+            {
+                Create("buffer0", "cat", "dog");
+                var vimBuffer0 = _vimBuffer;
+                vimBuffer0.TextView.MoveCaretToLine(0, 1);
+                var vimBuffer1 = CreateVimBuffer("buffer1", "foo", "bar");
+                vimBuffer1.TextView.MoveCaretToLine(1, 2);
+                var vimBuffer2 = CreateVimBuffer("buffer2", "aaa", "bbb");
+                vimBuffer2.TextView.MoveCaretToLine(2, 0);
+                _vimRaw.OnFocus(vimBuffer0);
+                _vimRaw.OnFocus(vimBuffer1);
+                _vimRaw.OnFocus(vimBuffer2);
+                vimBuffer2.ProcessNotation("2<C-^>");
+                Assert.Equal(vimBuffer0.TextView.Caret.Position.VirtualBufferPosition, _vimHost.NavigateToData);
+            }
+        }
+
         public sealed class FilterTest : NormalModeIntegrationTest
         {
             private string _command;

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -8,6 +8,7 @@ using Vim.Extensions;
 using Vim.UnitTest.Exports;
 using Vim.UnitTest.Mock;
 using Xunit;
+using Microsoft.FSharp.Core;
 
 namespace Vim.UnitTest
 {
@@ -1886,8 +1887,8 @@ namespace Vim.UnitTest
             private readonly Vim _vimRaw;
 
             private string _name;
-            private int _line;
-            private int _column;
+            private FSharpOption<int> _line;
+            private FSharpOption<int> _column;
 
             public EditAlternateFileTest()
             {
@@ -1949,12 +1950,12 @@ namespace Vim.UnitTest
                 Assert.Equal("buffer2.cs", _vimData.FileHistory.Items.Head);
 
                 _name = null;
-                _line = int.MinValue;
-                _column = int.MinValue;
+                _line = null;
+                _column = null;
                 vimBuffers[2].ProcessNotation(command);
                 Assert.Equal(name, _name);
-                Assert.Equal(0, _line);
-                Assert.Equal(-1, _column);
+                Assert.Equal(0, _line.Value);
+                Assert.Null(_column);
             }
         }
 

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -3105,6 +3105,59 @@ namespace Vim.UnitTest
                 Assert.True(_vimTextBuffer.LastEditPoint.IsSome());
                 Assert.Equal(_textBuffer.GetLine(1).Start, _vimTextBuffer.LastEditPoint.Value);
             }
+
+            /// <summary>
+            /// Jumping to a mark set at the end of a line should not go into virtual space
+            /// </summary>
+            [WpfFact]
+            public void JumpToEndOfLineMark()
+            {
+                Create("cat", "dog", "bat");
+                Vim.MarkMap.SetLocalMark('a', _vimBufferData, 1, 3);
+                _vimBuffer.Process("`a");
+                Assert.Equal(_textView.GetPointInLine(1, 2).Position, _textView.GetCaretPoint().Position);
+            }
+
+            /// <summary>
+            /// Jumping to a mark set at the end of a line should work with 've=onemore'
+            /// </summary>
+            [WpfFact]
+            public void JumpToEndOfLineMarkWithOneMore()
+            {
+                Create("cat", "dog", "bat");
+                _globalSettings.VirtualEdit = "onemore";
+                Vim.MarkMap.SetLocalMark('a', _vimBufferData, 1, 3);
+                _vimBuffer.Process("`a");
+                Assert.Equal(_textView.GetPointInLine(1, 3).Position, _textView.GetCaretPoint().Position);
+            }
+
+            /// <summary>
+            /// Deleting to a mark set at the end of a line should not go into virtual space
+            /// </summary>
+            [WpfFact]
+            public void DeleteToEndOfLineMark()
+            {
+                // This is messed up, but it's what vim does.
+                Create("cat", "dog", "bat");
+                _textView.MoveCaretToLine(0, 2);
+                Vim.MarkMap.SetLocalMark('a', _vimBufferData, 1, 3);
+                _vimBuffer.Process("d`a");
+                Assert.Equal(new[] { "cag", "bat" }, _textBuffer.GetLines());
+            }
+
+            /// <summary>
+            /// Deleting to a mark set at the end of a line should work with 've=onemore'
+            /// </summary>
+            [WpfFact]
+            public void DeleteToEndOfLineMarkWithOneMore()
+            {
+                Create("cat", "dog", "bat");
+                _globalSettings.VirtualEdit = "onemore";
+                _textView.MoveCaretToLine(0, 2);
+                Vim.MarkMap.SetLocalMark('a', _vimBufferData, 1, 3);
+                _vimBuffer.Process("d`a");
+                Assert.Equal(new[] { "ca", "bat" }, _textBuffer.GetLines());
+            }
         }
 
         public sealed class ChangeLinesTest : NormalModeIntegrationTest

--- a/Test/VimCoreTest/VimBufferTest.cs
+++ b/Test/VimCoreTest/VimBufferTest.cs
@@ -527,7 +527,7 @@ namespace Vim.UnitTest
             public ClosingSetsLastEditedPositionMark()
             {
                 OpenFakeVimBufferTestWindow();
-                _vimBuffer.MarkMap.SetLastExitedPosition("VimBufferTest.cs", 0, 0);
+                _vimBuffer.MarkMap.UnloadBuffer(_vimBufferData, 0, 0);
             }
 
             protected void OpenFakeVimBufferTestWindow()
@@ -576,7 +576,7 @@ namespace Vim.UnitTest
             [WpfFact]
             public void ReopeningTheWindowLastColumn()
             {
-                _vimBuffer.MarkMap.SetLastExitedPosition("VimBufferTest.cs", 0, 5);
+                _vimBuffer.MarkMap.UnloadBuffer(_vimBufferData, 0, 5);
                 OpenFakeVimBufferTestWindow();
 
                 var option = Vim.MarkMap.GetMark(Mark.LastExitedPosition, _vimBuffer.VimBufferData);
@@ -586,7 +586,7 @@ namespace Vim.UnitTest
             [WpfFact]
             public void ReopeningTheWindowLastColumnAfterFirstLine()
             {
-                _vimBuffer.MarkMap.SetLastExitedPosition("VimBufferTest.cs", 1, 6);
+                _vimBuffer.MarkMap.UnloadBuffer(_vimBufferData, 1, 6);
                 OpenFakeVimBufferTestWindow();
 
                 var option = Vim.MarkMap.GetMark(Mark.LastExitedPosition, _vimBuffer.VimBufferData);

--- a/Test/VimCoreTest/VimBufferTest.cs
+++ b/Test/VimCoreTest/VimBufferTest.cs
@@ -527,7 +527,7 @@ namespace Vim.UnitTest
             public ClosingSetsLastEditedPositionMark()
             {
                 OpenFakeVimBufferTestWindow();
-                _vimBuffer.MarkMap.UnloadBuffer(_vimBufferData, 0, 0);
+                _vimBuffer.MarkMap.UnloadBuffer(_vimBufferData, "VimBufferTest.cs", 0, 0);
             }
 
             protected void OpenFakeVimBufferTestWindow()
@@ -576,7 +576,7 @@ namespace Vim.UnitTest
             [WpfFact]
             public void ReopeningTheWindowLastColumn()
             {
-                _vimBuffer.MarkMap.UnloadBuffer(_vimBufferData, 0, 5);
+                _vimBuffer.MarkMap.UnloadBuffer(_vimBufferData, "VimBufferTest.cs", 0, 5);
                 OpenFakeVimBufferTestWindow();
 
                 var option = Vim.MarkMap.GetMark(Mark.LastExitedPosition, _vimBuffer.VimBufferData);
@@ -586,7 +586,7 @@ namespace Vim.UnitTest
             [WpfFact]
             public void ReopeningTheWindowLastColumnAfterFirstLine()
             {
-                _vimBuffer.MarkMap.UnloadBuffer(_vimBufferData, 1, 6);
+                _vimBuffer.MarkMap.UnloadBuffer(_vimBufferData, "VimBufferTest.cs", 1, 6);
                 OpenFakeVimBufferTestWindow();
 
                 var option = Vim.MarkMap.GetMark(Mark.LastExitedPosition, _vimBuffer.VimBufferData);

--- a/Test/VimCoreTest/VimBufferTest.cs
+++ b/Test/VimCoreTest/VimBufferTest.cs
@@ -634,6 +634,23 @@ namespace Vim.UnitTest
             }
         }
 
+        public class UnloadedMarksTest : ClosingSetsLastEditedPositionMark
+        {
+            [WpfFact]
+            public void ReloadUnloadedMark()
+            {
+                Vim.MarkMap.SetGlobalMark(Letter.A, _vimBufferData.VimTextBuffer, 1, 2);
+                AssertPosition(1, 2, Vim.MarkMap.GetGlobalMark(Letter.A));
+
+                _vimBuffer.Close();
+                Assert.True(Vim.MarkMap.GetGlobalMark(Letter.A).IsNone());
+
+                // reopen the file
+                OpenFakeVimBufferTestWindow();
+                AssertPosition(1, 2, Vim.MarkMap.GetGlobalMark(Letter.A));
+            }
+        }
+
         public sealed class MiscTest : VimBufferTest
         {
             /// <summary>

--- a/Test/VimCoreTest/VimTest.cs
+++ b/Test/VimCoreTest/VimTest.cs
@@ -75,6 +75,7 @@ namespace Vim.UnitTest
             var markMap = _factory.Create<IMarkMap>();
             markMap.Setup(x => x.SetMark(Mark.LastJump, It.IsAny<IVimBufferData>(), 0, 0)).Returns(true);
             markMap.Setup(x => x.UnloadBuffer(It.IsAny<IVimBufferData>(), "VimTest.cs", 0, 0)).Returns(true);
+            markMap.Setup(x => x.ReloadBuffer(It.IsAny<IVimBufferData>(), "VimTest.cs")).Returns(true);
             _vimRaw = new Vim(
                 _vimHost.Object,
                 _bufferFactory,

--- a/Test/VimCoreTest/VimTest.cs
+++ b/Test/VimCoreTest/VimTest.cs
@@ -74,7 +74,7 @@ namespace Vim.UnitTest
             var creationListeners = new[] { new Lazy<IVimBufferCreationListener>(() => _simpleListener) };
             var markMap = _factory.Create<IMarkMap>();
             markMap.Setup(x => x.SetMark(Mark.LastJump, It.IsAny<IVimBufferData>(), 0, 0)).Returns(true);
-            markMap.Setup(x => x.SetLastExitedPosition("VimTest.cs", 0, 0)).Returns(true);
+            markMap.Setup(x => x.UnloadBuffer(It.IsAny<IVimBufferData>(), 0, 0)).Returns(true);
             _vimRaw = new Vim(
                 _vimHost.Object,
                 _bufferFactory,

--- a/Test/VimCoreTest/VimTest.cs
+++ b/Test/VimCoreTest/VimTest.cs
@@ -652,6 +652,43 @@ namespace Vim.UnitTest
             }
         }
 
+        public sealed class RecentBufferTest : VimTest
+        {
+            private IVimBuffer CreateVimBuffer()
+            {
+                var textView = CreateTextView();
+                var buffer = _vim.CreateVimBuffer(textView);
+                return buffer;
+            }
+
+            private void FocusVimBuffer(IVimBuffer vimBuffer)
+            {
+                _vimRaw.OnFocus(vimBuffer);
+            }
+
+            [WpfFact]
+            public void RecentBuffer()
+            {
+                var buffer1 = CreateVimBuffer();
+                var buffer2 = CreateVimBuffer();
+                var buffer3 = CreateVimBuffer();
+
+                FocusVimBuffer(buffer1);
+                FocusVimBuffer(buffer2);
+                FocusVimBuffer(buffer3);
+                Assert.Equal(buffer3, _vim.TryGetRecentBuffer(0).Value);
+                Assert.Equal(buffer2, _vim.TryGetRecentBuffer(1).Value);
+                Assert.Equal(buffer1, _vim.TryGetRecentBuffer(2).Value);
+                Assert.True(_vim.TryGetRecentBuffer(3).IsNone());
+
+                FocusVimBuffer(buffer2);
+                Assert.Equal(buffer2, _vim.TryGetRecentBuffer(0).Value);
+                Assert.Equal(buffer3, _vim.TryGetRecentBuffer(1).Value);
+                Assert.Equal(buffer1, _vim.TryGetRecentBuffer(2).Value);
+                Assert.True(_vim.TryGetRecentBuffer(3).IsNone());
+            }
+        }
+
         public sealed class GlobalSettingsCustomizationTest : VimTest
         {
             public GlobalSettingsCustomizationTest()

--- a/Test/VimCoreTest/VimTest.cs
+++ b/Test/VimCoreTest/VimTest.cs
@@ -74,7 +74,7 @@ namespace Vim.UnitTest
             var creationListeners = new[] { new Lazy<IVimBufferCreationListener>(() => _simpleListener) };
             var markMap = _factory.Create<IMarkMap>();
             markMap.Setup(x => x.SetMark(Mark.LastJump, It.IsAny<IVimBufferData>(), 0, 0)).Returns(true);
-            markMap.Setup(x => x.UnloadBuffer(It.IsAny<IVimBufferData>(), 0, 0)).Returns(true);
+            markMap.Setup(x => x.UnloadBuffer(It.IsAny<IVimBufferData>(), "VimTest.cs", 0, 0)).Returns(true);
             _vimRaw = new Vim(
                 _vimHost.Object,
                 _bufferFactory,

--- a/Test/VimWpfTest/VimHostTests.cs
+++ b/Test/VimWpfTest/VimHostTests.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Vim.UnitTest;
 using Vim.EditorHost;
+using Microsoft.FSharp.Core;
 
 namespace Vim.UI.Wpf.UnitTest
 {
@@ -79,7 +80,7 @@ namespace Vim.UI.Wpf.UnitTest
                 throw new NotImplementedException();
             }
 
-            public override bool LoadFileIntoNewWindow(string filePath, int line, int column)
+            public override bool LoadFileIntoNewWindow(string filePath, FSharpOption<int> line, FSharpOption<int> column)
             {
                 throw new NotImplementedException();
             }

--- a/Test/VimWpfTest/VimHostTests.cs
+++ b/Test/VimWpfTest/VimHostTests.cs
@@ -79,7 +79,7 @@ namespace Vim.UI.Wpf.UnitTest
                 throw new NotImplementedException();
             }
 
-            public override bool LoadFileIntoNewWindow(string filePath)
+            public override bool LoadFileIntoNewWindow(string filePath, int line, int column)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Implement what vim calls "edit alternate file" (see `:help ctrl-^`). It also extends VsVim's handling of global marks to support unloaded buffers.

### Changes

- Add most recently used buffer list
- Implement `<C-^>` to switch to the nth most recently focused buffer
- Add file history
- Implement, for example, `:e#` and `:e#[count]` to edit recent files
- Add the `:files` command (with the aliases `:buffers` and `:ls`)
- Fix display of all global marks with `:marks` command
- Migrate global marks when buffers are unloaded
- Recreate global marks when buffers are reloaded
- Support navigating to a global mark in an unloaded buffer
- Fix cursor position when navigating to a mark in a another buffer
- Support setting initial cursor position when opening new documents
- Prevent putting caret in virtual space for end-of-line marks

### Issues

- Fixes #1890
- Fixes #1905
- Fixes #1872
- Fixes #1972
- Fixes #2191

### Discussion

This doesn't exactly replicate all vim semantics, but tries to keep the spirit of the commands in the context of Visual Studio. Specifically, `<C-^>` will never take you to a file that isn't open and `[count]<C-^>` will take you the the nth most recent focused buffer, not to a a specific buffer with an unchanging number from the `:files` list. Furthermore, `<C-^>` is not like `:e#` but more like `:tabe#` in that it doesn't replace the contents of the existing window with a new buffer. Nevertheless, `:e#` *can* take you to a file that is not open, but similarly, `:e#[count]` takes you to the nth most recent file.

The intent is that `<C-^>` and `:tabe#` do what you would expect them to do in Visual Studio and small counts might be useful to switch a little further back, but probably memorizing buffer numbers peculiar to the current editing session is not the best/fastest way to switch to a specific non-recent buffer in Visual Studio.

Global mark changes were included in the same PR because they both relate heavily to the files associated with text buffers.