### PR TITLE
Remove last of VS2010 code

### DIFF
--- a/Src/VimCore/TaggerUtil.fs
+++ b/Src/VimCore/TaggerUtil.fs
@@ -31,7 +31,7 @@ module TaggerUtilCore =
     ///    is acted on directly by many editor components.  Providing a large range 
     ///    unnecessarily increases their work load.
     /// 2. It can cause a ripple effect in Visual Studio 2010 RTM.  The SnapshotSpan 
-    ///    returned will be immediately be the vale passed to GetTags for every other
+    ///    returned will be immediately be the value passed to GetTags for every other
     ///    ITagger in the system (TextMarkerVisualManager issue). 
     ///
     /// In order to provide the minimum possible valid SnapshotSpan the simple taggers

--- a/Src/VimEditorHost/EditorVersion.cs
+++ b/Src/VimEditorHost/EditorVersion.cs
@@ -11,7 +11,6 @@ namespace Vim.EditorHost
     /// <remarks>These must be listed in ascending version order</remarks>
     public enum EditorVersion
     {
-        Vs2010,
         Vs2012,
         Vs2013,
         Vs2015,

--- a/Src/VimEditorHost/EditorVersionUtil.cs
+++ b/Src/VimEditorHost/EditorVersionUtil.cs
@@ -16,7 +16,6 @@ namespace Vim.EditorHost
         {
             switch (majorVersion)
             {
-                case 10: return EditorVersion.Vs2010;
                 case 11: return EditorVersion.Vs2012;
                 case 12: return EditorVersion.Vs2013;
                 case 14: return EditorVersion.Vs2015;
@@ -29,7 +28,6 @@ namespace Vim.EditorHost
         {
             switch (version)
             {
-                case EditorVersion.Vs2010: return 10;
                 case EditorVersion.Vs2012: return 11;
                 case EditorVersion.Vs2013: return 12;
                 case EditorVersion.Vs2015: return 14;

--- a/Src/VsInterfaces/Extension.cs
+++ b/Src/VsInterfaces/Extension.cs
@@ -20,8 +20,6 @@ namespace Vim.VisualStudio
 
             switch (parts[0])
             {
-                case "10":
-                    return VisualStudioVersion.Vs2010;
                 case "11":
                     return VisualStudioVersion.Vs2012;
                 case "12":

--- a/Src/VsInterfaces/VisualStudioVersion.cs
+++ b/Src/VsInterfaces/VisualStudioVersion.cs
@@ -6,7 +6,6 @@ namespace Vim.VisualStudio
     /// </summary>
     public enum VisualStudioVersion
     {
-        Vs2010,
         Vs2012,
         Vs2013,
         Vs2015,

--- a/Src/VsVimShared/Constants.cs
+++ b/Src/VsVimShared/Constants.cs
@@ -31,7 +31,7 @@ namespace Vim.VisualStudio
 
         /// <summary>
         /// This text view role was added in VS 2013.  Adding the constant here so we can refer to 
-        /// it within our code as we compile against the VS 2010 binaries
+        /// it within our code as we compile against the VS 2012 binaries
         /// </summary>
         public const string TextViewRoleEmbeddedPeekTextView = "EMBEDDED_PEEK_TEXT_VIEW";
 

--- a/Src/VsVimShared/IVsAdapter.cs
+++ b/Src/VsVimShared/IVsAdapter.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 namespace Vim.VisualStudio
 {
     /// <summary>
-    /// Adapter layer to convert between 2010 and pre-2010 equivalent types 
+    /// Adapter layer to convert between WPF editor and pre-editor APIs.
     /// and hierarchies
     /// </summary>
     public interface IVsAdapter

--- a/Src/VsVimShared/Implementation/Misc/CSharpAdapter.cs
+++ b/Src/VsVimShared/Implementation/Misc/CSharpAdapter.cs
@@ -14,7 +14,7 @@ namespace Vim.VisualStudio.Implementation.Misc
     {
         /// <summary>
         /// This regex is intended to match the C# generated event handler pattern.  This is the pattern which is 
-        /// used in Visual Studio 2010
+        /// used in Visual Studio 2010+
         /// </summary>
         private static readonly Regex s_fullEventSyntaxRegex = new Regex(@"\+=\s*new\s+[a-z0-9.]+\s*\([a-z0-9_]*\)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 

--- a/Src/VsVimShared/Implementation/Misc/ScopeData.cs
+++ b/Src/VsVimShared/Implementation/Misc/ScopeData.cs
@@ -108,7 +108,7 @@ namespace Vim.VisualStudio.Implementation.Misc
                 {
                     using (var keyBindingsKey = rootKey.OpenSubKey("KeyBindingTables"))
                     {
-                        // For "Global".  The id in the registry here is incorrect for Vs 2010
+                        // For "Global".  The id in the registry here is incorrect for Vs 2010+
                         // so hard code the known value
                         if (!TryGetKeyBindingScopeName(vsShell, keyBindingsKey, "{5efc7975-14bc-11cf-9b2b-00aa00573819}", 13018, out globalScopeName))
                         {

--- a/Src/VsVimShared/Implementation/VisualAssist/VisualAssistUtil.cs
+++ b/Src/VsVimShared/Implementation/VisualAssist/VisualAssistUtil.cs
@@ -65,9 +65,6 @@ namespace Vim.VisualStudio.Implementation.VisualAssist
             string subKey;
             switch (version)
             {
-                case VisualStudioVersion.Vs2010:
-                    subKey = "VANet10";
-                    break;
                 case VisualStudioVersion.Vs2012:
                 case VisualStudioVersion.Vs2013:
                 case VisualStudioVersion.Vs2015:
@@ -75,8 +72,8 @@ namespace Vim.VisualStudio.Implementation.VisualAssist
                     break;
                 case VisualStudioVersion.Unknown:
                 default:
-                    // Default to the Vs2010 version
-                    subKey = "VANet10";
+                    // Default to the Vs2012 version
+                    subKey = "VANet11";
                     break;
             }
 

--- a/Test/VimCoreTest/EditorVersionUtilTest.cs
+++ b/Test/VimCoreTest/EditorVersionUtilTest.cs
@@ -22,7 +22,6 @@ namespace Vim.UnitTest
         [Fact]
         public void GetVersionNumberAll()
         {
-            Assert.Equal(10, EditorVersionUtil.GetMajorVersionNumber(EditorVersion.Vs2010));
             Assert.Equal(11, EditorVersionUtil.GetMajorVersionNumber(EditorVersion.Vs2012));
             Assert.Equal(12, EditorVersionUtil.GetMajorVersionNumber(EditorVersion.Vs2013));
             Assert.Equal(14, EditorVersionUtil.GetMajorVersionNumber(EditorVersion.Vs2015));

--- a/Test/VsVimSharedTest/VimApplicationSettingsTest.cs
+++ b/Test/VsVimSharedTest/VimApplicationSettingsTest.cs
@@ -222,7 +222,7 @@ namespace Vim.VisualStudio.UnitTest
         private readonly VimApplicationSettings _vimApplicationSettingsRaw;
         private readonly WritableSettingsStore _writableSettingsStore;
 
-        protected VimApplicationSettingsTest(VisualStudioVersion visualStudioVersion = VisualStudioVersion.Vs2010, WritableSettingsStore settingsStore = null)
+        protected VimApplicationSettingsTest(VisualStudioVersion visualStudioVersion = VisualStudioVersion.Vs2012, WritableSettingsStore settingsStore = null)
         {
             settingsStore = settingsStore ?? new SimpleWritableSettingsStore();
             _factory = new MockRepository(MockBehavior.Strict);


### PR DESCRIPTION
VsVim stopped supporting VS2010 a few releases ago. This removes the
last of the code that helped support that release.