### PR TITLE
Printable unicode

### DIFF
--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -4,6 +4,7 @@
 // VimCorePort assemblies.
 namespace Vim
 open System
+open System.Globalization
 open System.Collections.ObjectModel
 open System.IO
 open System.Text
@@ -504,6 +505,48 @@ type internal CharSpan
 
 module internal CharUtil =
 
+    let PrintableCategories =
+        seq {
+            // Letters
+            yield UnicodeCategory.UppercaseLetter
+            yield UnicodeCategory.LowercaseLetter
+            yield UnicodeCategory.TitlecaseLetter
+            yield UnicodeCategory.ModifierLetter
+            yield UnicodeCategory.OtherLetter
+            // Marks
+            yield UnicodeCategory.NonSpacingMark
+            yield UnicodeCategory.SpacingCombiningMark
+            yield UnicodeCategory.EnclosingMark
+            // Digits
+            yield UnicodeCategory.DecimalDigitNumber
+            yield UnicodeCategory.LetterNumber
+            yield UnicodeCategory.OtherNumber
+            // Not separators
+            //yield UnicodeCategory.SpaceSeparator
+            //yield UnicodeCategory.LineSeparator
+            //yield UnicodeCategory.ParagraphSeparator
+            // Not control, etc.
+            //yield UnicodeCategory.Control
+            //yield UnicodeCategory.Format
+            //yield UnicodeCategory.Surrogate
+            //yield UnicodeCategory.PrivateUse
+            // Punctuation
+            yield UnicodeCategory.ConnectorPunctuation
+            yield UnicodeCategory.DashPunctuation
+            yield UnicodeCategory.OpenPunctuation
+            yield UnicodeCategory.ClosePunctuation
+            yield UnicodeCategory.InitialQuotePunctuation
+            yield UnicodeCategory.FinalQuotePunctuation
+            yield UnicodeCategory.OtherPunctuation
+            // Symbols
+            yield UnicodeCategory.MathSymbol
+            yield UnicodeCategory.CurrencySymbol
+            yield UnicodeCategory.ModifierSymbol
+            yield UnicodeCategory.OtherSymbol
+            // Not unassigned
+            //yield UnicodeCategory.OtherNotAssigned
+        } |> set
+
     let MinValue = System.Char.MinValue
     let IsDigit x = System.Char.IsDigit(x)
     let IsWhiteSpace x = System.Char.IsWhiteSpace(x)
@@ -526,6 +569,9 @@ module internal CharUtil =
     let IsLetterOrDigit x = System.Char.IsLetterOrDigit(x)
     let IsTagNameChar x = System.Char.IsLetterOrDigit(x) || x = ':' || x = '.' || x = '_' || x = '-'
     let IsFileNameChar x = IsTagNameChar x
+    let IsPrintable x =
+        let category = CharUnicodeInfo.GetUnicodeCategory(x)
+        PrintableCategories.Contains category
     let ToLower x = System.Char.ToLower(x)
     let ToUpper x = System.Char.ToUpper(x)
     let ChangeCase x = if IsUpper x then ToLower x else ToUpper x

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -330,9 +330,9 @@ type internal NormalMode
             true
         elif Option.isSome keyInput.RawChar && VimKeyModifiers.None = keyInput.KeyModifiers then
 
-            // We can process any printable character.  If we don't process it,
-            // Visual Studio will insert it into the buffer.
-            CharUtil.IsPrintable keyInput.Char
+            // We can process any printable character (think international input)
+            // or any character which is part of the standard Vim input set.
+            CharUtil.IsPrintable keyInput.Char || Set.contains keyInput.Char _coreCharSet
         else 
             false
     

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -329,9 +329,10 @@ type internal NormalMode
         elif doesCommandStartWith keyInput then 
             true
         elif Option.isSome keyInput.RawChar && VimKeyModifiers.None = keyInput.KeyModifiers then
-            // We can process any letter (think international input) or any character
-            // which is part of the standard Vim input set
-            CharUtil.IsLetter keyInput.Char || Set.contains keyInput.Char _coreCharSet
+
+            // We can process any printable character.  If we don't process it,
+            // Visual Studio will insert it into the buffer.
+            CharUtil.IsPrintable keyInput.Char
         else 
             false
     

--- a/Src/VsVimShared/OleCommandUtil.cs
+++ b/Src/VsVimShared/OleCommandUtil.cs
@@ -75,7 +75,6 @@ namespace Vim.VisualStudio
         /// </summary>
         internal static bool TryConvert(VSConstants.VSStd2KCmdID cmdId, IntPtr variantIn, out KeyInput keyInput, out EditCommandKind kind, out bool isRawText)
         {
-            var category = System.Globalization.CharUnicodeInfo.GetUnicodeCategory(' ');
             isRawText = false;
             switch (cmdId)
             {

--- a/Src/VsVimShared/OleCommandUtil.cs
+++ b/Src/VsVimShared/OleCommandUtil.cs
@@ -75,6 +75,7 @@ namespace Vim.VisualStudio
         /// </summary>
         internal static bool TryConvert(VSConstants.VSStd2KCmdID cmdId, IntPtr variantIn, out KeyInput keyInput, out EditCommandKind kind, out bool isRawText)
         {
+            var category = System.Globalization.CharUnicodeInfo.GetUnicodeCategory(' ');
             isRawText = false;
             switch (cmdId)
             {

--- a/Test/VimCoreTest/NormalModeTest.cs
+++ b/Test/VimCoreTest/NormalModeTest.cs
@@ -181,6 +181,22 @@ namespace Vim.UnitTest
             Assert.False(_mode.CanProcess(KeyInputUtil.ChangeKeyModifiersDangerous(KeyInputUtil.TabKey, VimKeyModifiers.Control)));
         }
 
+        /// <summary>
+        /// Must be able to process non-ASCII punctuation otherwise
+        /// they will end up as input
+        /// </summary>
+        [WpfFact]
+        public void CanProcessPrintableNonAscii()
+        {
+            // Reported in issue #1793.
+            Create(s_defaultLines);
+            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('¤')));
+            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('¨')));
+            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('£')));
+            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('§')));
+            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('´')));
+        }
+
         #endregion
 
         #region Movement


### PR DESCRIPTION
Normal mode needs to report that it can process printable non-ASCII punctuation characters so that Visual Studio does not enter them in normal mode.

### Changes

- Add 'is printable' to char utilities
- Report any printable Unicode character as processable in normal mode
- Add tests for a few non-ASCII punctuation characters

### Fixes

- Fixes #1793
