### PR TITLE
Support escaped key notation in string expression constants

### DIFF
--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1490,12 +1490,31 @@ type Parser
                 moveNextChar()
                 if afterEscape then
                     match c with
+                    | 'e' -> builder.AppendChar (char 0x1b)
                     | 't' -> builder.AppendChar '\t'
                     | 'b' -> builder.AppendChar '\b'
                     | 'f' -> builder.AppendChar '\f'
                     | 'n' -> builder.AppendChar '\n'
                     | 'r' -> builder.AppendChar '\r'
-                    | '\\' -> builder.AppendChar '\\'
+                    | '<' ->
+
+                        // Escaped open angle bracket in a string literal
+                        // starts key notation.
+                        let notation = x.ParseWhile (fun token -> 
+                            match token.TokenKind with 
+                            | TokenKind.Character '>' -> false
+                            | _ -> true)
+                        if _tokenizer.CurrentChar = '>' then
+                            _tokenizer.MoveNextToken()
+                            match notation with
+                            | None -> ()
+                            | Some notation ->
+                                let notation = "<" + notation + ">"
+                                let keyInput = KeyNotationUtil.StringToKeyInput notation
+                                match keyInput.RawChar with
+                                | None -> ()
+                                | Some rawChar -> builder.AppendChar rawChar
+
                     | _ -> builder.AppendChar c
                     inner false
                 elif c = '\\' then

--- a/Test/VimCoreTest/ParserTest.cs
+++ b/Test/VimCoreTest/ParserTest.cs
@@ -827,6 +827,16 @@ let x = 42
             {
                 Assert.Equal("\t", ParseStringConstant(@"""\t"""));
             }
+
+            /// <summary>
+            /// Key notation is allowed in string expression constants
+            /// </summary>
+            [Fact]
+            public void KeyNotation()
+            {
+                // Reported in issue #1845.
+                Assert.Equal("aaa\rbbb", ParseStringConstant(@"""aaa\<CR>bbb"""));
+            }
         }
 
         public sealed class SubstituteTest : ParserTest

--- a/Test/VimCoreTest/ParserTest.cs
+++ b/Test/VimCoreTest/ParserTest.cs
@@ -829,6 +829,15 @@ let x = 42
             }
 
             /// <summary>
+            /// Backslash escapes itself
+            /// </summary>
+            [Fact]
+            public void Backslash()
+            {
+                Assert.Equal(@"f\o", ParseStringConstant(@"""f\\o"""));
+            }
+
+            /// <summary>
             /// Key notation is allowed in string expression constants
             /// </summary>
             [Fact]


### PR DESCRIPTION
- Fixes #1845