### PR TITLE
Backspace in replace mode

### DIFF
--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3380,6 +3380,9 @@ type internal IInsertUtil =
     /// Repeat the given edit series. 
     abstract RepeatBlock: command: InsertCommand -> atEndOfLine: bool -> blockSpan: BlockSpan -> string option
 
+    /// Notify that an new undo sequence is in effect
+    abstract NewUndoSequence: unit -> unit
+
 /// Contains the stored information about a Visual Span.  This instance *will* be 
 /// stored for long periods of time and used to repeat a Command instance across
 /// multiple IVimBuffer instances so it must be buffer agnostic

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3114,6 +3114,9 @@ type InsertCommand  =
     /// Shift the current line one indent width to the right
     | ShiftLineRight
 
+    /// Undo replace
+    | UndoReplace
+
     /// Delete non-blank characters before cursor on current line
     | DeleteLineBeforeCursor
 
@@ -3168,6 +3171,7 @@ type InsertCommand  =
         | InsertCommand.Overwrite s -> Some (TextChange.Replace s)
         | InsertCommand.ShiftLineLeft -> None
         | InsertCommand.ShiftLineRight -> None
+        | InsertCommand.UndoReplace -> None
         | InsertCommand.DeleteLineBeforeCursor -> None
         | InsertCommand.Paste -> None
 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3380,7 +3380,7 @@ type internal IInsertUtil =
     /// Repeat the given edit series. 
     abstract RepeatBlock: command: InsertCommand -> atEndOfLine: bool -> blockSpan: BlockSpan -> string option
 
-    /// Notify that an new undo sequence is in effect
+    /// Signal that a new undo sequence is in effect
     abstract NewUndoSequence: unit -> unit
 
 /// Contains the stored information about a Visual Span.  This instance *will* be 

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -912,4 +912,5 @@ type internal InsertUtil
         member x.RunInsertCommand command = x.RunInsertCommand command
         member x.RepeatEdit textChange addNewLines count = x.RepeatEdit textChange addNewLines count
         member x.RepeatBlock command atEndOfLine blockSpan = x.RepeatBlock command atEndOfLine blockSpan
+        member x.NewUndoSequence () = x.ClearReplaceUndoLine()
 

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -751,6 +751,7 @@ type internal InsertMode
         ProcessResult.OfCommandResult result
 
     member x.BreakUndoSequence name =
+        _insertUtil.NewUndoSequence()
         match _sessionData.Transaction with
         | None -> ()
         | Some transaction ->

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -1060,6 +1060,7 @@ type internal InsertMode
     /// ModeArgument value. 
     member x.OnEnter arg =
         x.EnsureCommandsBuilt()
+        _insertUtil.NewUndoSequence()
 
         // Record start point upon initial entry to insert mode
         _vimBuffer.VimTextBuffer.InsertStartPoint <- Some x.CaretPoint

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -447,12 +447,20 @@ type internal InsertMode
 
                 // Map any insert commands to their replacement counterparts.
                 match rawInsertCommand with
-                | RawInsertCommand.InsertCommand (keyInput, InsertCommand.InsertCharacterAboveCaret, flags) ->
-                    RawInsertCommand.InsertCommand (keyInput, InsertCommand.ReplaceCharacterAboveCaret, flags)
-                    |> Some
-                | RawInsertCommand.InsertCommand (keyInput, InsertCommand.InsertCharacterBelowCaret, flags) ->
-                    RawInsertCommand.InsertCommand (keyInput, InsertCommand.ReplaceCharacterBelowCaret, flags)
-                    |> Some
+                | RawInsertCommand.InsertCommand (keyInput, command, flags) ->
+                    let replaceCommand =
+                        match command with
+                        | InsertCommand.Back ->
+                            Some InsertCommand.UndoReplace
+                        | InsertCommand.InsertCharacterAboveCaret ->
+                            Some InsertCommand.ReplaceCharacterAboveCaret
+                        | InsertCommand.InsertCharacterBelowCaret ->
+                            Some InsertCommand.ReplaceCharacterBelowCaret
+                        | _ -> None
+                    match replaceCommand with
+                    | Some replaceCommand ->
+                        RawInsertCommand.InsertCommand (keyInput, replaceCommand, flags) |> Some
+                    | None -> Some rawInsertCommand
                 | _ -> Some rawInsertCommand
             else
                 Some rawInsertCommand
@@ -735,12 +743,9 @@ type internal InsertMode
             match command with
             | InsertCommand.ShiftLineLeft -> ()
             | InsertCommand.ShiftLineRight -> ()
-            | InsertCommand.InsertCharacterAboveCaret -> ()
-            | InsertCommand.InsertCharacterBelowCaret -> ()
-            | InsertCommand.ReplaceCharacterAboveCaret -> ()
-            | InsertCommand.ReplaceCharacterBelowCaret -> ()
             | _ -> 
-                // All other commands break the undo sequence
+
+                // All other commands break the undo sequence.
                 x.BreakUndoSequence "Insert after motion" 
 
         ProcessResult.OfCommandResult result

--- a/Test/VimCoreTest/InsertModeTest.cs
+++ b/Test/VimCoreTest/InsertModeTest.cs
@@ -79,6 +79,7 @@ namespace Vim.UnitTest
             _broker.SetupGet(x => x.IsSignatureHelpActive).Returns(false);
             _broker.SetupGet(x => x.IsSmartTagSessionActive).Returns(false);
             _insertUtil = _factory.Create<IInsertUtil>();
+            _insertUtil.Setup(x => x.NewUndoSequence());
             _motionUtil = _factory.Create<IMotionUtil>();
             _commandUtil = _factory.Create<ICommandUtil>();
             _capture = _factory.Create<IMotionCapture>();


### PR DESCRIPTION
When backspacing in replace mode the editor should effectively "undo" any previous replacements. This is one of the oldest issues, filed in 2011!

- Fixes #653