### PR TITLE
Stay in operator pending while waiting for more input

### DIFF
--- a/Src/VimCore/CommandRunner.fs
+++ b/Src/VimCore/CommandRunner.fs
@@ -354,6 +354,20 @@ type internal CommandRunner
                 x.ResetState()
                 BindResult.Error
             | BindResult.NeedMoreInput bindData ->
+
+                // If we were waiting for an operator and we need more input,
+                // stay waiting for an operator.
+                let bindData =
+                    match _runBindData with
+                    | None -> bindData
+                    | Some oldBindData ->
+                        let isNone = bindData.KeyRemapMode = KeyRemapMode.None
+                        let wasPending = oldBindData.KeyRemapMode = KeyRemapMode.OperatorPending
+                        if isNone && wasPending then
+                            { KeyRemapMode = oldBindData.KeyRemapMode; BindFunction = bindData.BindFunction }
+                        else
+                            bindData
+
                 _runBindData <- Some bindData
                 BindResult.NeedMoreInput { KeyRemapMode = bindData.KeyRemapMode; BindFunction = x.Run }
             

--- a/Src/VimTestUtils/VimUtil.cs
+++ b/Src/VimTestUtils/VimUtil.cs
@@ -151,6 +151,8 @@ namespace Vim.UnitTest
             KeyRemapMode remapMode = null,
             CommandFlags flags = CommandFlags.None)
         {
+            remapMode = remapMode ?? KeyRemapMode.None;
+
             Func<KeyInput, BindResult<NormalCommand>> func = null;
             func = keyInput =>
             {
@@ -287,6 +289,8 @@ namespace Vim.UnitTest
         internal static BindData<T> CreateBindData<T>(Func<KeyInput, BindResult<T>> func = null, KeyRemapMode remapMode = null)
         {
             func = func ?? (x => BindResult<T>.Cancelled);
+            remapMode = remapMode ?? KeyRemapMode.None;
+
             return new BindData<T>(remapMode, func.ToFSharpFunc());
         }
 

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -6675,6 +6675,24 @@ namespace Vim.UnitTest
                 _vimBuffer.Process("yi(");
                 Assert.Equal("dog", UnnamedRegister.StringValue);
             }
+
+            /// <summary>
+            /// Ensure we stay in operator pending until we're not waiting for input
+            /// </summary>
+            [WpfFact]
+            public void Block_InnerParen_OperatorPending()
+            {
+                // Reported in issue #1903.
+                Create("cat (dog) bear");
+                _textView.MoveCaretTo(6);
+                Assert.Equal(KeyRemapMode.Normal, _vimBuffer.NormalMode.KeyRemapMode);
+                _vimBuffer.Process("y");
+                Assert.Equal(KeyRemapMode.OperatorPending, _vimBuffer.NormalMode.KeyRemapMode);
+                _vimBuffer.Process("i");
+                Assert.Equal(KeyRemapMode.OperatorPending, _vimBuffer.NormalMode.KeyRemapMode);
+                _vimBuffer.Process("(");
+                Assert.Equal(KeyRemapMode.Normal, _vimBuffer.NormalMode.KeyRemapMode);
+            }
         }
 
         public sealed class BackwardEndOfWordMotionTest : NormalModeIntegrationTest


### PR DESCRIPTION
Once we transition to operator pending during key processing (after registers and counts have been processed and we start an operator) stay in operator pending while we are waiting for more input.

- Fixes #1903