### PR TITLE
Multiline substitution and '\%V'

### DIFF
--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -1227,7 +1227,7 @@ type internal CommonOperations
                 let index = capture.Index
                 let length = endPosition - startPosition
 
-                // We can only match the very end of the replacement
+                // We can only match at the very end of the search
                 // region if the last line doesn't have a linebreak
                 // and we're at the end of the buffer.
                 if index < length || (index = length && lastLineHasNoLineBreak && index = snapshot.Length) then

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -1229,7 +1229,25 @@ type internal CommonOperations
 
                 // We can only match the very end of the replacement
                 // region if the last line doesn't have a linebreak.
-                index < length || (index = length && lastLineHasNoLineBreak && index = snapshot.Length)
+                if index < length || (index = length && lastLineHasNoLineBreak && index = snapshot.Length) then
+                    if regex.MatchesVisualSelection then
+
+                        // If the pattern includes '\%V', we need to check the match
+                        // against the last visual selection.
+                        let visualSelection = _vimTextBuffer.LastVisualSelection
+                        match visualSelection with
+                        | None -> false
+                        | Some visualSelection ->
+
+                            // Is the match entirely within the visual selection?
+                            let selectionStartIndex = visualSelection.VisualSpan.Start.Position - startPosition
+                            let selectionEndIndex = visualSelection.VisualSpan.End.Position - startPosition
+                            let isInSelection = index >= selectionStartIndex && index < selectionEndIndex
+                            isInSelection
+                    else
+                        true
+                else
+                    false
             else
                 false
 

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -1228,7 +1228,8 @@ type internal CommonOperations
                 let length = endPosition - startPosition
 
                 // We can only match the very end of the replacement
-                // region if the last line doesn't have a linebreak.
+                // region if the last line doesn't have a linebreak
+                // and we're at the end of the buffer.
                 if index < length || (index = length && lastLineHasNoLineBreak && index = snapshot.Length) then
                     if regex.MatchesVisualSelection then
 
@@ -1240,12 +1241,9 @@ type internal CommonOperations
                         | Some visualSelection ->
 
                             // Is the match entirely within the visual selection?
-                            let startIndex = visualSelection.VisualSpan.Start.Position - startPosition
-                            let endIndex = visualSelection.VisualSpan.End.Position - startPosition
-                            let startsInSelection = index >= startIndex && index < endIndex
-                            let matchEndIndex = index + capture.Length
-                            let endsInSelection = matchEndIndex >= startIndex && matchEndIndex <= endIndex
-                            startsInSelection && endsInSelection
+                            let selectionStartIndex = visualSelection.VisualSpan.Start.Position - startPosition
+                            let selectionEndIndex = visualSelection.VisualSpan.End.Position - startPosition
+                            index >= selectionStartIndex && index + capture.Length <= selectionEndIndex
                     else
                         true
                 else

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -1240,10 +1240,12 @@ type internal CommonOperations
                         | Some visualSelection ->
 
                             // Is the match entirely within the visual selection?
-                            let selectionStartIndex = visualSelection.VisualSpan.Start.Position - startPosition
-                            let selectionEndIndex = visualSelection.VisualSpan.End.Position - startPosition
-                            let isInSelection = index >= selectionStartIndex && index < selectionEndIndex
-                            isInSelection
+                            let startIndex = visualSelection.VisualSpan.Start.Position - startPosition
+                            let endIndex = visualSelection.VisualSpan.End.Position - startPosition
+                            let startsInSelection = index >= startIndex && index < endIndex
+                            let matchEndIndex = index + capture.Length
+                            let endsInSelection = matchEndIndex >= startIndex && matchEndIndex <= endIndex
+                            startsInSelection && endsInSelection
                     else
                         true
                 else

--- a/Src/VimCore/VimRegex.fs
+++ b/Src/VimCore/VimRegex.fs
@@ -577,7 +577,7 @@ module VimRegexFactory =
         | ']' -> if data.IsCollectionOpen then data.EndCollection() else data.AppendEscapedChar(']')
         | 'd' -> data.AppendString @"\d"
         | 'D' -> data.AppendString @"\D"
-        | 's' -> data.AppendString "[ \t]"
+        | 's' -> data.AppendString "[ \t]" // Purposely not verbatim to get tab
         | 'S' -> data.AppendString @"\S"
         | 'w' -> data.AppendString @"\w"
         | 'W' -> data.AppendString @"\W"

--- a/Src/VimCore/VimRegex.fs
+++ b/Src/VimCore/VimRegex.fs
@@ -577,7 +577,7 @@ module VimRegexFactory =
         | ']' -> if data.IsCollectionOpen then data.EndCollection() else data.AppendEscapedChar(']')
         | 'd' -> data.AppendString @"\d"
         | 'D' -> data.AppendString @"\D"
-        | 's' -> data.AppendString ("[" + NamedCollectionMap.["space"] + "]")
+        | 's' -> data.AppendString ("[" + NamedCollectionMap.["blank"] + "]")
         | 'S' -> data.AppendString @"\S"
         | 'w' -> data.AppendString @"\w"
         | 'W' -> data.AppendString @"\W"

--- a/Src/VimCore/VimRegex.fs
+++ b/Src/VimCore/VimRegex.fs
@@ -681,7 +681,7 @@ module VimRegexFactory =
                 | 's' -> data.AppendString @"\s"
                 | '^' -> data.AppendChar '^'
                 | '$' -> data.AppendChar '$'
-                | '.' -> data.AppendString @"(.|\n)"
+                | '.' -> data.AppendString (@"(.|" + NewLineRegex + @")")
                 | _ -> data.Break()
         | 'v' -> ConvertCharAsSpecial data c
         | 'V' -> ConvertCharAsSpecial data c

--- a/Src/VimCore/VimRegex.fs
+++ b/Src/VimCore/VimRegex.fs
@@ -577,7 +577,7 @@ module VimRegexFactory =
         | ']' -> if data.IsCollectionOpen then data.EndCollection() else data.AppendEscapedChar(']')
         | 'd' -> data.AppendString @"\d"
         | 'D' -> data.AppendString @"\D"
-        | 's' -> data.AppendString @"\s"
+        | 's' -> data.AppendString "[ \t]"
         | 'S' -> data.AppendString @"\S"
         | 'w' -> data.AppendString @"\w"
         | 'W' -> data.AppendString @"\W"
@@ -678,6 +678,7 @@ module VimRegexFactory =
             | Some c -> 
                 data.IncrementIndex 1
                 match c with 
+                | 's' -> data.AppendString @"\s"
                 | '^' -> data.AppendChar '^'
                 | '$' -> data.AppendChar '$'
                 | '.' -> data.AppendString @"(.|\n)"

--- a/Src/VimCore/VimRegex.fs
+++ b/Src/VimCore/VimRegex.fs
@@ -428,7 +428,7 @@ module VimRegexFactory =
             ("upper", "A-Z")
             ("xdigit", "A-Fa-f0-9")
             ("return", StringUtil.OfChar CharCodes.Enter)
-            ("tab", "`t")
+            ("tab", "\t")
             ("escape", StringUtil.OfChar CharCodes.Escape)
             ("backspace", StringUtil.OfChar CharCodes.Backspace)
         |] |> Map.ofArray
@@ -577,7 +577,7 @@ module VimRegexFactory =
         | ']' -> if data.IsCollectionOpen then data.EndCollection() else data.AppendEscapedChar(']')
         | 'd' -> data.AppendString @"\d"
         | 'D' -> data.AppendString @"\D"
-        | 's' -> data.AppendString "[ \t]" // Purposely not verbatim to get tab
+        | 's' -> data.AppendString ("[" + NamedCollectionMap.["space"] + "]")
         | 'S' -> data.AppendString @"\S"
         | 'w' -> data.AppendString @"\w"
         | 'W' -> data.AppendString @"\W"

--- a/Src/VimCore/VimRegex.fs
+++ b/Src/VimCore/VimRegex.fs
@@ -403,7 +403,7 @@ module VimRegexFactory =
 
     let ControlCharString = GenerateCharString CharUtil.IsControl
     let PunctuationCharString = GenerateCharString Char.IsPunctuation
-    let SpaceCharString = GenerateCharString Char.IsWhiteSpace
+    let SpaceCharString = (GenerateCharString Char.IsWhiteSpace).Replace("\n", "") // vim excludes newline
     let BlankCharString = " \t"
 
     let BlankCharRegex = "[" + BlankCharString + "]"
@@ -685,10 +685,14 @@ module VimRegexFactory =
             | Some c -> 
                 data.IncrementIndex 1
                 match c with 
-                | 's' -> data.AppendString (CombineAlternatives BlankCharRegex NewLineRegex)
+                | 's' ->
+                    data.AppendString (CombineAlternatives BlankCharRegex NewLineRegex)
+                    data.IncludesNewLine <- true
                 | '^' -> data.AppendChar '^'
                 | '$' -> data.AppendChar '$'
-                | '.' -> data.AppendString (CombineAlternatives "." NewLineRegex)
+                | '.' ->
+                    data.AppendString (CombineAlternatives "." NewLineRegex)
+                    data.IncludesNewLine <- true
                 | _ -> data.Break()
         | 'v' -> ConvertCharAsSpecial data c
         | 'V' -> ConvertCharAsSpecial data c

--- a/Src/VimCore/VimRegex.fs
+++ b/Src/VimCore/VimRegex.fs
@@ -678,7 +678,7 @@ module VimRegexFactory =
             | Some c -> 
                 data.IncrementIndex 1
                 match c with 
-                | 's' -> data.AppendString @"\s"
+                | 's' -> data.AppendString (@"([" + NamedCollectionMap.["blank"] + "]|" + NewLineRegex + @")")
                 | '^' -> data.AppendChar '^'
                 | '$' -> data.AppendChar '$'
                 | '.' -> data.AppendString (@"(.|" + NewLineRegex + @")")

--- a/Src/VimCore/VimRegex.fsi
+++ b/Src/VimCore/VimRegex.fsi
@@ -13,6 +13,9 @@ type VimRegex =
     /// The pattern includes a new line reference (\n not $).  
     member IncludesNewLine: bool
 
+    /// The pattern matches the visual selection.
+    member MatchesVisualSelection: bool
+
     /// Pattern of the BCL version of the regular expression
     member RegexPattern: string
 

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -1080,6 +1080,14 @@ namespace Vim.UnitTest
                 }
 
                 [WpfFact]
+                public void MultilineReplaceWholeShebang()
+                {
+                    Create("foo", "bar", "baz", "qux");
+                    RunCommand(@"s/foo\_.*qux/xyzzy/");
+                    Assert.Equal(new[] { "xyzzy" }, _textBuffer.GetLines());
+                }
+
+                [WpfFact]
                 public void FirstThroughLastWithTrailingLineBreak()
                 {
                     Create("cat", "dog", "");

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -1088,6 +1088,33 @@ namespace Vim.UnitTest
                 }
 
                 [WpfFact]
+                public void ReplaceInVisualSelection()
+                {
+                    // Reported in issue #2147.
+                    Create("    foo bar baz qux    ");
+                    _vimBuffer.Process("wv4e");
+                    Assert.Equal(ModeKind.VisualCharacter, _vimBuffer.ModeKind);
+                    Assert.Equal("foo bar baz qux", _textView.GetSelectionSpan().GetText());
+                    RunCommand(@"s/\%V /_/g");
+                    Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+                    Assert.Equal(new[] { "    foo_bar_baz_qux    " }, _textBuffer.GetLines());
+                }
+
+                [WpfFact]
+                public void ReplaceInPreviousVisualSelection()
+                {
+                    // Reported in issue #2147.
+                    Create("    foo bar baz qux    ");
+                    _vimBuffer.Process("wv4e");
+                    Assert.Equal(ModeKind.VisualCharacter, _vimBuffer.ModeKind);
+                    Assert.Equal("foo bar baz qux", _textView.GetSelectionSpan().GetText());
+                    _vimBuffer.ProcessNotation("<Esc>");
+                    Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+                    RunCommand(@"s/\%V /_/g");
+                    Assert.Equal(new[] { "    foo_bar_baz_qux    " }, _textBuffer.GetLines());
+                }
+
+                [WpfFact]
                 public void FirstThroughLastWithTrailingLineBreak()
                 {
                     Create("cat", "dog", "");

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -1056,6 +1056,30 @@ namespace Vim.UnitTest
                 }
 
                 [WpfFact]
+                public void MultilineReplaceFirstLine()
+                {
+                    Create("foo", "bar", "baz");
+                    RunCommand(@"s/foo\nbar/qux/");
+                    Assert.Equal(new[] { "qux", "baz" }, _textBuffer.GetLines());
+                }
+
+                [WpfFact]
+                public void MultilineReplaceWholeBufferAtBeginning()
+                {
+                    Create("foo", "bar", "baz");
+                    RunCommand(@"%s/foo\nbar/qux/");
+                    Assert.Equal(new[] { "qux", "baz" }, _textBuffer.GetLines());
+                }
+
+                [WpfFact]
+                public void MultilineReplaceWholeBufferAtEnd()
+                {
+                    Create("foo", "bar", "baz");
+                    RunCommand(@"%s/bar\nbaz/qux/");
+                    Assert.Equal(new[] { "foo", "qux" }, _textBuffer.GetLines());
+                }
+
+                [WpfFact]
                 public void FirstThroughLastWithTrailingLineBreak()
                 {
                     Create("cat", "dog", "");


### PR DESCRIPTION
### Changes

- Support multiline substitution
- Support `\%V` special pattern during substitution to mean "match is entirely within the visual selection"

### Fixes

- Fixes #1155 
- Fixes #2147

### Discussion

This was by far the hardest change I've implemented. VsVim previously performed all its substitutions on a line-by-line basis (literally), making multiline substitution impossible. First I tried to use the editor search service but that turned out to be problematic. I'm somewhat nervous about changing something that is so central to vim, but I feel like I understand the problem and all the changes are for the better.

It would be possible to use the old code when not doing multiline substitutions and only use the new code for multiline, but the new code also handles the single line case so it seems better to have just one way to do it.