### PR TITLE
Blocks and token matching

### DIFF
--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -341,8 +341,8 @@ module internal SeqUtil =
                     yield e.Current }
         inner count
 
-    /// Same functionality as Seq.tryFind except it allows you to pass along a 
-    /// state value along 
+    /// Same functionality as Seq.tryFind except it allows you to pass
+    /// a state value along 
     let tryFind initialState predicate (sequence: 'a seq) =
         use e = sequence.GetEnumerator()
         let rec inner state = 

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -428,8 +428,8 @@ type internal BlockUtil() =
         // Compute a tuple of three quantities:
         // - Whether the target point is inside a string literal
         // - The start point of the string, as long as it there
-        //   is no unbalanced start character between the beginning
-        //   and the target
+        //   is no unmatched start character in string literals
+        //   before the target
         // - The quote character used to delineate the string
         let isInStringLiteral (target: SnapshotPoint) (sequence: SnapshotPoint seq) =
             let mutable escape = false
@@ -452,7 +452,7 @@ type internal BlockUtil() =
                             | Some _ when c = '\\' -> escape <- true
                             | _ -> ()
                     if point = target then
-                        if depth = 0 then
+                        if depth <= 0 then
                             result <- true, start, quote
                         else
                             result <- true, None, quote
@@ -463,7 +463,6 @@ type internal BlockUtil() =
                 elif c = '\'' || c = '\"' then
                     quote <- Some c
                     start <- Some point
-                    depth <- 0
 
             result
 

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -448,7 +448,7 @@ type internal BlockUtil() =
                             escape <- true
                         else
                             match quote with
-                            | Some quoteChar when c = '\n' || isChar quoteChar point -> quote <- None
+                            | Some quoteChar when c = '\n' || c = quoteChar -> quote <- None
                             | Some _ when c = '\\' -> escape <- true
                             | _ -> ()
                     if point = target then
@@ -520,7 +520,7 @@ type internal BlockUtil() =
                             escape <- false
                         else
                             match quote with
-                            | Some quoteChar when c = '\n' || isChar quoteChar point -> quote <- None
+                            | Some quoteChar when c = '\n' || c = quoteChar -> quote <- None
                             | Some _ when c = '\\' -> escape <- true
                             | _ -> ()
                             if endPointIsInStringLiteral then yield point

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -589,16 +589,15 @@ type MatchingTokenUtil() =
                     index <- index + 1
 
                     // If we're in a string literal, just keep advancing until
-                    // we encounter the matching quote.
+                    // we encounter the matching quote (but not past end-of-line).
                     match quote with
-                    | Some _ when c = '\\' ->
-                        if index < length then
-
-                            // Skip escaped character.
-                            index <- index + 1
+                    | Some _ when c = '\\' -> if index < length then index <- index + 1
+                    | Some _ when c = '\n' -> quote <- None
                     | Some quoteChar when quoteChar = c -> quote <- None
                     | _ -> ()
                 elif c = '\'' || c = '\"' then
+
+                    // Starting a new string literal.
                     quote <- Some c
                     index <- index + 1
                 elif c = startChar then 

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -355,7 +355,7 @@ type internal BlockUtil() =
 
         // Blocks in vim are a messy combination of heuristics and
         // a lot of special cases. The main complication is the
-        // handling of parentheses is string and character literals.
+        // handling of parentheses in string and character literals.
         // The idea is to match parentheses the same way that the
         // programming language would, that is if they are syntactic
         // elements, match them that way, and if they are string
@@ -373,9 +373,9 @@ type internal BlockUtil() =
         // comments can also be problematic, but vim does very little
         // to accomodate those cases.
 
-        // However, this is an inexact science because different
+        // In any case, this is an inexact science because different
         // programming languages have different ways of representing
-        // and encoding strings. The goal is do the intuitive thing
+        // and encoding strings. The goal is to do the intuitive thing
         // from a programming point of view in as many cases as
         // possible.
 
@@ -425,9 +425,12 @@ type internal BlockUtil() =
 
         let snapshot = SnapshotPointUtil.GetSnapshot contextPoint
 
-        // Parse from the beginning of the line and return the
-        // start of the containing string literal if there are
-        // no preceding block start characters in the literal.
+        // Compute a tuple of three quantities:
+        // - Whether the target point is inside a string literal
+        // - The start point of the string, as long as it there
+        //   is not a start character between the beginning and
+        //   the target
+        // - The quote character used to delineate the string
         let isInStringLiteral (target: SnapshotPoint) (sequence: SnapshotPoint seq) =
             let mutable escape = false
             let mutable quote = None
@@ -538,7 +541,7 @@ type internal BlockUtil() =
                 |> filterToContextForward endPointQuote
                 |> SeqUtil.tryFind 0 (findMatched startChar endChar)
 
-        // Return the same from the block start to block end.
+        // Return the span from the block start to block end.
         match startPoint, lastPoint with
         | Some startPoint, Some lastPoint -> Some (startPoint, lastPoint)
         | _ -> None

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -434,9 +434,9 @@ type internal BlockUtil() =
         let isInStringLiteral (target: SnapshotPoint) (sequence: SnapshotPoint seq) =
             let mutable escape = false
             let mutable quote = None
-            let mutable currentResult = false, None, quote
-            let mutable result = currentResult
+            let mutable start = None
             let mutable depth = 0
+            let mutable result = false, None, None
 
             for point in sequence do
                 let c = SnapshotUtil.GetChar point.Position snapshot
@@ -453,7 +453,7 @@ type internal BlockUtil() =
                             | _ -> ()
                     if point = target then
                         if depth = 0 then
-                            result <- currentResult
+                            result <- true, start, quote
                         else
                             result <- true, None, quote
                     elif c = startChar then
@@ -462,8 +462,8 @@ type internal BlockUtil() =
                         depth <- depth - 1
                 elif c = '\'' || c = '\"' then
                     quote <- Some c
+                    start <- Some point
                     depth <- 0
-                    currentResult <- true, Some point, quote
 
             result
 

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -348,6 +348,202 @@ type MatchingTokenKind =
 
     | Braces
 
+type internal BlockUtil() =
+
+    /// Get the block span for the specified char at the given context point
+    member x.GetBlock (blockKind: BlockKind) contextPoint =
+
+        // Blocks in vim are a messy combination of heuristics and
+        // a lot of special cases. The main complication is the
+        // handling of parentheses is string and character literals.
+        // The idea is to match parentheses the same way that the
+        // programming language would, that is if they are syntactic
+        // elements, match them that way, and if they are string
+        // elements, match them that way instead.
+
+        // If the context point for a block is outside a string literal,
+        // we don't want unbalanced parentheses in strings throwing us
+        // off. Likewise, if we are inside a string literal, we don't
+        // want a parenthesis inside the string to match a syntactic
+        // parenthesis outside the string. So if possible we want
+        // to allow valid blocks in, say, a regular expression in
+        // a string, as well as valid syntactic expression blocks.
+
+        // Likewise, unbalances parentheses or stray quote marks in
+        // comments can also be problematic, but vim does very little
+        // to accomodate those cases.
+
+        // However, this is an inexact science because different
+        // programming languages have different ways of representing
+        // and encoding strings. The goal is do the intuitive thing
+        // from a programming point of view in as many cases as
+        // possible.
+
+        // Our "univeral string" (covering common cases in C, C++, C#,
+        // F#, Python and Java, etc.) is text surrounded with single
+        // or double quotes and using backslash to escape the quote
+        // character.
+
+        // A more robust solution would be to use an abstract syntax
+        // tree supplied by a language service appropriate for the
+        // current buffer but even that approach has drawbacks. The
+        // current approach works as well for a programming snippet
+        // in a text file as it does in an actual source file.
+
+        let startChar, endChar = blockKind.Characters
+
+        // Is the char at the given point escaped?
+        let isEscaped point =
+            match SnapshotPointUtil.TrySubtractOne point with
+            | None -> false
+            | Some point -> SnapshotPointUtil.GetChar point = '\\'
+
+        // Is the char at the given point double escaped?
+        let isDoubleEscaped point =
+            match SnapshotPointUtil.TrySubtract point 2, SnapshotPointUtil.TrySubtract point 2 with
+            | None, _
+            | _, None -> false
+            | Some point1, Some point2 -> SnapshotPointUtil.GetChar point1 = '\\' && SnapshotPointUtil.GetChar point2 = '\\'
+
+        // Is the char at the given point unescaped and equal to the specified character?
+        let isChar c point = SnapshotPointUtil.GetChar point = c && (not (isEscaped point) || isDoubleEscaped point)
+
+        // Given the specified block start and end characters, return a
+        // function that transform a tuple of a point and the current nesting
+        // count into a tuple of final success and the next nesting count.
+        let findMatched plusChar minusChar =
+            let inner point count =
+                let count =
+                    if isChar minusChar point then
+                        count - 1
+                    elif isChar plusChar point then
+                        count + 1
+                    else
+                        count
+                count = 0, count
+            inner
+
+        let snapshot = SnapshotPointUtil.GetSnapshot contextPoint
+
+        // Parse from the beginning of the line and return the
+        // start of the containing string literal if there are
+        // no preceding block start characters in the literal.
+        let isInStringLiteral (target: SnapshotPoint) (sequence: SnapshotPoint seq) =
+            let mutable escape = false
+            let mutable quote = None
+            let mutable currentResult = false, None, quote
+            let mutable result = currentResult
+
+            for point in sequence do
+                let c = SnapshotUtil.GetChar point.Position snapshot
+                if quote <> None then
+                    if escape then
+                        escape <- false
+                    else
+                        if c = '\\' then
+                            escape <- true
+                        else
+                            match quote with
+                            | Some quoteChar when c = '\n' || isChar quoteChar point -> quote <- None
+                            | Some _ when c = '\\' -> escape <- true
+                            | _ -> ()
+                    if point = target then
+                        result <- currentResult
+                    elif c = startChar then
+                        currentResult <- true, None, quote
+                elif c = '\'' || c = '\"' then
+                    quote <- Some c
+                    currentResult <- true, Some point, quote
+
+            result
+
+        // Choose a starting point within the block.
+        let endPoint =
+            if isChar startChar contextPoint then
+                SnapshotPointUtil.AddOneOrCurrent contextPoint
+            else
+                contextPoint
+
+        // Go to the beginning of the line and then scan forward to
+        // the beginning of the containing string literal, if any.
+        let endPoint, endPointIsInStringLiteral, endPointQuote =
+            match
+                SnapshotPointUtil.GetContainingLine endPoint
+                |> SnapshotLineUtil.GetExtent
+                |> SnapshotSpanUtil.GetPoints SearchPath.Forward
+                |> isInStringLiteral endPoint
+                with
+                | true, Some adjustedEndPoint, _ -> adjustedEndPoint, false, None
+                | true, None, Some quoteChar -> endPoint, true, Some quoteChar
+                | _ -> endPoint, false, None
+
+        // Parse backward skipping non-string literals
+        // if the context is a string literal and skipping
+        // string literals otherwise.
+        let filterToContextBackward endPointQuote (sequence: SnapshotPoint seq) =
+            if endPointIsInStringLiteral then sequence else
+            let mutable quote: char option = endPointQuote
+            seq {
+                for point in sequence do
+                    let c = SnapshotUtil.GetChar point.Position snapshot
+                    if quote <> None then
+                        match quote with
+                        | Some quoteChar when c = '\n' || isChar quoteChar point -> quote <- None
+                        | _ -> ()
+                        if endPointIsInStringLiteral then yield point
+                    elif c = '\'' || c = '\"' then
+                        quote <- Some c
+                    else
+                        if not endPointIsInStringLiteral then yield point
+            }
+
+        // Parse forward skipping non-string literals
+        // if the context is a string literal and skipping
+        // string literals otherwise.
+        let filterToContextForward endPointQuote (sequence: SnapshotPoint seq) =
+            let mutable escape = false
+            let mutable quote: char option = endPointQuote
+            seq {
+                for point in sequence do
+                    let c = SnapshotUtil.GetChar point.Position snapshot
+                    if quote <> None then
+                        if escape then
+                            escape <- false
+                        else
+                            match quote with
+                            | Some quoteChar when c = '\n' || isChar quoteChar point -> quote <- None
+                            | Some _ when c = '\\' -> escape <- true
+                            | _ -> ()
+                            if endPointIsInStringLiteral then yield point
+                    elif c = '\'' || c = '\"' then
+                        quote <- Some c
+                    else
+                        if not endPointIsInStringLiteral then yield point
+            }
+
+        // Search backward for the character that starts this block.
+        let startPoint =
+            SnapshotSpan(SnapshotPoint(snapshot, 0), endPoint)
+            |> SnapshotSpanUtil.GetPoints SearchPath.Backward
+            |> filterToContextBackward endPointQuote
+            |> SeqUtil.tryFind 1 (findMatched endChar startChar)
+
+        // Then search forward for the character that ends this block.
+        let lastPoint =
+            match startPoint with
+            | None -> None
+            | Some startPoint ->
+                SnapshotSpan(startPoint, SnapshotUtil.GetEndPoint snapshot)
+                |> SnapshotSpanUtil.GetPoints SearchPath.Forward
+                |> filterToContextForward endPointQuote
+                |> SeqUtil.tryFind 0 (findMatched startChar endChar)
+
+        // Return the same from the block start to block end.
+        match startPoint, lastPoint with
+        | Some startPoint, Some lastPoint -> Some (startPoint, lastPoint)
+        | _ -> None
+
+
 type MatchingTokenUtil() = 
 
     /// This is the key for accessing directive blocks within the ITextSnapshot.  This
@@ -576,70 +772,15 @@ type MatchingTokenUtil() =
 
         // Find the matching character for the one which occurs at the specified
         // SnapshotPoint
-        let findMatchingTokenChar target startChar endChar = 
-            let stack = Stack<int>()
-            let length = SnapshotUtil.GetLength snapshot
-            let mutable found: int option = None
-            let mutable targetDepth: int option = None
-            let mutable quote: char option = None
-            let mutable index = 0
-            while index < length do
-                let c = SnapshotUtil.GetChar index snapshot
-                if quote <> None then
-                    index <- index + 1
-
-                    // If we're in a string literal, just keep advancing until
-                    // we encounter the matching quote (but not past end-of-line).
-                    match quote with
-                    | Some _ when c = '\\' -> if index < length then index <- index + 1
-                    | Some _ when c = '\n' -> quote <- None
-                    | Some quoteChar when quoteChar = c -> quote <- None
-                    | _ -> ()
-                elif c = '\'' || c = '\"' then
-
-                    // Starting a new string literal.
-                    quote <- Some c
-                    index <- index + 1
-                elif c = startChar then 
-
-                    // If this is our starting character then the matching token occurs
-                    // when the depth once again hits the current depth
-                    if index = target then
-                        targetDepth <- Some stack.Count
-
-                    stack.Push index
-                    index <- index + 1
-                elif c = endChar then 
-
-                    if index = target then
-                        // We are currently at the targeted char and it's an end marker
-                        // so whatever the beginning marker is is the matching token
-                        if stack.Count > 0 then
-                            found <- stack.Peek() |> Some
-
-                        index <- length
-                    elif stack.Count > 0 then
-                        stack.Pop()  |> ignore
-                        match targetDepth with
-                        | None -> index <- index + 1
-                        | Some size ->
-
-                            // If we make it back down to the depth that we were targeting
-                            // when we saw the start character then this is the matching token
-                            if size = stack.Count then
-                                found <- Some index
-                                index <- length
-                            else
-                                index <- index + 1
-
-                    else
-                        index <- index + 1
-                else
-                    index <- index + 1
-
-            match found with
+        let findMatchingTokenChar target (blockKind: BlockKind) =
+            let contextPoint = new SnapshotPoint(snapshot, target)
+            let blockUtil = BlockUtil()
+            match blockUtil.GetBlock blockKind contextPoint with
+            | Some (startPoint, endPoint) ->
+                let otherPoint = if contextPoint = startPoint then endPoint else startPoint
+                let snapshotSpan = new SnapshotSpan(otherPoint, 1)
+                Some snapshotSpan.Span
             | None -> None
-            | Some start -> Span(start, 1) |> Some
 
         // Find the comment matching the comment marker on the specified line
         let findMatchingComment target = 
@@ -730,9 +871,9 @@ type MatchingTokenUtil() =
             | Some (column, kind) ->
                 let position = line.Start.Position + column
                 match kind with 
-                | MatchingTokenKind.Braces -> findMatchingTokenChar position '{' '}'
-                | MatchingTokenKind.Brackets -> findMatchingTokenChar position '[' ']'
-                | MatchingTokenKind.Parens -> findMatchingTokenChar position '(' ')'
+                | MatchingTokenKind.Braces -> findMatchingTokenChar position BlockKind.CurlyBracket
+                | MatchingTokenKind.Brackets -> findMatchingTokenChar position BlockKind.Bracket
+                | MatchingTokenKind.Parens -> findMatchingTokenChar position BlockKind.Paren
                 | MatchingTokenKind.Directive -> findMatchingDirective position
                 | MatchingTokenKind.Comment -> findMatchingComment position
 
@@ -1081,196 +1222,8 @@ type internal MotionUtil
 
     /// Get the block span for the specified char at the given context point
     member x.GetBlock (blockKind: BlockKind) contextPoint =
-
-        // Blocks in vim are a messy combination of heuristics and
-        // a lot of special cases. The main complication is the
-        // handling of parentheses is string and character literals.
-        // The idea is to match parentheses the same way that the
-        // programming language would, that is if they are syntactic
-        // elements, match them that way, and if they are string
-        // elements, match them that way instead.
-
-        // If the context point for a block is outside a string literal,
-        // we don't want unbalanced parentheses in strings throwing us
-        // off. Likewise, if we are inside a string literal, we don't
-        // want a parenthesis inside the string to match a syntactic
-        // parenthesis outside the string. So if possible we want
-        // to allow valid blocks in, say, a regular expression in
-        // a string, as well as valid syntactic expression blocks.
-
-        // Likewise, unbalances parentheses or stray quote marks in
-        // comments can also be problematic, but vim does very little
-        // to accomodate those cases.
-
-        // However, this is an inexact science because different
-        // programming languages have different ways of representing
-        // and encoding strings. The goal is do the intuitive thing
-        // from a programming point of view in as many cases as
-        // possible.
-
-        // Our "univeral string" (covering common cases in C, C++, C#,
-        // F#, Python and Java, etc.) is text surrounded with single
-        // or double quotes and using backslash to escape the quote
-        // character.
-
-        // A more robust solution would be to use an abstract syntax
-        // tree supplied by a language service appropriate for the
-        // current buffer but even that approach has drawbacks. The
-        // current approach works as well for a programming snippet
-        // in a text file as it does in an actual source file.
-
-        let startChar, endChar = blockKind.Characters
-
-        // Is the char at the given point escaped?
-        let isEscaped point =
-            match SnapshotPointUtil.TrySubtractOne point with
-            | None -> false
-            | Some point -> SnapshotPointUtil.GetChar point = '\\'
-
-        // Is the char at the given point double escaped?
-        let isDoubleEscaped point =
-            match SnapshotPointUtil.TrySubtract point 2, SnapshotPointUtil.TrySubtract point 2 with
-            | None, _
-            | _, None -> false
-            | Some point1, Some point2 -> SnapshotPointUtil.GetChar point1 = '\\' && SnapshotPointUtil.GetChar point2 = '\\'
-
-        // Is the char at the given point unescaped and equal to the specified character?
-        let isChar c point = SnapshotPointUtil.GetChar point = c && (not (isEscaped point) || isDoubleEscaped point)
-
-        // Given the specified block start and end characters, return a
-        // function that transform a tuple of a point and the current nesting
-        // count into a tuple of final success and the next nesting count.
-        let findMatched plusChar minusChar =
-            let inner point count =
-                let count =
-                    if isChar minusChar point then
-                        count - 1
-                    elif isChar plusChar point then
-                        count + 1
-                    else
-                        count
-                count = 0, count
-            inner
-
-        let snapshot = SnapshotPointUtil.GetSnapshot contextPoint
-
-        // Parse from the beginning of the line and return the
-        // start of the containing string literal if there are
-        // no preceding block start characters in the literal.
-        let isInStringLiteral (target: SnapshotPoint) (sequence: SnapshotPoint seq) =
-            let mutable escape = false
-            let mutable quote = None
-            let mutable currentResult = false, None, quote
-            let mutable result = currentResult
-
-            for point in sequence do
-                let c = SnapshotUtil.GetChar point.Position snapshot
-                if quote <> None then
-                    if escape then
-                        escape <- false
-                    else
-                        if c = '\\' then
-                            escape <- true
-                        else
-                            match quote with
-                            | Some quoteChar when c = '\n' || isChar quoteChar point -> quote <- None
-                            | Some _ when c = '\\' -> escape <- true
-                            | _ -> ()
-                    if point = target then
-                        result <- currentResult
-                    elif c = startChar then
-                        currentResult <- true, None, quote
-                elif c = '\'' || c = '\"' then
-                    quote <- Some c
-                    currentResult <- true, Some point, quote
-
-            result
-
-        // Choose a starting point within the block.
-        let endPoint =
-            if isChar startChar contextPoint then
-                SnapshotPointUtil.AddOneOrCurrent contextPoint
-            else
-                contextPoint
-
-        // Go to the beginning of the line and then scan forward to
-        // the beginning of the containing string literal, if any.
-        let endPoint, endPointIsInStringLiteral, endPointQuote =
-            match
-                SnapshotPointUtil.GetContainingLine endPoint
-                |> SnapshotLineUtil.GetExtent
-                |> SnapshotSpanUtil.GetPoints SearchPath.Forward
-                |> isInStringLiteral endPoint
-                with
-                | true, Some adjustedEndPoint, _ -> adjustedEndPoint, false, None
-                | true, None, Some quoteChar -> endPoint, true, Some quoteChar
-                | _ -> endPoint, false, None
-
-        // Parse backward skipping non-string literals
-        // if the context is a string literal and skipping
-        // string literals otherwise.
-        let filterToContextBackward endPointQuote (sequence: SnapshotPoint seq) =
-            if endPointIsInStringLiteral then sequence else
-            let mutable quote: char option = endPointQuote
-            seq {
-                for point in sequence do
-                    let c = SnapshotUtil.GetChar point.Position snapshot
-                    if quote <> None then
-                        match quote with
-                        | Some quoteChar when c = '\n' || isChar quoteChar point -> quote <- None
-                        | _ -> ()
-                        if endPointIsInStringLiteral then yield point
-                    elif c = '\'' || c = '\"' then
-                        quote <- Some c
-                    else
-                        if not endPointIsInStringLiteral then yield point
-            }
-
-        // Parse forward skipping non-string literals
-        // if the context is a string literal and skipping
-        // string literals otherwise.
-        let filterToContextForward endPointQuote (sequence: SnapshotPoint seq) =
-            let mutable escape = false
-            let mutable quote: char option = endPointQuote
-            seq {
-                for point in sequence do
-                    let c = SnapshotUtil.GetChar point.Position snapshot
-                    if quote <> None then
-                        if escape then
-                            escape <- false
-                        else
-                            match quote with
-                            | Some quoteChar when c = '\n' || isChar quoteChar point -> quote <- None
-                            | Some _ when c = '\\' -> escape <- true
-                            | _ -> ()
-                            if endPointIsInStringLiteral then yield point
-                    elif c = '\'' || c = '\"' then
-                        quote <- Some c
-                    else
-                        if not endPointIsInStringLiteral then yield point
-            }
-
-        // Search backward for the character that starts this block.
-        let startPoint =
-            SnapshotSpan(SnapshotPoint(snapshot, 0), endPoint)
-            |> SnapshotSpanUtil.GetPoints SearchPath.Backward
-            |> filterToContextBackward endPointQuote
-            |> SeqUtil.tryFind 1 (findMatched endChar startChar)
-
-        // Then search forward for the character that ends this block.
-        let lastPoint =
-            match startPoint with
-            | None -> None
-            | Some startPoint ->
-                SnapshotSpan(startPoint, SnapshotUtil.GetEndPoint snapshot)
-                |> SnapshotSpanUtil.GetPoints SearchPath.Forward
-                |> filterToContextForward endPointQuote
-                |> SeqUtil.tryFind 0 (findMatched startChar endChar)
-
-        // Return the same from the block start to block end.
-        match startPoint, lastPoint with
-        | Some startPoint, Some lastPoint -> Some (startPoint, lastPoint)
-        | _ -> None
+        let blockUtil = BlockUtil()
+        blockUtil.GetBlock blockKind contextPoint
 
     member x.GetBlockWithCount (blockKind: BlockKind) contextPoint count = 
 

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -581,10 +581,27 @@ type MatchingTokenUtil() =
             let length = SnapshotUtil.GetLength snapshot
             let mutable found: int option = None
             let mutable targetDepth: int option = None
+            let mutable quote: char option = None
             let mutable index = 0
             while index < length do
                 let c = SnapshotUtil.GetChar index snapshot
-                if c = startChar then 
+                if quote <> None then
+                    index <- index + 1
+
+                    // If we're in a string literal, just keep advancing until
+                    // we encounter the matching quote.
+                    match quote with
+                    | Some _ when c = '\\' ->
+                        if index < length then
+
+                            // Skip escaped character.
+                            index <- index + 1
+                    | Some quoteChar when quoteChar = c -> quote <- None
+                    | _ -> ()
+                elif c = '\'' || c = '\"' then
+                    quote <- Some c
+                    index <- index + 1
+                elif c = startChar then 
 
                     // If this is our starting character then the matching token occurs
                     // when the depth once again hits the current depth

--- a/Test/VimCoreTest/MotionUtilTest.cs
+++ b/Test/VimCoreTest/MotionUtilTest.cs
@@ -381,6 +381,70 @@ namespace Vim.UnitTest
                 var span = _motionUtil.GetBlock(BlockKind.Bracket, _textBuffer.GetPoint(1));
                 Assert.True(span.IsNone());
             }
+
+            [WpfFact]
+            public void StringTrap_BeforeString()
+            {
+                Create("fun(a, \" (\", b) # bar");
+                var span = GetBlockSpan(BlockKind.Paren, _textBuffer.GetPoint(3));
+                Assert.Equal(_textBuffer.GetSpan(3, 12), span);
+            }
+
+            [WpfFact]
+            public void StringTrap_AtStartOfString()
+            {
+                Create("fun(a, \" (\", b) # bar");
+                var span = GetBlockSpan(BlockKind.Paren, _textBuffer.GetPoint(8));
+                Assert.Equal(_textBuffer.GetSpan(3, 12), span);
+            }
+
+            [WpfFact]
+            public void StringTrap_OnStartCharacter()
+            {
+                Create("fun(a, \" (\", b) # bar");
+                var span = _motionUtil.GetBlock(BlockKind.Paren, _textBuffer.GetPoint(9));
+                Assert.True(span.IsNone());
+            }
+
+            [WpfFact]
+            public void StringTrap_AfterString()
+            {
+                Create("fun(a, \" (\", b) # bar");
+                var span = GetBlockSpan(BlockKind.Paren, _textBuffer.GetPoint(14));
+                Assert.Equal(_textBuffer.GetSpan(3, 12), span);
+            }
+
+            [WpfFact]
+            public void BeforeBalancedString()
+            {
+                Create("fun(a, \"(foo)\", b) # bar");
+                var span = GetBlockSpan(BlockKind.Paren, _textBuffer.GetPoint(8));
+                Assert.Equal(_textBuffer.GetSpan(8, 5), span);
+            }
+
+            [WpfFact]
+            public void InBalancedString()
+            {
+                Create("fun(a, \"(foo)\", b) # bar");
+                var span = GetBlockSpan(BlockKind.Paren, _textBuffer.GetPoint(10));
+                Assert.Equal(_textBuffer.GetSpan(8, 5), span);
+            }
+
+            [WpfFact]
+            public void AfterBalancedString()
+            {
+                Create("fun(a, \"(foo)\", b) # bar");
+                var span = GetBlockSpan(BlockKind.Paren, _textBuffer.GetPoint(13));
+                Assert.Equal(_textBuffer.GetSpan(3, 15), span);
+            }
+
+            [WpfFact]
+            public void InSplitString()
+            {
+                Create("fun(a, \" ( \", b, \" ) \", c) # bar");
+                var span = GetBlockSpan(BlockKind.Paren, _textBuffer.GetPoint(10));
+                Assert.Equal(_textBuffer.GetSpan(9, 11), span);
+            }
         }
 
         public sealed class AllBlockTest : MotionUtilTest

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -969,6 +969,61 @@ namespace Vim.UnitTest
                 _vimBuffer.Process("%");
                 Assert.Equal(_textView.GetPointInLine(3, 0), _textView.GetCaretPoint());
             }
+
+            [WpfFact]
+            public void ParensWithCharacterLiteral()
+            {
+                // Reported in issue #2159.
+                Create("if (\"hello\".IndexOf('(') == 0)");
+                _textView.MoveCaretTo(3);
+                _vimBuffer.Process("%");
+                Assert.Equal(_textView.GetPointInLine(0, 29), _textView.GetCaretPoint());
+            }
+
+            [WpfFact]
+            public void AroundBalancedString()
+            {
+                Create("fun(a, \"(foo)\", b) # bar");
+                _textView.MoveCaretTo(3);
+                _vimBuffer.Process("%");
+                Assert.Equal(_textView.GetPointInLine(0, 17), _textView.GetCaretPoint());
+            }
+
+            [WpfFact]
+            public void InBalancedString()
+            {
+                Create("fun(a, \"(foo)\", b) # bar");
+                _textView.MoveCaretTo(8);
+                _vimBuffer.Process("%");
+                Assert.Equal(_textView.GetPointInLine(0, 12), _textView.GetCaretPoint());
+            }
+
+            [WpfFact]
+            public void InSplitString()
+            {
+                Create("fun(a, \" ( \", b, \" ) \", c) # bar");
+                _textView.MoveCaretTo(9);
+                _vimBuffer.Process("%");
+                Assert.Equal(_textView.GetPointInLine(0, 19), _textView.GetCaretPoint());
+            }
+
+            [WpfFact]
+            public void AroundSplitString()
+            {
+                Create("fun(a, \" ( \", b, \" ) \", c) # bar");
+                _textView.MoveCaretTo(3);
+                _vimBuffer.Process("%");
+                Assert.Equal(_textView.GetPointInLine(0, 25), _textView.GetCaretPoint());
+            }
+
+            [WpfFact]
+            public void AroundSplitUnbalancedString()
+            {
+                Create("fun(a, \" ) \", b, \" ( \", c) # bar");
+                _textView.MoveCaretTo(3);
+                _vimBuffer.Process("%");
+                Assert.Equal(_textView.GetPointInLine(0, 25), _textView.GetCaretPoint());
+            }
         }
 
         public sealed class UnmatchedTokenTest : NormalModeIntegrationTest

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -977,7 +977,9 @@ namespace Vim.UnitTest
                 Create("if (\"hello\".IndexOf('(') == 0)");
                 _textView.MoveCaretTo(3);
                 _vimBuffer.Process("%");
-                Assert.Equal(_textView.GetPointInLine(0, 29), _textView.GetCaretPoint());
+                Assert.Equal(29, _textView.GetCaretPoint().Position);
+                _vimBuffer.Process("%");
+                Assert.Equal(3, _textView.GetCaretPoint().Position);
             }
 
             [WpfFact]
@@ -986,7 +988,9 @@ namespace Vim.UnitTest
                 Create("fun(a, \"(foo)\", b) # bar");
                 _textView.MoveCaretTo(3);
                 _vimBuffer.Process("%");
-                Assert.Equal(_textView.GetPointInLine(0, 17), _textView.GetCaretPoint());
+                Assert.Equal(17, _textView.GetCaretPoint().Position);
+                _vimBuffer.Process("%");
+                Assert.Equal(3, _textView.GetCaretPoint().Position);
             }
 
             [WpfFact]
@@ -995,7 +999,9 @@ namespace Vim.UnitTest
                 Create("fun(a, \"(foo)\", b) # bar");
                 _textView.MoveCaretTo(8);
                 _vimBuffer.Process("%");
-                Assert.Equal(_textView.GetPointInLine(0, 12), _textView.GetCaretPoint());
+                Assert.Equal(12, _textView.GetCaretPoint().Position);
+                _vimBuffer.Process("%");
+                Assert.Equal(8, _textView.GetCaretPoint().Position);
             }
 
             [WpfFact]
@@ -1004,7 +1010,9 @@ namespace Vim.UnitTest
                 Create("fun(a, \" ( \", b, \" ) \", c) # bar");
                 _textView.MoveCaretTo(9);
                 _vimBuffer.Process("%");
-                Assert.Equal(_textView.GetPointInLine(0, 19), _textView.GetCaretPoint());
+                Assert.Equal(19, _textView.GetCaretPoint().Position);
+                _vimBuffer.Process("%");
+                Assert.Equal(9, _textView.GetCaretPoint().Position);
             }
 
             [WpfFact]
@@ -1013,7 +1021,9 @@ namespace Vim.UnitTest
                 Create("fun(a, \" ( \", b, \" ) \", c) # bar");
                 _textView.MoveCaretTo(3);
                 _vimBuffer.Process("%");
-                Assert.Equal(_textView.GetPointInLine(0, 25), _textView.GetCaretPoint());
+                Assert.Equal(25, _textView.GetCaretPoint().Position);
+                _vimBuffer.Process("%");
+                Assert.Equal(3, _textView.GetCaretPoint().Position);
             }
 
             [WpfFact]
@@ -1022,7 +1032,9 @@ namespace Vim.UnitTest
                 Create("fun(a, \" ) \", b, \" ( \", c) # bar");
                 _textView.MoveCaretTo(3);
                 _vimBuffer.Process("%");
-                Assert.Equal(_textView.GetPointInLine(0, 25), _textView.GetCaretPoint());
+                Assert.Equal(25, _textView.GetCaretPoint().Position);
+                _vimBuffer.Process("%");
+                Assert.Equal(3, _textView.GetCaretPoint().Position);
             }
         }
 


### PR DESCRIPTION
### Changes

- Convert `i(` (paren block motion), etc. and `%` (token matching) to use the same infrastructure
- Fix paren blocks, etc. to handle string and character literals
- Add tests for block and token matching corner cases

### Fixes

- Fixes #2159

### Discussion

There is a long comment in `GetBlock` discussing how vim behaves and how VsVim handles the problem. The idea is not to behave exactly as vim does, because it is not hard to trip up vim either, but to handle the most common cases that previously tripped up VsVim.