### PR TITLE
Block put

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -3251,6 +3251,10 @@ type internal CommandUtil
     member x.YankMotion registerName (result: MotionResult) =
         let value = x.CreateRegisterValue (StringData.OfSpan result.Span) result.OperationKind
         _commonOperations.SetRegisterValue registerName RegisterOperation.Yank value
+        match result.OperationKind with
+        | OperationKind.CharacterWise ->
+            TextViewUtil.MoveCaretToPoint _textView result.Start
+        | _ -> ()
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Yank the lines in the specified selection

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1970,6 +1970,18 @@ type internal CommandUtil
                     col |> Seq.iter (fun span -> edit.Delete(span) |> ignore)
                     edit.Apply() |> ignore
 
+                    // For character-wise put of simple text over a
+                    // block selection, replicate the text into a block.
+                    let stringData =
+                        match operationKind, stringData with
+                        | OperationKind.CharacterWise, StringData.Simple text ->
+                            seq { for _ in col do yield text }
+                            |> NonEmptyCollectionUtil.OfSeq 
+                            |> Option.get
+                            |> StringData.Block
+                        | _ ->
+                            stringData
+
                     // Now do a standard put operation.  The point of the put varies a bit
                     // based on whether we're doing a linewise or characterwise insert
                     let point =

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -1695,6 +1695,33 @@ namespace Vim.UnitTest
                 _vimBuffer.ProcessNotation("y$");
                 Assert.Equal("test", UnnamedRegister.StringValue);
             }
+
+            /// <summary>
+            /// Character-wise yank should leave the cursor at the beginning of what was yanked
+            /// </summary>
+            [WpfFact]
+            public void CharacterWiseYankCursor()
+            {
+                // Reported in issue #1900.
+                Create("cat dog", "");
+                _textView.MoveCaretTo(4);
+                _vimBuffer.ProcessNotation("y^");
+                Assert.Equal(0, _textView.GetCaretPoint().Position);
+                Assert.Equal("cat ", UnnamedRegister.StringValue);
+            }
+
+            /// <summary>
+            /// Line-wise yank should not move the cursor
+            /// </summary>
+            [WpfFact]
+            public void LineWiseYankCursor()
+            {
+                Create("cat dog", "");
+                _textView.MoveCaretTo(4);
+                _vimBuffer.ProcessNotation("yy");
+                Assert.Equal(4, _textView.GetCaretPoint().Position);
+                Assert.Equal("cat dog" + Environment.NewLine, UnnamedRegister.StringValue);
+            }
         }
 
         public sealed class FilterTest : NormalModeIntegrationTest

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -2305,7 +2305,7 @@ namespace Vim.UnitTest
                 UnnamedRegister.UpdateValue("fish", OperationKind.CharacterWise);
                 _vimBuffer.Process("p");
                 Assert.Equal("dfishg", _textView.GetLine(0).GetText());
-                Assert.Equal("ct", _textView.GetLine(1).GetText());
+                Assert.Equal("cfisht", _textView.GetLine(1).GetText());
                 Assert.Equal(4, _textView.GetCaretPoint().Position);
             }
 
@@ -2321,7 +2321,7 @@ namespace Vim.UnitTest
                 UnnamedRegister.UpdateValue("fish", OperationKind.CharacterWise);
                 _vimBuffer.Process("gp");
                 Assert.Equal("dfishg", _textView.GetLine(0).GetText());
-                Assert.Equal("ct", _textView.GetLine(1).GetText());
+                Assert.Equal("cfisht", _textView.GetLine(1).GetText());
                 Assert.Equal(5, _textView.GetCaretPoint().Position);
             }
 


### PR DESCRIPTION
### Changes

- After a character-wise yank, position the cursor at the beginning of what was yanked
- When putting simple text over a block selection, replicate the text being put

### Fixes

- Fixes #1900