### PR TITLE
Implement ':r!' to read from a command into the buffer

### DIFF
--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -202,7 +202,7 @@ type internal CommonOperations
             let replacement = EditUtil.RemoveEndingNewLine replacement
 
             // Normalize linebreaks.
-            let replacement = Regex.Replace(replacement, @"\r?\n", newLine)
+            let replacement = EditUtil.NormalizeNewLines replacement newLine
 
             // Replace the old lines with the filtered lines.
             _textBuffer.Replace(range.Extent.Span, replacement) |> ignore

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -2268,6 +2268,12 @@ module EditUtil =
                     inner (index + length)
         inner 0
 
+    /// Split a string into lines of text
+    let SplitLines (text: string) =
+        let text = RemoveEndingNewLine text
+        let text = NormalizeNewLines text "\n"
+        StringUtil.Split '\n' text
+
 /// In some cases we need to break a complete string into a series of text representations
 /// and new lines.  It's easiest to view this as a sequence of text values with their 
 /// associated line breaks

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -2049,6 +2049,7 @@ type Parser
             x.SkipBlanks()
             if _tokenizer.CurrentChar = '!' then
                 _tokenizer.MoveNextToken()
+                use resetFlags = _tokenizer.SetTokenizerFlagsScoped TokenizerFlags.AllowDoubleQuote
                 let command = x.ParseRestOfLine()
                 LineCommand.ReadCommand (lineRange, command)
             else

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -255,15 +255,18 @@ namespace Vim.UI.Wpf
             // Use a (generous) timeout since we have no way to interrupt it.
             var timeout = 30 * 1000;
 
+            // Avoid redirection for the 'start' command.
+            var doRedirect = !arguments.StartsWith("/c start ");
+
             // Populate the start info.
             var startInfo = new ProcessStartInfo
             {
                 FileName = command,
                 Arguments = arguments,
                 UseShellExecute = false,
-                RedirectStandardInput = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                RedirectStandardInput = doRedirect,
+                RedirectStandardOutput = doRedirect,
+                RedirectStandardError = doRedirect,
                 CreateNoWindow = true,
                 WorkingDirectory = vimdata.CurrentDirectory
             };
@@ -272,20 +275,27 @@ namespace Vim.UI.Wpf
             try
             {
                 var process = Process.Start(startInfo);
-                var stdin = process.StandardInput;
-                var stdout = process.StandardOutput;
-                var stderr = process.StandardError;
-                var stdinTask = Task.Run(() => { stdin.Write(input); stdin.Close(); });
-                var stdoutTask = Task.Run(() => stdout.ReadToEnd());
-                var stderrTask = Task.Run(() => stderr.ReadToEnd());
-                if (process.WaitForExit(timeout))
+                if (doRedirect)
                 {
-                    return new RunCommandResults(process.ExitCode, stdoutTask.Result, stderrTask.Result);
+                    var stdin = process.StandardInput;
+                    var stdout = process.StandardOutput;
+                    var stderr = process.StandardError;
+                    var stdinTask = Task.Run(() => { stdin.Write(input); stdin.Close(); });
+                    var stdoutTask = Task.Run(() => stdout.ReadToEnd());
+                    var stderrTask = Task.Run(() => stderr.ReadToEnd());
+                    if (process.WaitForExit(timeout))
+                    {
+                        return new RunCommandResults(process.ExitCode, stdoutTask.Result, stderrTask.Result);
+                    }
                 }
                 else
                 {
-                    throw new TimeoutException();
+                    if (process.WaitForExit(timeout))
+                    {
+                        return new RunCommandResults(process.ExitCode, String.Empty, String.Empty);
+                    }
                 }
+                throw new TimeoutException();
             }
             catch (Exception ex)
             {

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -256,7 +256,7 @@ namespace Vim.UI.Wpf
             var timeout = 30 * 1000;
 
             // Avoid redirection for the 'start' command.
-            var doRedirect = !arguments.StartsWith("/c start ");
+            var doRedirect = !arguments.StartsWith("/c start ", StringComparison.CurrentCultureIgnoreCase);
 
             // Populate the start info.
             var startInfo = new ProcessStartInfo

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -624,10 +624,10 @@ namespace Vim.UnitTest
                         _arguments = arguments;
                         _input = input;
 
-                        if (arguments.StartsWith("/c echo "))
+                        if (arguments.StartsWith("/c echolines "))
                         {
-                            // Echo all arguments.
-                            var argString = arguments.Substring("/c echo ".Length);
+                            // Echo all arguments as lines.
+                            var argString = arguments.Substring("/c echolines ".Length);
                             var args = argString.Split(' ').Concat(new[] { "" });
                             var output = String.Join(Environment.NewLine, args);
                             return new RunCommandResults(0, output, "");
@@ -644,8 +644,8 @@ namespace Vim.UnitTest
             public void DefaultLine()
             {
                 Create("cat", "dog", "bat", "");
-                ParseAndRun(":r!echo foo bar");
-                Assert.Equal("/c echo foo bar", _arguments);
+                ParseAndRun(":r!echolines foo bar");
+                Assert.Equal("/c echolines foo bar", _arguments);
                 Assert.Equal(new[] { "cat", "foo", "bar", "dog", "bat", "", }, _textBuffer.GetLines());
             }
 
@@ -653,8 +653,8 @@ namespace Vim.UnitTest
             public void SpecificLine()
             {
                 Create("cat", "dog", "bat", "");
-                ParseAndRun(":2r!echo foo bar");
-                Assert.Equal("/c echo foo bar", _arguments);
+                ParseAndRun(":2r!echolines foo bar");
+                Assert.Equal("/c echolines foo bar", _arguments);
                 Assert.Equal(new[] { "cat", "dog", "foo", "bar", "bat", "", }, _textBuffer.GetLines());
             }
 
@@ -662,8 +662,8 @@ namespace Vim.UnitTest
             public void BeforeFirst()
             {
                 Create("cat", "dog", "bat", "");
-                ParseAndRun(":0r!echo foo bar");
-                Assert.Equal("/c echo foo bar", _arguments);
+                ParseAndRun(":0r!echolines foo bar");
+                Assert.Equal("/c echolines foo bar", _arguments);
                 Assert.Equal(new[] { "foo", "bar", "cat", "dog", "bat", "", }, _textBuffer.GetLines());
             }
         }

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -610,7 +610,65 @@ namespace Vim.UnitTest
             }
         }
 
-        public sealed class RunSearhTest : InterpreterTest
+        public sealed class RunReadCommandTest : InterpreterTest
+        {
+            private string _command;
+            private string _arguments;
+            private string _input;
+
+            public RunReadCommandTest()
+            {
+                VimHost.RunCommandFunc = (command, arguments, input, vimData) =>
+                    {
+                        _command = command;
+                        _arguments = arguments;
+                        _input = input;
+
+                        if (arguments.StartsWith("/c echo "))
+                        {
+                            // Echo all arguments.
+                            var argString = arguments.Substring("/c echo ".Length);
+                            var args = argString.Split(' ').Concat(new[] { "" });
+                            var output = String.Join(Environment.NewLine, args);
+                            return new RunCommandResults(0, output, "");
+                        }
+                        else
+                        {
+                            Assert.True(false, "invalid arguments");
+                            return null;
+                        }
+                    };
+            }
+
+            [WpfFact]
+            public void DefaultLine()
+            {
+                Create("cat", "dog", "bat", "");
+                ParseAndRun(":r!echo foo bar");
+                Assert.Equal("/c echo foo bar", _arguments);
+                Assert.Equal(new[] { "cat", "foo", "bar", "dog", "bat", "", }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void SpecificLine()
+            {
+                Create("cat", "dog", "bat", "");
+                ParseAndRun(":2r!echo foo bar");
+                Assert.Equal("/c echo foo bar", _arguments);
+                Assert.Equal(new[] { "cat", "dog", "foo", "bar", "bat", "", }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void BeforeFirst()
+            {
+                Create("cat", "dog", "bat", "");
+                ParseAndRun(":0r!echo foo bar");
+                Assert.Equal("/c echo foo bar", _arguments);
+                Assert.Equal(new[] { "foo", "bar", "cat", "dog", "bat", "", }, _textBuffer.GetLines());
+            }
+        }
+
+        public sealed class RunSearchTest : InterpreterTest
         {
             [WpfFact]
             public void ForwardSearchUpdatesLastPattern()


### PR DESCRIPTION
### Changes

- Support command flavor of `:read`
- Avoid editor hang executing `start [command]`
- Fix `:read` handling of line zero (to mean before line 1)
- Add unit tests for command flavor of `:read`

### Fixes

- Fixes #2167