### PR TITLE
Fix visual text blocks when the cursor is on a empty line

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -358,7 +358,7 @@ type internal CommandUtil
                         |> OptionUtil.getOrDefault (SnapshotUtil.GetEndPoint (p.Snapshot))
                     SnapshotSpan(result.Span.Start, endPoint)
                 | None -> result.Span
-            else
+            elif result.OperationKind = OperationKind.LineWise then
                 // If the change command ends inside a line break then the actual delete operation
                 // is backed up so that it leaves a single blank line after the delete operation.  This
                 // allows the insert to begin on a blank line
@@ -370,6 +370,8 @@ type internal CommandUtil
                     else
                         result.Span
                 | None -> result.Span
+            else
+                result.Span
 
         // Use an undo transaction to preserve the caret position.  Experiments show that the rules
         // for caret undo should be

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1595,7 +1595,9 @@ type internal CommandUtil
 
         let isInitialSelection =
             match visualSpan with
-            | VisualSpan.Character characterSpan -> characterSpan.Length <= 1
+            | VisualSpan.Character characterSpan ->
+                let lineBreakSpan = SnapshotLineUtil.GetLineBreakSpan characterSpan.LastLine
+                characterSpan.Length <= 1 || characterSpan.Span = lineBreakSpan
             | VisualSpan.Block blockSpan -> blockSpan.Spaces <= 1
             | VisualSpan.Line lineRange -> lineRange.Count = 1
 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -742,6 +742,9 @@ type MotionResultFlags =
     /// When used as a delete argument force a big delete
     | BigDelete = 0x20
 
+    /// Suppress 'exclusive linewise' adjustment 
+    | SuppressAdjustment = 0x40
+
 /// Information about the type of the motion this was.
 [<RequireQualifiedAccess>]
 [<NoComparison>]

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -2003,7 +2003,7 @@ type internal MotionUtil
                 | TagBlockKind.All -> tagBlock.FullSpan
                 | TagBlockKind.Inner -> tagBlock.InnerSpan
             let span = SnapshotSpan(x.CurrentSnapshot, span)
-            MotionResult.Create(span, MotionKind.CharacterWiseExclusive, isForward = true) |> Some
+            MotionResult.Create(span, MotionKind.CharacterWiseExclusive, isForward = true, motionResultFlags = MotionResultFlags.SuppressAdjustment) |> Some
 
     /// Get the expanded tag block based on the current kind and point
     member x.GetExpandedTagBlock point kind = 
@@ -2897,7 +2897,9 @@ type internal MotionUtil
             let firstNonBlank = SnapshotLineUtil.GetFirstNonBlankOrStart startLine
             let endsInColumnZero = SnapshotPointUtil.IsStartOfLine originalSpan.End
 
-            if endLine.LineNumber <= startLine.LineNumber then
+            if Util.IsFlagSet motionResult.MotionResultFlags MotionResultFlags.SuppressAdjustment then
+                motionResult
+            elif endLine.LineNumber <= startLine.LineNumber then
                 // No adjustment needed when everything is on the same line
                 motionResult
             elif not endsInColumnZero then

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -5916,6 +5916,32 @@ namespace Vim.UnitTest
                     _vimBuffer.Process("dit");
                     Assert.Equal("<a></A>", _textBuffer.GetLine(0).GetText());
                 }
+
+                /// <summary>
+                /// Delete of multiline inner tag block is never linewise
+                /// </summary>
+                [WpfFact]
+                public void DeleteInnerSimpleMultiLine()
+                {
+                    // Reported in issue #2081.
+                    Create("<a>", "", "blah", "</a>");
+                    _textView.MoveCaretToLine(1);
+                    _vimBuffer.Process("dit");
+                    Assert.Equal(new[] { "<a></a>" }, _textBuffer.GetLines());
+                }
+
+                /// <summary>
+                /// Change of multiline inner tag block doesn't leave an blank line
+                /// </summary>
+                [WpfFact]
+                public void ChangeInnerSimpleMultiLine()
+                {
+                    // Reported in issue #2081.
+                    Create("<a>", "", "blah", "</a>");
+                    _textView.MoveCaretToLine(1);
+                    _vimBuffer.ProcessNotation("citfoo<Esc>");
+                    Assert.Equal(new[] { "<a>foo</a>" }, _textBuffer.GetLines());
+                }
             }
 
             public sealed class YankTagBlockTest : TagBlocksMotionTest

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -5931,7 +5931,7 @@ namespace Vim.UnitTest
                 }
 
                 /// <summary>
-                /// Change of multiline inner tag block doesn't leave an blank line
+                /// Change of multiline inner tag block doesn't leave a blank line
                 /// </summary>
                 [WpfFact]
                 public void ChangeInnerSimpleMultiLine()

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -1262,6 +1262,16 @@ namespace Vim.UnitTest
                 }
 
                 [WpfFact]
+                public void InnerSimpleMultiLineFromBlankLine()
+                {
+                    // Reported in issue #2081.
+                    Create("<a>", "", "blah", "</a>");
+                    _textView.MoveCaretToLine(1);
+                    _vimBuffer.Process("vity");
+                    Assert.Equal(Environment.NewLine + Environment.NewLine + "blah" + Environment.NewLine, UnnamedRegister.StringValue);
+                }
+
+                [WpfFact]
                 public void InnerSimpleSingleLine()
                 {
                     Create("<a>blah</a>");

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -1261,8 +1261,11 @@ namespace Vim.UnitTest
                     Assert.Equal(Environment.NewLine + "blah" + Environment.NewLine, UnnamedRegister.StringValue);
                 }
 
+                /// <summary>
+                /// Visual selection of a block from an empty line should not expand
+                /// </summary>
                 [WpfFact]
-                public void InnerSimpleMultiLineFromBlankLine()
+                public void InnerSimpleMultiLineFromEmptyLine()
                 {
                     // Reported in issue #2081.
                     Create("<a>", "", "blah", "</a>");


### PR DESCRIPTION
### Changes

- Correctly detect initial selection of linebreak
- Only trim trailing linebreak in change operation when linewise
- Suppress 'exclusive linewise' adjustment for tag blocks

### Fixes

- Fixes #2081

### Discussion

When vim is in inclusive mode and on an empty line, the initial selection includes the linebreak. Previously, VsVim would detect whether a character-wise selection was the initial selection by checking that the length of the span was less than one. Since a linebreak can be two characters, this test failed when the cursor was positioned on an empty line with a `\r\n` linebreak.