### PR TITLE
Block caret colors

### DIFF
--- a/Src/VimCore/VimSettings.fs
+++ b/Src/VimCore/VimSettings.fs
@@ -151,7 +151,7 @@ type internal GlobalSettings() =
         [|
             (AtomicInsertName, AtomicInsertName, SettingValue.Toggle false, SettingOptions.None)
             (BackspaceName, "bs", SettingValue.String "", SettingOptions.None)
-            (CaretOpacityName, CaretOpacityName, SettingValue.Number 65, SettingOptions.None)
+            (CaretOpacityName, CaretOpacityName, SettingValue.Number 100, SettingOptions.None)
             (ClipboardName, "cb", SettingValue.String "", SettingOptions.None)
             (CurrentDirectoryPathName, "cd", SettingValue.String ",,", SettingOptions.FileName)
             (GlobalDefaultName, "gd", SettingValue.Toggle false, SettingOptions.None)

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
@@ -406,6 +406,7 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
             var textRunProperties = _classificationFormatMap.DefaultTextProperties;
             var typeface = textRunProperties.Typeface;
             var fontSize = textRunProperties.FontRenderingEmSize;
+            var textHeight = offset + height;
 
             if (_caretOpacity < 1.0 && backgroundBrush is SolidColorBrush solidBrush)
             {
@@ -426,7 +427,10 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
                 FontStyle = typeface.Style,
                 FontSize = fontSize,
                 Width = width,
-                Height = offset + height,
+                Height = textHeight,
+                LineHeight = textHeight,
+                LineStackingStrategy = LineStackingStrategy.BlockLineHeight,
+                BaselineOffset = 0,
             };
 
             var element = new Canvas

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
@@ -303,7 +303,7 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
         private FormattedText CreateFormattedText()
         {
             var textRunProperties = _classificationFormatMap.DefaultTextProperties;
-            return new FormattedText("^", CultureInfo.CurrentUICulture, FlowDirection.RightToLeft, textRunProperties.Typeface, textRunProperties.FontRenderingEmSize, Brushes.Black);
+            return new FormattedText("A", CultureInfo.CurrentUICulture, FlowDirection.LeftToRight, textRunProperties.Typeface, textRunProperties.FontRenderingEmSize, Brushes.Black);
         }
 
         /// <summary>

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
@@ -428,7 +428,7 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
                 FontSize = fontSize,
                 Width = width,
                 Height = textHeight,
-                LineHeight = textHeight,
+                LineHeight = textHeight != 0 ? textHeight : double.NaN,
                 LineStackingStrategy = LineStackingStrategy.BlockLineHeight,
                 BaselineOffset = 0,
             };

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
@@ -395,41 +395,45 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
             var color = TryCalculateCaretColor();
             var tuple = CalculateCaretRectAndDisplayOffset();
             var rect = tuple.Item1;
+            var width = rect.Size.Width;
+            var height = rect.Size.Height;
             var offset = tuple.Item2;
             var caretCharacter = tuple.Item3;
 
-            var textViewProperties = _editorFormatMap.GetProperties("TextView Background");
-            var backgroundBrush = textViewProperties.GetBackgroundBrush(SystemColors.WindowBrush);
             var properties = _editorFormatMap.GetProperties(BlockCaretFormatDefinition.Name);
+            var foregroundBrush = properties.GetBackgroundBrush(SystemColors.WindowBrush);
+            var backgroundBrush = properties.GetForegroundBrush(SystemColors.WindowTextBrush);
             var textRunProperties = _classificationFormatMap.DefaultTextProperties;
             var typeface = textRunProperties.Typeface;
-
-            var line = _textView.Caret.ContainingTextViewLine;
+            var fontSize = textRunProperties.FontRenderingEmSize;
 
             var textBlock = new TextBlock
             {
                 Text = caretCharacter,
-                Foreground = backgroundBrush,
-                Background = properties.GetForegroundBrush(SystemColors.WindowTextBrush),
+                Foreground = foregroundBrush,
+                Background = backgroundBrush,
                 FontFamily = typeface.FontFamily,
                 FontStretch = typeface.Stretch,
                 FontWeight = typeface.Weight,
                 FontStyle = typeface.Style,
-                FontSize = textRunProperties.FontRenderingEmSize,
-            };
-
-            var border = new Border
-            {
-                Width = rect.Size.Width,
-                Height = rect.Size.Height,
+                FontSize = fontSize,
                 Opacity = _caretOpacity,
-                Child = textBlock,
+                Width = width,
+                Height = offset + height,
             };
 
-            Canvas.SetTop(border, _textView.Caret.Top);
-            Canvas.SetLeft(border, _textView.Caret.Left);
+            var element = new Canvas
+            {
+                Width = width,
+                Height = height,
+                ClipToBounds = true,
+            };
 
-            return new CaretData(_caretDisplay, _caretOpacity, border, color, rect.Size, offset, caretCharacter);
+            element.Children.Add(textBlock);
+            Canvas.SetTop(textBlock, -offset);
+            Canvas.SetLeft(textBlock, 0);
+
+            return new CaretData(_caretDisplay, _caretOpacity, element, color, rect.Size, offset, caretCharacter);
         }
 
         /// <summary>

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
@@ -48,7 +48,7 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
         private bool _isAdornmentPresent;
         private bool _isDestroyed;
         private bool _isUpdating;
-        private double _caretOpacity = 0.65;
+        private double _caretOpacity = 1.0;
 
         public ITextView TextView
         {

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
@@ -226,7 +226,7 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
             if (_caretData.HasValue && _caretData.Value.CaretDisplay != CaretDisplay.NormalCaret)
             {
                 var data = _caretData.Value;
-                data.Element.Opacity = data.Element.Opacity == 0.0 ? _caretOpacity : 0.0;
+                data.Element.Opacity = data.Element.Opacity == 0.0 ? 1.0 : 0.0;
             }
         }
 
@@ -407,6 +407,14 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
             var typeface = textRunProperties.Typeface;
             var fontSize = textRunProperties.FontRenderingEmSize;
 
+            if (_caretOpacity < 1.0 && backgroundBrush is SolidColorBrush solidBrush)
+            {
+                var oldColor = solidBrush.Color;
+                var alpha = (byte)Math.Round(0xff * _caretOpacity);
+                var newColor = Color.FromArgb(alpha, oldColor.R, oldColor.G, oldColor.B);
+                backgroundBrush = new SolidColorBrush(newColor);
+            }
+
             var textBlock = new TextBlock
             {
                 Text = caretCharacter,
@@ -417,7 +425,6 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
                 FontWeight = typeface.Weight,
                 FontStyle = typeface.Style,
                 FontSize = fontSize,
-                Opacity = _caretOpacity,
                 Width = width,
                 Height = offset + height,
             };

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
@@ -401,16 +401,16 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
             var caretCharacter = tuple.Item3;
 
             var properties = _editorFormatMap.GetProperties(BlockCaretFormatDefinition.Name);
-            var foregroundBrush = properties.GetBackgroundBrush(SystemColors.WindowBrush);
-            var backgroundBrush = properties.GetForegroundBrush(SystemColors.WindowTextBrush);
+            var foregroundBrush = properties.GetForegroundBrush(SystemColors.WindowBrush);
+            var backgroundBrush = properties.GetBackgroundBrush(SystemColors.WindowTextBrush);
             var textRunProperties = _classificationFormatMap.DefaultTextProperties;
             var typeface = textRunProperties.Typeface;
             var fontSize = textRunProperties.FontRenderingEmSize;
 
             if (_caretOpacity < 1.0 && backgroundBrush is SolidColorBrush solidBrush)
             {
-                var oldColor = solidBrush.Color;
                 var alpha = (byte)Math.Round(0xff * _caretOpacity);
+                var oldColor = solidBrush.Color;
                 var newColor = Color.FromArgb(alpha, oldColor.R, oldColor.G, oldColor.B);
                 backgroundBrush = new SolidColorBrush(newColor);
             }

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaretFactoryService.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaretFactoryService.cs
@@ -18,7 +18,7 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
 #pragma warning disable 169
         [Export(typeof(AdornmentLayerDefinition))]
         [Name(BlockCaretAdornmentLayerName)]
-        [Order(After = PredefinedAdornmentLayers.Selection)]
+        [Order(After = PredefinedAdornmentLayers.Text)]
         private AdornmentLayerDefinition _blockCaretAdornmentLayerDefinition;
 #pragma warning restore 169
 

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaretFormatDefinition.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaretFormatDefinition.cs
@@ -18,8 +18,8 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
         internal BlockCaretFormatDefinition()
         {
             DisplayName = "VsVim Block Caret";
-            ForegroundColor = Colors.Black;
-            BackgroundColor = Colors.White;
+            ForegroundColor = Colors.White;
+            BackgroundColor = Colors.Black;
         }
     }
 }

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaretFormatDefinition.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaretFormatDefinition.cs
@@ -19,7 +19,7 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
         {
             DisplayName = "VsVim Block Caret";
             ForegroundColor = Colors.Black;
-            BackgroundCustomizable = false;
+            BackgroundColor = Colors.White;
         }
     }
 }

--- a/Src/VsVimShared/Implementation/OptionPages/DefaultOptionPage.cs
+++ b/Src/VsVimShared/Implementation/OptionPages/DefaultOptionPage.cs
@@ -173,7 +173,8 @@ namespace Vim.VisualStudio.Implementation.OptionPages
 
         private static readonly ColorKey s_incrementalSearchColorKey = ColorKey.Background(VimConstants.IncrementalSearchTagName);
         private static readonly ColorKey s_highlightIncrementalSearchColorKey = ColorKey.Background(VimConstants.HighlightIncrementalSearchTagName);
-        private static readonly ColorKey s_blockCaretColorKey = ColorKey.Foreground(VimWpfConstants.BlockCaretFormatDefinitionName);
+        private static readonly ColorKey s_blockCaretForegroundColorKey = ColorKey.Foreground(VimWpfConstants.BlockCaretFormatDefinitionName);
+        private static readonly ColorKey s_blockCaretBackgroundColorKey = ColorKey.Background(VimWpfConstants.BlockCaretFormatDefinitionName);
         private static readonly ColorKey s_controlCharacterColorKey = ColorKey.Foreground(VimWpfConstants.ControlCharactersFormatDefinitionName);
         private static readonly ColorKey s_commandMarginForegroundColorKey = ColorKey.Foreground(VimWpfConstants.CommandMarginFormatDefinitionName);
         private static readonly ColorKey s_commandMarginBackgroundColorKey = ColorKey.Background(VimWpfConstants.CommandMarginFormatDefinitionName);
@@ -186,7 +187,8 @@ namespace Vim.VisualStudio.Implementation.OptionPages
             {
                 s_incrementalSearchColorKey,
                 s_highlightIncrementalSearchColorKey,
-                s_blockCaretColorKey,
+                s_blockCaretForegroundColorKey,
+                s_blockCaretBackgroundColorKey,
                 s_controlCharacterColorKey,
                 s_commandMarginForegroundColorKey,
                 s_commandMarginBackgroundColorKey,
@@ -257,12 +259,20 @@ namespace Vim.VisualStudio.Implementation.OptionPages
         [TypeConverter(typeof(WordWrapDisplaySettingConverter))]
         public WordWrapDisplay WordWrapDisplay { get; set; }
 
-        [DisplayName("Block Caret")]
+        [DisplayName("Block Caret Foreground")]
         [Category(CategoryColors)]
-        public Color BlockCaretColor
+        public Color BlockCaretForegroundColor
         {
-            get { return GetColor(s_blockCaretColorKey); }
-            set { SetColor(s_blockCaretColorKey, value); }
+            get { return GetColor(s_blockCaretForegroundColorKey); }
+            set { SetColor(s_blockCaretForegroundColorKey, value); }
+        }
+
+        [DisplayName("Block Caret Background")]
+        [Category(CategoryColors)]
+        public Color BlockCaretBackgroundColor
+        {
+            get { return GetColor(s_blockCaretBackgroundColorKey); }
+            set { SetColor(s_blockCaretBackgroundColorKey, value); }
         }
 
         [DisplayName("Incremental Search")]


### PR DESCRIPTION
Although VsVim currently supports a configurable block caret background color, the foreground color is always displayed as the character would appear if the caret were somewhere else. This change fixes that and allows the user to configure and display both foreground and background colors for the block caret. Doing this vastly improves readability and accessibility because it allows high contrast for the character under the cursor. In fact, it works so well that it makes it practical to turn off cursor blinking entirely.

Here is a screenshot of the new  block caret in action:

![image](https://user-images.githubusercontent.com/2680524/41024353-03b33272-693d-11e8-9091-eea4ff1ef1dc.png)

### Changes

- Allow block caret background to be configured
- Set default caret opacity to fully opaque (100%)
- Adapt VsVim options page to allow configuring block caret foreground and background
- Rewrite the block caret to actually draw the text of the character under the cursor
- Reverse the previous interpretation of background/foreground for the block caret

### Important Note

This change might produce somewhat surprising results when first installed.

First, the old VsVim used to use the configurable foreground color as the background of the block caret, which was wrong and confusing. This change fixes that and is therefore technically not backward-compatible, settings-wise. The price is a visit to the options page to fix the block caret colors.

Second, the old VsVim did not allow the block caret foreground to be set. Therefore, on first use, the block caret foreground will default to white, which is suitable for a light background window color. However, if a dark theme is in use, black or some other dark color might be a better choice and using white will temporarily *reduce* the contrast of the block caret. Again, a simple visit to the options page may be necessary to get the best results.

Third, some users may have previously overridden the block caret opacity using `:set vsvimcaret=XX`. Chances are that they did this to try to *improve* the readability. However, increasing the opacity of the new block caret will now almost certainly increase its readability. As a result, setting the opacity less than 100% is still supported, but as an aesthetic choice.

### Fixes

- Fixes #749
- Fixes #1945