### PR TITLE
Prevent vim buffer creation unless the view is in the text editor category

### DIFF
--- a/Src/VsVimShared/IVsAdapter.cs
+++ b/Src/VsVimShared/IVsAdapter.cs
@@ -71,6 +71,11 @@ namespace Vim.VisualStudio
         bool IsWatchWindowView(ITextView textView);
 
         /// <summary>
+        /// Is this a Text Editor ITextView instance
+        /// </summary>
+        bool IsTextEditorView(ITextView textView);
+
+        /// <summary>
         /// Determine if this ITextView is readonly.  This needs to mimic the behavior of 
         /// the VsCodeWindowAdapter::IsReadOnly method
         /// </summary>

--- a/Src/VsVimShared/Implementation/Misc/FallbackKeyProcessorProvider.cs
+++ b/Src/VsVimShared/Implementation/Misc/FallbackKeyProcessorProvider.cs
@@ -60,6 +60,11 @@ namespace Vim.VisualStudio.Implementation.Misc
                 return null;
             }
 
+            if (!_vsAdapter.IsTextEditorView(wpfTextView))
+            {
+                return null;
+            }
+
             if (!_vim.TryGetOrCreateVimBufferForHost(wpfTextView, out IVimBuffer vimBuffer))
             {
                 vimBuffer = null;

--- a/Src/VsVimShared/Implementation/Misc/FallbackKeyProcessorProvider.cs
+++ b/Src/VsVimShared/Implementation/Misc/FallbackKeyProcessorProvider.cs
@@ -50,21 +50,12 @@ namespace Vim.VisualStudio.Implementation.Misc
         }
 
         /// <summary>
-        /// We create a single fallback key processor on demand and reuse it
-        /// for all text views
+        /// Create a fallback key processor for every text view if we don't create a vim buffer
         /// </summary>
+        /// <param name="wpfTextView"></param>
+        /// <returns></returns>
         KeyProcessor IKeyProcessorProvider.GetAssociatedProcessor(IWpfTextView wpfTextView)
         {
-            if (_vsAdapter.IsWatchWindowView(wpfTextView))
-            {
-                return null;
-            }
-
-            if (!_vsAdapter.IsTextEditorView(wpfTextView))
-            {
-                return null;
-            }
-
             if (!_vim.TryGetOrCreateVimBufferForHost(wpfTextView, out IVimBuffer vimBuffer))
             {
                 vimBuffer = null;

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -771,6 +771,11 @@ namespace Vim.VisualStudio
                 return false;
             }
 
+            if (!_vsAdapter.IsTextEditorView(textView))
+            {
+                return false;
+            }
+
             var result = _extensionAdapterBroker.ShouldCreateVimBuffer(textView);
             if (result.HasValue)
             {

--- a/Test/VsVimSharedTest/VsVimHostTest.cs
+++ b/Test/VsVimSharedTest/VsVimHostTest.cs
@@ -39,6 +39,7 @@ namespace Vim.VisualStudio.UnitTest
             _factory = new MockRepository(MockBehavior.Strict);
             _adapter = _factory.Create<IVsAdapter>();
             _adapter.Setup(x => x.IsWatchWindowView(It.IsAny<ITextView>())).Returns(false);
+            _adapter.Setup(x => x.IsTextEditorView(It.IsAny<ITextView>())).Returns(true);
             _undoManagerProvider = _factory.Create<ITextBufferUndoManagerProvider>();
             _editorAdaptersFactoryService = _factory.Create<IVsEditorAdaptersFactoryService>();
             _editorOperationsFactoryService = _factory.Create<IEditorOperationsFactoryService>();


### PR DESCRIPTION
The F# Interactive window is not in the "Text Editor" fonts and colors category so VsVim fonts and colors are not available. In general, unless a window *is* in the "Text Editor" fonts and colors category, VsVim shouldn't be active in that window.

### Changes

-Prevent vim buffer creation unless the view is in the text editor category

### Fixes

- Fixes #1970