### PR TITLE
External caret movement in insert mode breaks the undo sequence

### DIFF
--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -964,6 +964,7 @@ type internal InsertMode
             let command = movement _sessionData.CombinedEditCommand oldPosition newPosition 
             x.ChangeCombinedEditCommand command
         else
+            x.BreakUndoSequence "Insert after motion" 
             x.ChangeCombinedEditCommand None
         _vimBuffer.VimTextBuffer.InsertStartPoint <- Some x.CaretPoint
         _vimBuffer.VimTextBuffer.IsSoftTabStopValidForBackspace <- true

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -3399,7 +3399,7 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
-            /// Undo of insert with horizontal arrow keys
+            /// Undo of insert with horizontal arrow key should break the undo sequence
             /// </summary>
             [WpfFact]
             public void Undo_InsertWithHorizontalArrowKeys()
@@ -3409,6 +3409,24 @@ namespace Vim.UnitTest
                 Assert.Equal("aaa ddd eee bbb ccc", _textBuffer.GetLineText(0));
                 _vimBuffer.ProcessNotation("u");
                 Assert.Equal("aaa eee bbb ccc", _textBuffer.GetLineText(0));
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa bbb ccc", _textBuffer.GetLineText(0));
+            }
+
+            /// <summary>
+            /// Undo of insert with external caret movement should break the undo sequence
+            /// </summary>
+            [WpfFact]
+            public void Undo_InsertWithExternalCaretMovement()
+            {
+                Create("aaa bbb ccc");
+                _textView.MoveCaretTo(4);
+                _vimBuffer.ProcessNotation("iddd ");
+                _textView.MoveCaretTo(12);
+                _vimBuffer.ProcessNotation("eee <Esc>");
+                Assert.Equal("aaa ddd bbb eee ccc", _textBuffer.GetLineText(0));
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("aaa ddd bbb ccc", _textBuffer.GetLineText(0));
                 _vimBuffer.ProcessNotation("u");
                 Assert.Equal("aaa bbb ccc", _textBuffer.GetLineText(0));
             }


### PR DESCRIPTION
Fixes #2188