### PR TITLE
Showcmd option

### DIFF
--- a/Src/VimCore/CommandRunner.fs
+++ b/Src/VimCore/CommandRunner.fs
@@ -73,6 +73,8 @@ type internal CommandRunner
         | Some count -> count
         | None -> 1
 
+    member x.Inputs = List.rev _data.Inputs
+
     /// Try and get the VisualSpan for the provided kind
     member x.GetVisualSpan kind = VisualSpan.CreateForSelection _textView kind _localSettings.TabStop
 
@@ -395,6 +397,7 @@ type internal CommandRunner
         member x.HasCount = x.HasCount
         member x.RegisterName = x.RegisterName
         member x.Count = x.Count
+        member x.Inputs = x.Inputs
         member x.KeyRemapMode = 
             match _runBindData with
             | None -> KeyRemapMode.None

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3563,6 +3563,8 @@ type ICommandRunner =
     /// When HasCount is true this has the associated count
     abstract Count: int 
 
+    abstract Inputs: KeyInput list
+    
     /// Add a Command.  If there is already a Command with the same name an exception will
     /// be raised
     abstract Add: CommandBinding -> unit

--- a/Src/VimCore/VimSettings.fs
+++ b/Src/VimCore/VimSettings.fs
@@ -173,6 +173,7 @@ type internal GlobalSettings() =
             (ScrollOffsetName, "so", SettingValue.Number 0, SettingOptions.None)
             (ShellName, "sh", "ComSpec" |> SystemUtil.GetEnvironmentVariable |> SettingValue.String, SettingOptions.FileName)
             (ShellFlagName, "shcf", SettingValue.String "/c", SettingOptions.None)
+            (ShowCommandName, "sc", SettingValue.Toggle true, SettingOptions.None)
             (SmartCaseName, "scs", SettingValue.Toggle false, SettingOptions.None)
             (StartOfLineName, "sol", SettingValue.Toggle true, SettingOptions.None)
             (StatusLineName, "stl", SettingValue.String "", SettingOptions.None)
@@ -406,6 +407,9 @@ type internal GlobalSettings() =
         member x.ShellFlag
             with get() = _map.GetStringValue ShellFlagName
             and set value = _map.TrySetValue ShellFlagName (SettingValue.String value) |> ignore
+        member x.ShowCommand
+            with get() = _map.GetBoolValue ShowCommandName
+            and set value = _map.TrySetValue ShowCommandName (SettingValue.Toggle value) |> ignore
         member x.SmartCase
             with get() = _map.GetBoolValue SmartCaseName
             and set value = _map.TrySetValue SmartCaseName (SettingValue.Toggle value) |> ignore

--- a/Src/VimCore/VimSettingsInterface.fs
+++ b/Src/VimCore/VimSettingsInterface.fs
@@ -34,6 +34,7 @@ module GlobalSettingNames =
     let SelectModeName = "selectmode"
     let ShellName = "shell"
     let ShellFlagName = "shellcmdflag"
+    let ShowCommandName = "showcmd"
     let SmartCaseName = "smartcase"
     let StartOfLineName = "startofline"
     let StatusLineName = "statusline"
@@ -420,6 +421,9 @@ and IVimGlobalSettings =
     /// The flag which is passed to the shell when executing shell commands
     abstract ShellFlag: string with get, set
 
+    /// The 'showcmd' setting as in Vim
+    abstract ShowCommand: bool with get, set
+    
     abstract StartOfLine: bool with get, set
 
     /// This option determines the content of the status line.

--- a/Src/VimTestUtils/Mock/MockVimBuffer.cs
+++ b/Src/VimTestUtils/Mock/MockVimBuffer.cs
@@ -23,6 +23,7 @@ namespace Vim.UnitTest.Mock
         public IVisualMode VisualCharacterModeImpl;
         public IVisualMode VisualLineModeImpl;
         public ICommandMode CommandModeImpl;
+        public FSharpList<KeyInput> BufferedKeyInputsImpl;
         public IDisabledMode DisabledModeImpl;
         public ISubstituteConfirmMode SubstituteConfirmModeImpl;
         public IIncrementalSearch IncrementalSearchImpl;
@@ -54,7 +55,7 @@ namespace Vim.UnitTest.Mock
 
         public FSharpList<KeyInput> BufferedKeyInputs
         {
-            get { throw new NotImplementedException(); }
+            get { return BufferedKeyInputsImpl; }
         }
 
         public bool CanProcess(KeyInput value)

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml
@@ -48,17 +48,40 @@
             Grid.Column="1"
             HorizontalScrollBarVisibility="Auto"
             VerticalScrollBarVisibility="Disabled">
-            <TextBox 
-                x:Name="_commandLineInput"
-                MaxHeight="200"
-                VerticalAlignment="Center"
-                IsReadOnly="{Binding Path=IsEditReadOnly}"
-                FontFamily="{Binding Path=TextFontFamily}"
-                FontSize="{Binding Path=TextFontSize}"
-                Foreground="{Binding Path=TextForeground}"
-                Background="{Binding Path=TextBackground}"
-                CaretBrush="{Binding Path=TextForeground}"
-                />
+            <Border BorderThickness="1" BorderBrush="{Binding ElementName=_commandLineInput, Path=BorderBrush}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBox
+                        x:Name="_commandLineInput"
+                        MaxHeight="200"
+                        BorderThickness="0"
+                        VerticalAlignment="Center"
+                        IsReadOnly="{Binding Path=IsEditReadOnly}"
+                        FontFamily="{Binding Path=TextFontFamily}"
+                        FontSize="{Binding Path=TextFontSize}"
+                        Foreground="{Binding Path=TextForeground}"
+                        Background="{Binding Path=TextBackground}"
+                        CaretBrush="{Binding Path=TextForeground}" 
+                        />
+                    <TextBox
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        MinWidth="50"
+                        IsReadOnly="True"
+                        x:Name="_showCommandText"
+                        BorderThickness="0"
+                        VerticalAlignment="Center"
+                        FontFamily="{Binding Path=TextFontFamily}"
+                        FontSize="{Binding Path=TextFontSize}"
+                        Foreground="{Binding Path=TextForeground}"
+                        Background="{Binding Path=TextBackground}"
+                        CaretBrush="{Binding Path=TextForeground}" 
+                        />
+                </Grid>
+            </Border>
         </ScrollViewer>
     </Grid>
 </UserControl>

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml.cs
@@ -113,6 +113,11 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             get { return _commandLineInput; }
         }
 
+        public TextBox ShowCommandText
+        {
+            get { return _showCommandText; }
+        }
+        
         public Visibility IsStatuslineVisible
         {
             get { return (Visibility)GetValue(IsStatuslineVisibleProperty); }

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -689,6 +689,11 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
 
         private void UpdateShowCommandText()
         {
+            if (!_vimBuffer.GlobalSettings.ShowCommand)
+            {
+                _margin.ShowCommandText.Visibility = Visibility.Collapsed;
+                return;
+            }
             string text = CommandMarginUtil.GetShowCommandText(_vimBuffer);
             _margin.ShowCommandText.Text = text;
             _margin.ShowCommandText.Visibility = string.IsNullOrEmpty(text) ? Visibility.Collapsed : Visibility.Visible;

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -186,6 +186,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             _vimBuffer.StatusMessage += OnStatusMessage;
             _vimBuffer.ErrorMessage += OnErrorMessage;
             _vimBuffer.WarningMessage += OnWarningMessage;
+            _vimBuffer.KeyInputProcessed += OnKeyInputProcessed;
             _vimBuffer.CommandMode.CommandChanged += OnCommandModeCommandChanged;
             _vimBuffer.TextView.GotAggregateFocus += OnGotAggregateFocus;
             _vimBuffer.Vim.MacroRecorder.RecordingStarted += OnRecordingStarted;
@@ -208,6 +209,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             _vimBuffer.StatusMessage -= OnStatusMessage;
             _vimBuffer.ErrorMessage -= OnErrorMessage;
             _vimBuffer.WarningMessage -= OnWarningMessage;
+            _vimBuffer.KeyInputProcessed -= OnKeyInputProcessed;
             _vimBuffer.CommandMode.CommandChanged -= OnCommandModeCommandChanged;
             _vimBuffer.TextView.GotAggregateFocus -= OnGotAggregateFocus;
             _vimBuffer.Vim.MacroRecorder.RecordingStarted -= OnRecordingStarted;
@@ -676,6 +678,20 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     _margin.UpdateCaretPosition(EditPosition.End);
                 }
             }
+            
+            UpdateShowCommandText();
+        }
+
+        private void OnKeyInputProcessed(object sender, KeyInputProcessedEventArgs e)
+        {
+            UpdateShowCommandText();
+        }
+
+        private void UpdateShowCommandText()
+        {
+            string text = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            _margin.ShowCommandText.Text = text;
+            _margin.ShowCommandText.Visibility = string.IsNullOrEmpty(text) ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void OnStatusMessage(object sender, StringEventArgs args)

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
@@ -213,7 +213,9 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         public static string GetShowCommandText(IVimBuffer vimBuffer)
         {
             if (vimBuffer.IncrementalSearch.InSearch)
+            {
                 return string.Empty;
+            }
 
             switch (vimBuffer.ModeKind)
             {
@@ -238,24 +240,40 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         {
             var normalMode = vimBuffer.NormalMode;
             if (!string.IsNullOrEmpty(normalMode.Command))
+            {
                 return normalMode.Command;
+            }
+
             if (normalMode.CommandRunner.Inputs.Any())
+            {
                 return KeyInputsToShowCommandText(normalMode.CommandRunner.Inputs);
+            }
+
             if (vimBuffer.BufferedKeyInputs.Any())
+            {
                 return KeyInputsToShowCommandText(vimBuffer.BufferedKeyInputs);
+            }
+
             return string.Empty;
         }
 
         private static string GetVisualModeShowCommandText(IVimBuffer vimBuffer, IVisualMode visualMode)
         {
             if (visualMode.CommandRunner.Inputs.Any())
+            {
                 return KeyInputsToShowCommandText(visualMode.CommandRunner.Inputs);
+            }
+
             if (vimBuffer.BufferedKeyInputs.Any())
+            {
                 return KeyInputsToShowCommandText(vimBuffer.BufferedKeyInputs);
+            }
 
             var visualSpan = visualMode.VisualSelection.VisualSpan;
             if (!visualSpan.Spans.Any())
+            {
                 return string.Empty; // not sure if this can happen
+            }
 
             switch (visualSpan.VisualKind.VisualModeKind)
             {
@@ -263,13 +281,18 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     return visualSpan.LineRange.Count.ToString();
                 case ModeKind.VisualCharacter:
                     if (visualSpan.LineRange.Count > 1)
+                    {
                         return visualSpan.LineRange.Count.ToString();
+                    }
         
                     var charSpan = visualSpan.Spans.First();
                     // account for the selection possibly extending past the last printable character in the line to include some or all of a multi-character newline
                     var line = charSpan.Snapshot.GetLineFromPosition(charSpan.Start);
                     if (charSpan.End.Position > line.End)
+                    {
                         return (line.End - charSpan.Start + 1).ToString();
+                    }
+
                     return charSpan.Length.ToString();
                 case ModeKind.VisualBlock:
                     return $"{visualSpan.LineRange.Count}x{visualSpan.Spans.Max(x => x.Length)}";

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
@@ -239,11 +239,6 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         private static string GetNormalModeShowCommandText(IVimBuffer vimBuffer)
         {
             var normalMode = vimBuffer.NormalMode;
-            if (!string.IsNullOrEmpty(normalMode.Command))
-            {
-                return normalMode.Command;
-            }
-
             if (normalMode.CommandRunner.Inputs.Any())
             {
                 return KeyInputsToShowCommandText(normalMode.CommandRunner.Inputs);
@@ -252,6 +247,11 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             if (vimBuffer.BufferedKeyInputs.Any())
             {
                 return KeyInputsToShowCommandText(vimBuffer.BufferedKeyInputs);
+            }
+
+            if (!string.IsNullOrEmpty(normalMode.Command))
+            {
+                return normalMode.Command;
             }
 
             return string.Empty;

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
@@ -224,7 +224,8 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     var visualMode = (IVisualMode) vimBuffer.Mode;
                     if (visualMode.CommandRunner.Inputs.Any())
                         return string.Concat(visualMode.CommandRunner.Inputs.Select(x => x.Char));
-
+                    if (vimBuffer.BufferedKeyInputs.Any())
+                        return string.Concat(vimBuffer.BufferedKeyInputs.Select(x => x.Char));
                     var span = visualMode.VisualSelection.VisualSpan;
                     switch (span.VisualKind.VisualModeKind)
                     {

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
@@ -231,9 +231,9 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                         case ModeKind.VisualLine:
                             return span.LineRange.Count.ToString();
                         case ModeKind.VisualCharacter:
-                            return span.LineRange.Count > 1 ? span.LineRange.Count.ToString() : span.Spans.First().Length.ToString();
+                            return span.LineRange.Count > 1 ? span.LineRange.Count.ToString() : span.Spans.Max(x => x.Length).ToString();
                         case ModeKind.VisualBlock:
-                            return $"{span.LineRange.Count}x{span.Spans.First().Length}";
+                            return $"{span.LineRange.Count}x{span.Spans.Max(x => x.Length)}";
                     }
 
                     break;

--- a/Test/VimWpfTest/CommandMarginControllerTest.cs
+++ b/Test/VimWpfTest/CommandMarginControllerTest.cs
@@ -23,6 +23,7 @@ namespace Vim.UI.Wpf.UnitTest
         private readonly CommandMarginController _controller;
         private readonly MockVimBuffer _vimBuffer;
         private readonly Mock<IIncrementalSearch> _search;
+        private Mock<IVimGlobalSettings> _globalSettings;
 
         protected CommandMarginControllerTest()
         {
@@ -42,8 +43,8 @@ namespace Vim.UI.Wpf.UnitTest
             var textBuffer = CreateTextBuffer(new[] { "" });
             _vimBuffer.TextViewImpl = TextEditorFactoryService.CreateTextView(textBuffer);
 
-            var globalSettings = new Mock<IVimGlobalSettings>();
-            _vimBuffer.GlobalSettingsImpl = globalSettings.Object;
+            _globalSettings = new Mock<IVimGlobalSettings>();
+            _vimBuffer.GlobalSettingsImpl = _globalSettings.Object;
 
             var editorFormatMap = _factory.Create<IEditorFormatMap>(MockBehavior.Loose);
             editorFormatMap.Setup(x => x.GetProperties(It.IsAny<string>())).Returns(new ResourceDictionary());
@@ -404,6 +405,7 @@ namespace Vim.UI.Wpf.UnitTest
             public void NoEvents1()
             {
                 var mode = new Mock<INormalMode>();
+                _globalSettings.SetupGet(x => x.ShowCommand).Returns(true);
                 _search.SetupGet(x => x.InSearch).Returns(false).Verifiable();
                 mode.SetupGet(x => x.Command).Returns("foo");
                 mode.SetupGet(x => x.ModeKind).Returns(ModeKind.Normal);

--- a/Test/VimWpfTest/CommandMarginControllerTest.cs
+++ b/Test/VimWpfTest/CommandMarginControllerTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Windows;
+using Microsoft.FSharp.Collections;
 using Microsoft.FSharp.Core;
 using Microsoft.VisualStudio.Text.Classification;
 using Moq;
@@ -411,7 +412,7 @@ namespace Vim.UI.Wpf.UnitTest
                 _vimBuffer.NormalModeImpl = mode.Object;
 
                 SimulateKeystroke();
-                Assert.Equal("foo", _marginControl.CommandLineTextBox.Text);
+                Assert.Equal("foo", _marginControl.ShowCommandText.Text);
                 mode.Verify();
                 _factory.Verify();
             }
@@ -508,7 +509,9 @@ namespace Vim.UI.Wpf.UnitTest
             public void Search_Visual_Complete()
             {
                 var mode = _factory.Create<IVisualMode>();
-                mode.Setup(x => x.CommandRunner).Returns(_factory.Create<ICommandRunner>(MockBehavior.Loose).Object);
+                var runner = _factory.Create<ICommandRunner>(MockBehavior.Loose);
+                mode.Setup(x => x.CommandRunner).Returns(runner.Object);
+                runner.Setup(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
                 mode.Setup(x => x.ModeKind).Returns(ModeKind.VisualCharacter);
                 _vimBuffer.VisualCharacterModeImpl = mode.Object;
                 _vimBuffer.ModeKindImpl = ModeKind.VisualCharacter;

--- a/Test/VimWpfTest/CommandMarginControllerTest.cs
+++ b/Test/VimWpfTest/CommandMarginControllerTest.cs
@@ -405,10 +405,14 @@ namespace Vim.UI.Wpf.UnitTest
             public void NoEvents1()
             {
                 var mode = new Mock<INormalMode>();
+                var runner = new Mock<ICommandRunner>();
+                mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
+                runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
                 _globalSettings.SetupGet(x => x.ShowCommand).Returns(true);
                 _search.SetupGet(x => x.InSearch).Returns(false).Verifiable();
                 mode.SetupGet(x => x.Command).Returns("foo");
                 mode.SetupGet(x => x.ModeKind).Returns(ModeKind.Normal);
+                _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
                 _vimBuffer.ModeKindImpl = ModeKind.Normal;
                 _vimBuffer.ModeImpl = mode.Object;
                 _vimBuffer.NormalModeImpl = mode.Object;

--- a/Test/VimWpfTest/CommandMarginUtilTest.cs
+++ b/Test/VimWpfTest/CommandMarginUtilTest.cs
@@ -62,34 +62,37 @@ namespace Vim.UI.Wpf.UnitTest
         [WpfFact]
         public void GetCommandStatusVisualCharacterMode()
         {
-            const int expectedLineCount = 2;
-            const int expectedSelectionLength = 3;
-
-            var textBuffer = CreateTextBuffer("cat", "dog", "fish");
+            string[] lines = { "cat", "dog", "fish" };
+            var textBuffer = CreateTextBuffer(lines);
 
             _search.SetupGet(x => x.InSearch).Returns(false);
             var mode = _factory.Create<IVisualMode>();
             var runner = _factory.Create<ICommandRunner>();
             runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
             mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
-            
+
+            _vimBuffer.TextBufferImpl = textBuffer;
             _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
             _vimBuffer.ModeImpl = mode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.VisualCharacter;
             
-            var span1 = new CharacterSpan(textBuffer.GetPoint(0), textBuffer.GetPointInLine(0, expectedSelectionLength));
+            // span1 selection is within one line, so the display should be the selected character count
+            var span1 = new CharacterSpan(textBuffer.GetPointInLine(1, 1), textBuffer.GetPointInLine(1, 3));
             var selection1 = new VisualSelection.Character(span1, SearchPath.Forward);
             mode.SetupGet(x => x.VisualSelection).Returns(selection1);
-
-            var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
-            Assert.Equal(expectedSelectionLength.ToString(), actual);
+            Assert.Equal("2", CommandMarginUtil.GetShowCommandText(_vimBuffer));
             
-            var span2 = new CharacterSpan(textBuffer.GetPoint(0), textBuffer.GetPointInLine(1, 2));
+            // span2 selection is over two lines, so the the display should be the selected line count
+            var span2 = new CharacterSpan(textBuffer.GetPointInLine(0, 1), textBuffer.GetPointInLine(1, 2));
             var selection2 = new VisualSelection.Character(span2, SearchPath.Forward);
             mode.SetupGet(x => x.VisualSelection).Returns(selection2);
+            Assert.Equal("2", CommandMarginUtil.GetShowCommandText(_vimBuffer));
 
-            actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
-            Assert.Equal(expectedLineCount.ToString(), actual);
+            // span3 selection is within one line and includes the CRLF at the end of the line, so the the display should be the length of the line + 1
+            var span3 = new CharacterSpan(textBuffer.GetPointInLine(1, 1), textBuffer.GetPointInLine(1, lines[1].Length + 2));
+            var selection3 = new VisualSelection.Character(span3, SearchPath.Forward);
+            mode.SetupGet(x => x.VisualSelection).Returns(selection3);
+            Assert.Equal("3", CommandMarginUtil.GetShowCommandText(_vimBuffer));
         }
         
         [WpfFact]
@@ -119,7 +122,10 @@ namespace Vim.UI.Wpf.UnitTest
         [WpfFact]
         public void GetCommandStatusVisualLineMode()
         {
-            const int expectedLineCount = 23;
+            string[] lines = { "cat", "dog", "fish" };
+            var textBuffer = CreateTextBuffer(lines);
+            
+           const int expectedLineCount = 23;
             
             _search.SetupGet(x => x.InSearch).Returns(false);
             var mode = _factory.Create<IVisualMode>();
@@ -127,17 +133,15 @@ namespace Vim.UI.Wpf.UnitTest
             runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
             mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
 
-            var snapshot = _factory.Create<ITextSnapshot>();
-            snapshot.SetupGet(x => x.LineCount).Returns(expectedLineCount * 3);
-            var selection = new VisualSelection.Line(new SnapshotLineRange(snapshot.Object, 0, expectedLineCount), SearchPath.Forward, 0);
-            mode.SetupGet(x => x.VisualSelection).Returns(selection);
-            
+            _vimBuffer.TextBufferImpl = textBuffer;
             _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
             _vimBuffer.ModeImpl = mode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.VisualLine;
             
-            var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
-            Assert.Equal(expectedLineCount.ToString(), actual);
+            var span = new CharacterSpan(textBuffer.GetPointInLine(1, 1), textBuffer.GetPointInLine(2, 3));
+            var selection = new VisualSelection.Character(span, SearchPath.Forward);
+            mode.SetupGet(x => x.VisualSelection).Returns(selection);
+            Assert.Equal("2", CommandMarginUtil.GetShowCommandText(_vimBuffer));
         }
         
         [WpfFact]

--- a/Test/VimWpfTest/CommandMarginUtilTest.cs
+++ b/Test/VimWpfTest/CommandMarginUtilTest.cs
@@ -1,0 +1,152 @@
+﻿using System.Linq;
+using Microsoft.FSharp.Collections;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Vim.EditorHost;
+using Vim.UI.Wpf.Implementation.CommandMargin;
+using Vim.UnitTest;
+using Vim.UnitTest.Mock;
+using Xunit;
+
+namespace Vim.UI.Wpf.UnitTest
+{
+    public class CommandMarginUtilTest : VimTestBase
+    {
+        private readonly MockRepository _factory;
+        private readonly Mock<IIncrementalSearch> _search;
+        private readonly MockVimBuffer _vimBuffer;
+
+        public CommandMarginUtilTest()
+        {
+            _factory = new MockRepository(MockBehavior.Strict);
+            
+            _search = _factory.Create<IIncrementalSearch>();
+            
+            _vimBuffer = new MockVimBuffer
+            {
+                IncrementalSearchImpl = _search.Object,
+                VimImpl = MockObjectFactory.CreateVim(factory: _factory).Object,
+                CommandModeImpl = _factory.Create<ICommandMode>(MockBehavior.Loose).Object
+            };
+        }
+
+        [WpfFact]
+        public void GetCommandStatusNormalMode()
+        {
+            _search.SetupGet(x => x.InSearch).Returns(false);
+            var mode = _factory.Create<INormalMode>();
+            const string partialCommand = "di";
+            mode.SetupGet(x => x.Command).Returns(partialCommand);
+            _vimBuffer.NormalModeImpl = mode.Object;
+            _vimBuffer.ModeKindImpl = ModeKind.Normal;
+            var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            Assert.Equal(partialCommand, actual);
+        }
+        
+        [WpfFact]
+        public void GetCommandStatusNormalModeBufferedKeys()
+        {
+            _search.SetupGet(x => x.InSearch).Returns(false);
+            var mode = _factory.Create<INormalMode>();
+            const string partialCommand = @"\s";
+            mode.SetupGet(x => x.Command).Returns(string.Empty);
+            _vimBuffer.BufferedKeyInputsImpl = ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput));
+            _vimBuffer.NormalModeImpl = mode.Object;
+            _vimBuffer.ModeKindImpl = ModeKind.Normal;
+            var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            Assert.Equal(partialCommand, actual);
+        }
+        
+        [WpfFact]
+        public void GetCommandStatusVisualCharacterMode()
+        {
+            const int expectedLineCount = 2;
+            const int expectedSelectionLength = 3;
+
+            var textBuffer = CreateTextBuffer("cat", "dog", "fish");
+
+            _search.SetupGet(x => x.InSearch).Returns(false);
+            var mode = _factory.Create<IVisualMode>();
+            var runner = _factory.Create<ICommandRunner>();
+            runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
+            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
+            
+            _vimBuffer.ModeImpl = mode.Object;
+            _vimBuffer.ModeKindImpl = ModeKind.VisualCharacter;
+            
+            var span1 = new CharacterSpan(textBuffer.GetPoint(0), textBuffer.GetPointInLine(0, expectedSelectionLength));
+            var selection1 = new VisualSelection.Character(span1, SearchPath.Forward);
+            mode.SetupGet(x => x.VisualSelection).Returns(selection1);
+
+            var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            Assert.Equal(expectedSelectionLength.ToString(), actual);
+            
+            var span2 = new CharacterSpan(textBuffer.GetPoint(0), textBuffer.GetPointInLine(1, 2));
+            var selection2 = new VisualSelection.Character(span2, SearchPath.Forward);
+            mode.SetupGet(x => x.VisualSelection).Returns(selection2);
+
+            actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            Assert.Equal(expectedLineCount.ToString(), actual);
+        }
+        
+        [WpfFact]
+        public void GetCommandStatusVisualBlockMode()
+        {
+            const int expectedLineCount = 2;
+            const int expectedColumnCount = 3;
+
+            var textBuffer = CreateTextBuffer("cat", "dog", "fish");
+            var span = new BlockSpan(textBuffer.GetPoint(0), 4, expectedColumnCount, expectedLineCount);
+            var selection = new VisualSelection.Block(span, BlockCaretLocation.TopLeft);
+
+            _search.SetupGet(x => x.InSearch).Returns(false);
+            var mode = _factory.Create<IVisualMode>();
+            var runner = _factory.Create<ICommandRunner>();
+            runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
+            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
+            mode.SetupGet(x => x.VisualSelection).Returns(selection);
+
+            _vimBuffer.ModeImpl = mode.Object;
+            _vimBuffer.ModeKindImpl = ModeKind.VisualLine;
+            var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            Assert.Equal($"{expectedLineCount}x{expectedColumnCount}", actual);
+        }
+        
+        [WpfFact]
+        public void GetCommandStatusVisualLineMode()
+        {
+            const int expectedLineCount = 23;
+            
+            _search.SetupGet(x => x.InSearch).Returns(false);
+            var mode = _factory.Create<IVisualMode>();
+            var runner = _factory.Create<ICommandRunner>();
+            runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
+            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
+
+            var snapshot = _factory.Create<ITextSnapshot>();
+            snapshot.SetupGet(x => x.LineCount).Returns(expectedLineCount * 3);
+            var selection = new VisualSelection.Line(new SnapshotLineRange(snapshot.Object, 0, expectedLineCount), SearchPath.Forward, 0);
+            mode.SetupGet(x => x.VisualSelection).Returns(selection);
+            
+            _vimBuffer.ModeImpl = mode.Object;
+            _vimBuffer.ModeKindImpl = ModeKind.VisualLine;
+            var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            Assert.Equal(expectedLineCount.ToString(), actual);
+        }
+        
+        [WpfFact]
+        public void GetCommandStatusVisualModeBufferedKeys()
+        {
+            _search.SetupGet(x => x.InSearch).Returns(false);
+            var mode = _factory.Create<IVisualMode>();
+            var runner = _factory.Create<ICommandRunner>();
+            const string partialCommand = @"3f";
+            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
+            runner.SetupGet(x => x.Inputs).Returns(ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput)));
+            _vimBuffer.ModeImpl = mode.Object;
+            _vimBuffer.ModeKindImpl = ModeKind.VisualCharacter;
+            var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            Assert.Equal(partialCommand, actual);
+        }
+    }
+}

--- a/Test/VimWpfTest/CommandMarginUtilTest.cs
+++ b/Test/VimWpfTest/CommandMarginUtilTest.cs
@@ -50,9 +50,11 @@ namespace Vim.UI.Wpf.UnitTest
             var mode = _factory.Create<INormalMode>();
             const string partialCommand = @"\s";
             mode.SetupGet(x => x.Command).Returns(string.Empty);
+            
             _vimBuffer.BufferedKeyInputsImpl = ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput));
             _vimBuffer.NormalModeImpl = mode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.Normal;
+            
             var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
             Assert.Equal(partialCommand, actual);
         }
@@ -71,6 +73,7 @@ namespace Vim.UI.Wpf.UnitTest
             runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
             mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
             
+            _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
             _vimBuffer.ModeImpl = mode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.VisualCharacter;
             
@@ -103,6 +106,7 @@ namespace Vim.UI.Wpf.UnitTest
             var mode = _factory.Create<IVisualMode>();
             var runner = _factory.Create<ICommandRunner>();
             runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
+            _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
             mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
             mode.SetupGet(x => x.VisualSelection).Returns(selection);
 
@@ -128,10 +132,29 @@ namespace Vim.UI.Wpf.UnitTest
             var selection = new VisualSelection.Line(new SnapshotLineRange(snapshot.Object, 0, expectedLineCount), SearchPath.Forward, 0);
             mode.SetupGet(x => x.VisualSelection).Returns(selection);
             
+            _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
             _vimBuffer.ModeImpl = mode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.VisualLine;
+            
             var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
             Assert.Equal(expectedLineCount.ToString(), actual);
+        }
+        
+        [WpfFact]
+        public void GetCommandStatusVisualModeCommandInputs()
+        {
+            _search.SetupGet(x => x.InSearch).Returns(false);
+            var mode = _factory.Create<IVisualMode>();
+            var runner = _factory.Create<ICommandRunner>();
+            const string partialCommand = @"3f";
+            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
+            runner.SetupGet(x => x.Inputs).Returns(ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput)));
+            
+            _vimBuffer.ModeImpl = mode.Object;
+            _vimBuffer.ModeKindImpl = ModeKind.VisualCharacter;
+            
+            var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            Assert.Equal(partialCommand, actual);
         }
         
         [WpfFact]
@@ -140,11 +163,14 @@ namespace Vim.UI.Wpf.UnitTest
             _search.SetupGet(x => x.InSearch).Returns(false);
             var mode = _factory.Create<IVisualMode>();
             var runner = _factory.Create<ICommandRunner>();
-            const string partialCommand = @"3f";
+            const string partialCommand = @"\e";
             mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
-            runner.SetupGet(x => x.Inputs).Returns(ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput)));
+            runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
+            
+            _vimBuffer.BufferedKeyInputsImpl = ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput));
             _vimBuffer.ModeImpl = mode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.VisualCharacter;
+            
             var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
             Assert.Equal(partialCommand, actual);
         }

--- a/Test/VimWpfTest/CommandMarginUtilTest.cs
+++ b/Test/VimWpfTest/CommandMarginUtilTest.cs
@@ -50,12 +50,36 @@ namespace Vim.UI.Wpf.UnitTest
             const string partialCommand = @"\s";
             mode.SetupGet(x => x.Command).Returns(string.Empty);
             
+            var runner = _factory.Create<ICommandRunner>();
+            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
+            runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
+            
             _vimBuffer.BufferedKeyInputsImpl = ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput));
             _vimBuffer.NormalModeImpl = mode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.Normal;
             
             var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
             Assert.Equal(partialCommand, actual);
+        }
+        
+        [WpfFact]
+        public void GetCommandStatusNormalModeCommandInputs()
+        {
+            _search.SetupGet(x => x.InSearch).Returns(false);
+            var mode = _factory.Create<INormalMode>();
+            mode.SetupGet(x => x.Command).Returns(string.Empty);
+            
+            var runner = _factory.Create<ICommandRunner>();
+            const string partialCommand = "\u0017"; // <C-w>
+            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
+            runner.SetupGet(x => x.Inputs).Returns(ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput)));
+
+            _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
+            _vimBuffer.NormalModeImpl = mode.Object;
+            _vimBuffer.ModeKindImpl = ModeKind.Normal;
+            
+            var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            Assert.Equal("^W", actual);
         }
         
         [WpfFact]

--- a/Test/VimWpfTest/CommandMarginUtilTest.cs
+++ b/Test/VimWpfTest/CommandMarginUtilTest.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using Microsoft.FSharp.Collections;
-using Microsoft.VisualStudio.Text;
 using Moq;
 using Vim.EditorHost;
 using Vim.UI.Wpf.Implementation.CommandMargin;
@@ -114,7 +113,7 @@ namespace Vim.UI.Wpf.UnitTest
             mode.SetupGet(x => x.VisualSelection).Returns(selection);
 
             _vimBuffer.ModeImpl = mode.Object;
-            _vimBuffer.ModeKindImpl = ModeKind.VisualLine;
+            _vimBuffer.ModeKindImpl = ModeKind.VisualBlock;
             var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
             Assert.Equal($"{expectedLineCount}x{expectedColumnCount}", actual);
         }
@@ -124,8 +123,6 @@ namespace Vim.UI.Wpf.UnitTest
         {
             string[] lines = { "cat", "dog", "fish" };
             var textBuffer = CreateTextBuffer(lines);
-            
-           const int expectedLineCount = 23;
             
             _search.SetupGet(x => x.InSearch).Returns(false);
             var mode = _factory.Create<IVisualMode>();
@@ -138,8 +135,8 @@ namespace Vim.UI.Wpf.UnitTest
             _vimBuffer.ModeImpl = mode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.VisualLine;
             
-            var span = new CharacterSpan(textBuffer.GetPointInLine(1, 1), textBuffer.GetPointInLine(2, 3));
-            var selection = new VisualSelection.Character(span, SearchPath.Forward);
+            var span = new SnapshotLineRange(textBuffer.CurrentSnapshot, 1, 2);
+            var selection = new VisualSelection.Line(span, SearchPath.Forward, 0);
             mode.SetupGet(x => x.VisualSelection).Returns(selection);
             Assert.Equal("2", CommandMarginUtil.GetShowCommandText(_vimBuffer));
         }

--- a/Test/VimWpfTest/CommandMarginUtilTest.cs
+++ b/Test/VimWpfTest/CommandMarginUtilTest.cs
@@ -14,30 +14,45 @@ namespace Vim.UI.Wpf.UnitTest
         private readonly MockRepository _factory;
         private readonly Mock<IIncrementalSearch> _search;
         private readonly MockVimBuffer _vimBuffer;
+        private readonly Mock<ICommandRunner> _normalRunner;
+        private readonly Mock<INormalMode> _normalMode;
+        private readonly Mock<IVisualMode> _visualMode;
+        private readonly Mock<ICommandRunner> _visualRunner;
 
         public CommandMarginUtilTest()
         {
             _factory = new MockRepository(MockBehavior.Strict);
             
             _search = _factory.Create<IIncrementalSearch>();
+            _search.SetupGet(x => x.InSearch).Returns(false);
+            
+            _normalMode = _factory.Create<INormalMode>();
+            _normalMode.SetupGet(x => x.Command).Returns(string.Empty);
+            _normalRunner = _factory.Create<ICommandRunner>();
+            _normalMode.SetupGet(x => x.CommandRunner).Returns(_normalRunner.Object);
+            _normalRunner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
+
+            _visualMode = _factory.Create<IVisualMode>();
+            _visualRunner = _factory.Create<ICommandRunner>();
+            _visualMode.SetupGet(x => x.CommandRunner).Returns(_visualRunner.Object);
+            _visualRunner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
             
             _vimBuffer = new MockVimBuffer
-            {
-                IncrementalSearchImpl = _search.Object,
-                VimImpl = MockObjectFactory.CreateVim(factory: _factory).Object,
-                CommandModeImpl = _factory.Create<ICommandMode>(MockBehavior.Loose).Object
-            };
+                         {
+                                 IncrementalSearchImpl = _search.Object,
+                                 VimImpl = MockObjectFactory.CreateVim(factory: _factory).Object,
+                                 NormalModeImpl = _normalMode.Object,
+                                 BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty
+                         };
         }
 
         [WpfFact]
         public void GetCommandStatusNormalMode()
         {
-            _search.SetupGet(x => x.InSearch).Returns(false);
-            var mode = _factory.Create<INormalMode>();
             const string partialCommand = "di";
-            mode.SetupGet(x => x.Command).Returns(partialCommand);
-            _vimBuffer.NormalModeImpl = mode.Object;
+            _normalMode.SetupGet(x => x.Command).Returns(partialCommand);
             _vimBuffer.ModeKindImpl = ModeKind.Normal;
+
             var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
             Assert.Equal(partialCommand, actual);
         }
@@ -45,17 +60,8 @@ namespace Vim.UI.Wpf.UnitTest
         [WpfFact]
         public void GetCommandStatusNormalModeBufferedKeys()
         {
-            _search.SetupGet(x => x.InSearch).Returns(false);
-            var mode = _factory.Create<INormalMode>();
             const string partialCommand = @"\s";
-            mode.SetupGet(x => x.Command).Returns(string.Empty);
-            
-            var runner = _factory.Create<ICommandRunner>();
-            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
-            runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
-            
             _vimBuffer.BufferedKeyInputsImpl = ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput));
-            _vimBuffer.NormalModeImpl = mode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.Normal;
             
             var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
@@ -65,21 +71,17 @@ namespace Vim.UI.Wpf.UnitTest
         [WpfFact]
         public void GetCommandStatusNormalModeCommandInputs()
         {
-            _search.SetupGet(x => x.InSearch).Returns(false);
-            var mode = _factory.Create<INormalMode>();
-            mode.SetupGet(x => x.Command).Returns(string.Empty);
-            
-            var runner = _factory.Create<ICommandRunner>();
-            const string partialCommand = "\u0017"; // <C-w>
-            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
-            runner.SetupGet(x => x.Inputs).Returns(ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput)));
-
-            _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
-            _vimBuffer.NormalModeImpl = mode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.Normal;
             
+            const string partialCommand1 = "\u0017g"; // <C-w>g
+            _normalRunner.SetupGet(x => x.Inputs).Returns(ListModule.OfSeq(partialCommand1.Select(KeyInputUtil.CharToKeyInput)));
             var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
-            Assert.Equal("^W", actual);
+            Assert.Equal("^Wg", actual);
+            
+            const string partialCommand2 = "\u0017\u0007"; // <C-w><C-g>
+            _normalRunner.SetupGet(x => x.Inputs).Returns(ListModule.OfSeq(partialCommand2.Select(KeyInputUtil.CharToKeyInput)));
+            actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            Assert.Equal("^W^G", actual);
         }
         
         [WpfFact]
@@ -88,33 +90,26 @@ namespace Vim.UI.Wpf.UnitTest
             string[] lines = { "cat", "dog", "fish" };
             var textBuffer = CreateTextBuffer(lines);
 
-            _search.SetupGet(x => x.InSearch).Returns(false);
-            var mode = _factory.Create<IVisualMode>();
-            var runner = _factory.Create<ICommandRunner>();
-            runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
-            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
-
             _vimBuffer.TextBufferImpl = textBuffer;
-            _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
-            _vimBuffer.ModeImpl = mode.Object;
+            _vimBuffer.ModeImpl = _visualMode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.VisualCharacter;
             
             // span1 selection is within one line, so the display should be the selected character count
             var span1 = new CharacterSpan(textBuffer.GetPointInLine(1, 1), textBuffer.GetPointInLine(1, 3));
             var selection1 = new VisualSelection.Character(span1, SearchPath.Forward);
-            mode.SetupGet(x => x.VisualSelection).Returns(selection1);
+            _visualMode.SetupGet(x => x.VisualSelection).Returns(selection1);
             Assert.Equal("2", CommandMarginUtil.GetShowCommandText(_vimBuffer));
             
             // span2 selection is over two lines, so the the display should be the selected line count
             var span2 = new CharacterSpan(textBuffer.GetPointInLine(0, 1), textBuffer.GetPointInLine(1, 2));
             var selection2 = new VisualSelection.Character(span2, SearchPath.Forward);
-            mode.SetupGet(x => x.VisualSelection).Returns(selection2);
+            _visualMode.SetupGet(x => x.VisualSelection).Returns(selection2);
             Assert.Equal("2", CommandMarginUtil.GetShowCommandText(_vimBuffer));
 
             // span3 selection is within one line and includes the CRLF at the end of the line, so the the display should be the length of the line + 1
             var span3 = new CharacterSpan(textBuffer.GetPointInLine(1, 1), textBuffer.GetPointInLine(1, lines[1].Length + 2));
             var selection3 = new VisualSelection.Character(span3, SearchPath.Forward);
-            mode.SetupGet(x => x.VisualSelection).Returns(selection3);
+            _visualMode.SetupGet(x => x.VisualSelection).Returns(selection3);
             Assert.Equal("3", CommandMarginUtil.GetShowCommandText(_vimBuffer));
         }
         
@@ -128,15 +123,10 @@ namespace Vim.UI.Wpf.UnitTest
             var span = new BlockSpan(textBuffer.GetPoint(0), 4, expectedColumnCount, expectedLineCount);
             var selection = new VisualSelection.Block(span, BlockCaretLocation.TopLeft);
 
-            _search.SetupGet(x => x.InSearch).Returns(false);
-            var mode = _factory.Create<IVisualMode>();
-            var runner = _factory.Create<ICommandRunner>();
-            runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
             _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
-            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
-            mode.SetupGet(x => x.VisualSelection).Returns(selection);
+            _visualMode.SetupGet(x => x.VisualSelection).Returns(selection);
 
-            _vimBuffer.ModeImpl = mode.Object;
+            _vimBuffer.ModeImpl = _visualMode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.VisualBlock;
             var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
             Assert.Equal($"{expectedLineCount}x{expectedColumnCount}", actual);
@@ -148,34 +138,23 @@ namespace Vim.UI.Wpf.UnitTest
             string[] lines = { "cat", "dog", "fish" };
             var textBuffer = CreateTextBuffer(lines);
             
-            _search.SetupGet(x => x.InSearch).Returns(false);
-            var mode = _factory.Create<IVisualMode>();
-            var runner = _factory.Create<ICommandRunner>();
-            runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
-            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
-
             _vimBuffer.TextBufferImpl = textBuffer;
-            _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
-            _vimBuffer.ModeImpl = mode.Object;
+            _vimBuffer.ModeImpl = _visualMode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.VisualLine;
             
             var span = new SnapshotLineRange(textBuffer.CurrentSnapshot, 1, 2);
             var selection = new VisualSelection.Line(span, SearchPath.Forward, 0);
-            mode.SetupGet(x => x.VisualSelection).Returns(selection);
+            _visualMode.SetupGet(x => x.VisualSelection).Returns(selection);
             Assert.Equal("2", CommandMarginUtil.GetShowCommandText(_vimBuffer));
         }
         
         [WpfFact]
         public void GetCommandStatusVisualModeCommandInputs()
         {
-            _search.SetupGet(x => x.InSearch).Returns(false);
-            var mode = _factory.Create<IVisualMode>();
-            var runner = _factory.Create<ICommandRunner>();
             const string partialCommand = @"3f";
-            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
-            runner.SetupGet(x => x.Inputs).Returns(ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput)));
+            _visualRunner.SetupGet(x => x.Inputs).Returns(ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput)));
             
-            _vimBuffer.ModeImpl = mode.Object;
+            _vimBuffer.ModeImpl = _visualMode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.VisualCharacter;
             
             var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
@@ -185,15 +164,10 @@ namespace Vim.UI.Wpf.UnitTest
         [WpfFact]
         public void GetCommandStatusVisualModeBufferedKeys()
         {
-            _search.SetupGet(x => x.InSearch).Returns(false);
-            var mode = _factory.Create<IVisualMode>();
-            var runner = _factory.Create<ICommandRunner>();
             const string partialCommand = @"\e";
-            mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
-            runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
             
             _vimBuffer.BufferedKeyInputsImpl = ListModule.OfSeq(partialCommand.Select(KeyInputUtil.CharToKeyInput));
-            _vimBuffer.ModeImpl = mode.Object;
+            _vimBuffer.ModeImpl = _visualMode.Object;
             _vimBuffer.ModeKindImpl = ModeKind.VisualCharacter;
             
             var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);


### PR DESCRIPTION
Proposed implementation of feature request: #2181 

I'm a bit unsatisfied with the frequent double-update of the showcmd area in CommandMarginController, once on KeyInputEnd, and again on KeyInputProcessed.  There may be a more efficient way of positioning these updates, but not being 100% comfortable with the key-processing model, I'm playing it safe here.  Note that AFAIK, KeyInputProcessed only needs to be handled due to the fact that buffered keys could be processed in KeyMappingTimeoutHandler.OnTimerTick after a timeout.