### PR TITLE
Improve out-of-the-box fidelity with vim

### DIFF
--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -63,7 +63,7 @@ namespace Vim.UI.Wpf
 
         public virtual DefaultSettings DefaultSettings
         {
-            get { return DefaultSettings.GVim73; }
+            get { return DefaultSettings.GVim74; }
         }
 
         protected VimHost(

--- a/Test/VimCoreTest/VimTest.cs
+++ b/Test/VimCoreTest/VimTest.cs
@@ -60,7 +60,7 @@ namespace Vim.UnitTest
             _vimHost.Setup(x => x.AutoSynchronizeSettings).Returns(true);
             _vimHost.Setup(x => x.VimCreated(It.IsAny<IVim>()));
             _vimHost.Setup(x => x.GetName(It.IsAny<ITextBuffer>())).Returns("VimTest.cs");
-            _vimHost.SetupGet(x => x.DefaultSettings).Returns(DefaultSettings.GVim73);
+            _vimHost.SetupGet(x => x.DefaultSettings).Returns(DefaultSettings.GVim74);
             if (createVim)
             {
                 CreateVim();


### PR DESCRIPTION
### Changes

- Set the default behavior to GVim74 instead of GVim73 (gvim has defaulted to `:behave mswin` for five years now)
- Remove "advanced key" exceptions to "handle all with VsVim" because VsVim emulates all of them

# Discussion

Vim assumes that on Windows, new users will be most familiar with Windows-like `selectmode` and `<C-c>` to copy, and `<C-v>` to paste. Yet VsVim currently defaults to `behave=xterm` and even users who select "handle all with VsVim" need to manually toggle half a dozen settings to get the full VsVim keyboard.

VsVim can get the best of both worlds by defaulting to `behave mswin` (the effective meaning of GVim74) and making it easy to truly handle all keys with VsVim.