### PR TITLE
Load session data before loading vimrc

### DIFF
--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -639,15 +639,18 @@ type internal Vim
             x.CreateVimBuffer textView (Some settings)
 
     member x.MaybeLoadFiles() =
+
+        // Load registers before loading the vimrc so that
+        // registers that are set in the vimrc "stick".
+        if x.AutoLoadSessionData && not _sessionDataAutoLoaded then
+            x.LoadSessionData()
+            _sessionDataAutoLoaded <- true
+
         if x.AutoLoadVimRc then
             match _vimRcState with
             | VimRcState.None -> x.LoadVimRc() |> ignore
             | VimRcState.LoadSucceeded _ -> ()
             | VimRcState.LoadFailed -> ()
-
-        if x.AutoLoadSessionData && not _sessionDataAutoLoaded then
-            x.LoadSessionData()
-            _sessionDataAutoLoaded <- true
 
     member x.LoadVimRcCore() =
         Contract.Assert(_isLoadingVimRc)


### PR DESCRIPTION
Because session data was loaded after loading the vimrc, it was impossible set a register in an rc file.

Fixes #2094
