### PR TITLE
Ensure VsVim package is loaded when loading session data

### DIFF
--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4129,6 +4129,9 @@ type IVimHost =
     /// then -1 should be returned
     abstract TabCount: int
 
+    /// Ensure that the VsVim package is loaded
+    abstract EnsurePackageLoaded: unit -> unit
+
     abstract Beep: unit -> unit
 
     /// Called at the start of a bulk operation such as a macro replay or a repeat of

--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -795,6 +795,11 @@ type internal Vim
             | None -> ()
 
     member x.LoadSessionData() =
+
+        // Make sure the VsVim package is loaded so that session data
+        // will be saved on exit (issues #2087 and #1726).
+        _vimHost.EnsurePackageLoaded()
+
         x.LoadSessionDataCore (x.GetSessionDataFilePath())
 
     member x.SaveSessionDataCore filePath = 

--- a/Src/VimTestUtils/Mock/MockVimHost.cs
+++ b/Src/VimTestUtils/Mock/MockVimHost.cs
@@ -22,6 +22,7 @@ namespace Vim.UnitTest.Mock
         public bool IsAutoCommandEnabled { get; set; }
         public bool IsUndoRedoExpected { get; set; }
         public DefaultSettings DefaultSettings { get; set; }
+        public bool EnsuredPackageLoaded { get; private set; }
         public int BeepCount { get; set; }
         public bool ClosedOtherWindows { get; private set; }
         public bool ClosedOtherTabs { get; private set; }
@@ -106,6 +107,11 @@ namespace Vim.UnitTest.Mock
             ShouldCreateVimBufferImpl = false;
             ShouldIncludeRcFile = true;
             WordWrapStyle = WordWrapStyles.WordWrap;
+        }
+
+        void IVimHost.EnsurePackageLoaded()
+        {
+            EnsuredPackageLoaded = true;
         }
 
         void IVimHost.Beep()

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -78,6 +78,10 @@ namespace Vim.UI.Wpf
             _editorOperationsFactoryService = editorOperationsFactoryService;
         }
 
+        public virtual void EnsurePackageLoaded()
+        {
+        }
+
         public virtual void Beep()
         {
             SystemSounds.Beep.Play();
@@ -529,6 +533,11 @@ namespace Vim.UI.Wpf
         DefaultSettings IVimHost.DefaultSettings
         {
             get { return DefaultSettings; }
+        }
+
+        void IVimHost.EnsurePackageLoaded()
+        {
+            EnsurePackageLoaded();
         }
 
         void IVimHost.Beep()

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -144,6 +144,7 @@ namespace Vim.VisualStudio
         private readonly ISmartIndentationService _smartIndentationService;
         private readonly IExtensionAdapterBroker _extensionAdapterBroker;
         private readonly IVsRunningDocumentTable _runningDocumentTable;
+        private readonly IVsShell _vsShell;
         private IVim _vim;
 
         internal _DTE DTE
@@ -213,6 +214,7 @@ namespace Vim.VisualStudio
             _smartIndentationService = smartIndentationService;
             _extensionAdapterBroker = extensionAdapterBroker;
             _runningDocumentTable = serviceProvider.GetService<SVsRunningDocumentTable, IVsRunningDocumentTable>();
+            _vsShell = (IVsShell)serviceProvider.GetService(typeof(SVsShell));
 
             _vsMonitorSelection.AdviseSelectionEvents(this, out uint selectionCookie);
             _runningDocumentTable.AdviseRunningDocTableEvents(this, out uint runningDocumentTableCookie);
@@ -258,6 +260,12 @@ namespace Vim.VisualStudio
                 telemetry.WriteEvent($"VsVim Installed {VimConstants.VersionNumber}");
                 vimApplicationSettings.LastVersionUsed = VimConstants.VersionNumber;
             }
+        }
+
+        public override void EnsurePackageLoaded()
+        {
+            var guid = VsVimConstants.PackageGuid;
+            _vsShell.LoadPackage(ref guid, out IVsPackage package);
         }
 
         public override void CloseAllOtherTabs(ITextView textView)

--- a/Test/VimCoreTest/VimTest.cs
+++ b/Test/VimCoreTest/VimTest.cs
@@ -60,6 +60,7 @@ namespace Vim.UnitTest
             _vimHost.Setup(x => x.AutoSynchronizeSettings).Returns(true);
             _vimHost.Setup(x => x.VimCreated(It.IsAny<IVim>()));
             _vimHost.Setup(x => x.GetName(It.IsAny<ITextBuffer>())).Returns("VimTest.cs");
+            _vimHost.Setup(x => x.EnsurePackageLoaded());
             _vimHost.SetupGet(x => x.DefaultSettings).Returns(DefaultSettings.GVim74);
             if (createVim)
             {
@@ -239,6 +240,16 @@ namespace Vim.UnitTest
                 var register = _vim.RegisterMap.GetRegister(name);
                 Assert.Equal(kind, register.OperationKind);
                 Assert.Equal(value, register.StringValue);
+            }
+
+            [WpfFact]
+            public void PackageLoaded()
+            {
+                var ensuredPackageLoaded = false;
+                _vimHost.Setup(x => x.EnsurePackageLoaded())
+                    .Callback(() => { ensuredPackageLoaded = true; });
+                _vimRaw.LoadSessionData();
+                Assert.True(ensuredPackageLoaded);
             }
 
             [WpfFact]

--- a/Test/VsVimSharedTest/VsVimHostTest.cs
+++ b/Test/VsVimSharedTest/VsVimHostTest.cs
@@ -30,7 +30,8 @@ namespace Vim.VisualStudio.UnitTest
         private Mock<IEditorOperationsFactoryService> _editorOperationsFactoryService;
         private Mock<IVimApplicationSettings> _vimApplicationSettings;
         private Mock<_DTE> _dte;
-        private Mock<IVsUIShell4> _shell;
+        private Mock<IVsUIShell4> _uiVSShell;
+        private Mock<IVsShell> _vsShell;
         private Mock<StatusBar> _statusBar;
         private Mock<IExtensionAdapterBroker> _extensionAdapterBroker;
 
@@ -44,7 +45,8 @@ namespace Vim.VisualStudio.UnitTest
             _editorAdaptersFactoryService = _factory.Create<IVsEditorAdaptersFactoryService>();
             _editorOperationsFactoryService = _factory.Create<IEditorOperationsFactoryService>();
             _statusBar = _factory.Create<StatusBar>();
-            _shell = _factory.Create<IVsUIShell4>();
+            _uiVSShell = _factory.Create<IVsUIShell4>();
+            _vsShell = _factory.Create<IVsShell>(MockBehavior.Loose);
             _dte = _factory.Create<_DTE>();
             _dte.SetupGet(x => x.StatusBar).Returns(_statusBar.Object);
             _textManager = _factory.Create<ITextManager>();
@@ -65,7 +67,8 @@ namespace Vim.VisualStudio.UnitTest
 
             var sp = _factory.Create<SVsServiceProvider>();
             sp.Setup(x => x.GetService(typeof(_DTE))).Returns(_dte.Object);
-            sp.Setup(x => x.GetService(typeof(SVsUIShell))).Returns(_shell.Object);
+            sp.Setup(x => x.GetService(typeof(SVsUIShell))).Returns(_uiVSShell.Object);
+            sp.Setup(x => x.GetService(typeof(SVsShell))).Returns(_vsShell.Object);
             sp.Setup(x => x.GetService(typeof(IVsExtensibility))).Returns(_factory.Create<IVsExtensibility>().Object);
             sp.Setup(x => x.GetService(typeof(SVsShellMonitorSelection))).Returns(vsMonitorSelection.Object);
             sp.Setup(x => x.GetService(typeof(SVsRunningDocumentTable))).Returns(vsRunningDocumentTable.Object);


### PR DESCRIPTION
### Fixes

- Fixes #1726
- Fixes #2087

### Discussion

Because the VsVim package was responsible for saving session data, and because Visual Studio lazy loads packages, it was often the case the VsVim session data was not saved. This change ensures that whenever we load session data, the VsVim package is also loaded so that session data will be saved on exit.