### PR TITLE
Showcmd updates

### DIFF
--- a/Src/VimCore/CommandRunner.fs
+++ b/Src/VimCore/CommandRunner.fs
@@ -73,7 +73,7 @@ type internal CommandRunner
         | Some count -> count
         | None -> 1
 
-    member x.Inputs = List.rev _data.Inputs
+    member x.Inputs = _data.Inputs
 
     /// Try and get the VisualSpan for the provided kind
     member x.GetVisualSpan kind = VisualSpan.CreateForSelection _textView kind _localSettings.TabStop
@@ -331,7 +331,7 @@ type internal CommandRunner
             // support reentrancy while binding
             BindResult.Error
         else
-            _data <- {_data with Inputs = ki :: _data.Inputs }
+            _data <- {_data with Inputs = _data.Inputs @ [ki] }
             let result = 
                 _inBind <- true
                 try

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3569,6 +3569,7 @@ type ICommandRunner =
     /// When HasCount is true this has the associated count
     abstract Count: int 
 
+    /// List of processed KeyInputs in the order in which they were typed
     abstract Inputs: KeyInput list
     
     /// Add a Command.  If there is already a Command with the same name an exception will

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Text;
-using System.Windows;
-using Microsoft.VisualStudio.Text;
 using Vim.Extensions;
 using Vim.UI.Wpf.Properties;
 
@@ -239,34 +235,16 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         private static string GetNormalModeShowCommandText(IVimBuffer vimBuffer)
         {
             var normalMode = vimBuffer.NormalMode;
-            if (normalMode.CommandRunner.Inputs.Any())
-            {
-                return KeyInputsToShowCommandText(normalMode.CommandRunner.Inputs);
-            }
-
-            if (vimBuffer.BufferedKeyInputs.Any())
-            {
-                return KeyInputsToShowCommandText(vimBuffer.BufferedKeyInputs);
-            }
-
-            if (!string.IsNullOrEmpty(normalMode.Command))
-            {
-                return normalMode.Command;
-            }
-
-            return string.Empty;
+            var cmdText = KeyInputsToShowCommandText(normalMode.CommandRunner.Inputs.Concat(vimBuffer.BufferedKeyInputs));
+            return string.IsNullOrEmpty(cmdText) ? normalMode.Command : cmdText;
         }
 
         private static string GetVisualModeShowCommandText(IVimBuffer vimBuffer, IVisualMode visualMode)
         {
-            if (visualMode.CommandRunner.Inputs.Any())
+            var cmdText = KeyInputsToShowCommandText(visualMode.CommandRunner.Inputs.Concat(vimBuffer.BufferedKeyInputs));
+            if (!string.IsNullOrEmpty(cmdText))
             {
-                return KeyInputsToShowCommandText(visualMode.CommandRunner.Inputs);
-            }
-
-            if (vimBuffer.BufferedKeyInputs.Any())
-            {
-                return KeyInputsToShowCommandText(vimBuffer.BufferedKeyInputs);
+                return cmdText;
             }
 
             var visualSpan = visualMode.VisualSelection.VisualSpan;

--- a/Test/VimWpfTest/CommandMarginUtilTest.cs
+++ b/Test/VimWpfTest/CommandMarginUtilTest.cs
@@ -85,6 +85,19 @@ namespace Vim.UI.Wpf.UnitTest
         }
         
         [WpfFact]
+        public void GetCommandStatusNormalModeCommandInputsAndBufferedKeys()
+        {
+            const string commandInputs = "2c";
+            const string bufferedInputs = "2t";
+            _normalRunner.SetupGet(x => x.Inputs).Returns(ListModule.OfSeq(commandInputs.Select(KeyInputUtil.CharToKeyInput)));
+            _vimBuffer.BufferedKeyInputsImpl = ListModule.OfSeq(bufferedInputs.Select(KeyInputUtil.CharToKeyInput));
+            _vimBuffer.ModeKindImpl = ModeKind.Normal;
+            
+            var actual = CommandMarginUtil.GetShowCommandText(_vimBuffer);
+            Assert.Equal(commandInputs + bufferedInputs, actual);
+        }
+
+        [WpfFact]
         public void GetCommandStatusVisualCharacterMode()
         {
             string[] lines = { "cat", "dog", "fish" };


### PR DESCRIPTION
Updates to issue: #2194 

* Command runner stores key inputs in the order in which they are typed by the user.  Avoids the need to repeatedly reverse the list for display purposes.

* Buffered key inputs should be displayed in addition to inputs processed by the command runner, such as in the case where key inputs that are not prefixes are followed by inputs that are prefixes.  

E.g. in Vim:
`:set showcmd`
`:noremap c "_c`
`:noremap cc "_cc`
Typing `2c` should display `2c`
Typing `2c2` should display `2"_c2`