### PR TITLE
Append empty transaction when completing an active linked undo transaction

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -888,7 +888,8 @@ type internal CommandUtil
     /// Used for the several commands which make an edit here and need the edit to be linked
     /// with the next insert mode change.
     member x.CreateTransactionForLinkedChange name action =
-        let transaction = _undoRedoOperations.CreateLinkedUndoTransaction name
+        let flags = LinkedUndoTransactionFlags.EndsWithInsert
+        let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags name flags
 
         try
             x.EditWithUndoTransaction name action

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -1597,6 +1597,7 @@ type internal CommonOperations
     /// after the redo completes
     member x.Redo count = 
         _undoRedoOperations.Redo count
+        x.AdjustCaretForVirtualEdit()
         x.EnsureAtPoint x.CaretPoint ViewFlags.Standard
 
     /// Ensure the given view properties are met at the given point

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -211,6 +211,8 @@ type LinkedUndoTransactionFlags =
 
     | CanBeEmpty = 0x1
 
+    | EndsWithInsert = 0x2
+
 /// Wraps a set of IUndoTransaction items such that they undo and redo as a single
 /// entity.
 type ILinkedUndoTransaction =

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -750,7 +750,7 @@ type internal InsertMode
         | None -> ()
         | Some transaction ->
             transaction.Complete()
-            let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags name LinkedUndoTransactionFlags.CanBeEmpty
+            let transaction = x.CreateLinkedUndoTransaction name
             _sessionData <- { _sessionData with Transaction = Some transaction }
 
     /// Paste the contents of the specified register with the given flags 

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -1050,6 +1050,11 @@ type internal InsertMode
     member x.OnClose () =
         _bag.DisposeAll()
 
+    /// Create a linked undo transaction suitable for insert mode
+    member x.CreateLinkedUndoTransaction name =
+        let flags = LinkedUndoTransactionFlags.CanBeEmpty ||| LinkedUndoTransactionFlags.EndsWithInsert
+        _undoRedoOperations.CreateLinkedUndoTransactionWithFlags name flags
+
     /// Entering an insert or replace mode.  Setup the InsertSessionData based on the 
     /// ModeArgument value. 
     member x.OnEnter arg =
@@ -1070,10 +1075,10 @@ type internal InsertMode
                 Some transaction, InsertKind.Block (atEndOfLine, blockSpan)
             | ModeArgument.InsertWithCount count ->
                 if count > 1 then
-                    let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Insert with count" LinkedUndoTransactionFlags.CanBeEmpty
+                    let transaction = x.CreateLinkedUndoTransaction "Insert with count"
                     Some transaction, InsertKind.Repeat (count, false, TextChange.Insert StringUtil.Empty)
                 else
-                    let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Insert" LinkedUndoTransactionFlags.CanBeEmpty
+                    let transaction = x.CreateLinkedUndoTransaction "Insert"
                     Some transaction, InsertKind.Normal
             | ModeArgument.InsertWithCountAndNewLine (count, transaction) ->
                 if count > 1 then
@@ -1083,7 +1088,7 @@ type internal InsertMode
             | ModeArgument.InsertWithTransaction transaction ->
                 Some transaction, InsertKind.Normal
             | _ -> 
-                let transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags "Insert with transaction" LinkedUndoTransactionFlags.CanBeEmpty
+                let transaction = x.CreateLinkedUndoTransaction "Insert with transaction"
                 Some transaction, InsertKind.Normal
 
         // If the LastCommand coming into insert / replace mode is not setup for linking 

--- a/Src/VimCore/UndoRedoOperations.fs
+++ b/Src/VimCore/UndoRedoOperations.fs
@@ -363,7 +363,16 @@ and UndoRedoOperations
                 | UndoRedoData.Linked (count, false) :: tail -> 
                     Contract.Assert(count > 0)
                     hasData <- true
-                    _undoStack <- UndoRedoData.Linked (count, true) :: tail
+
+                    // Append an empty transaction to the previous undo transaction
+                    // to break the undo sequence.
+                    match _textUndoHistory with
+                    | Some textUndoHistory ->
+                        use undoTransaction = textUndoHistory.CreateTransaction "Break undo sequence"
+                        undoTransaction.Complete()
+                    | None -> ()
+
+                    _undoStack <- UndoRedoData.Linked (count + 1, true) :: tail
                 | _ -> ()
 
                 // If a linked undo operation completes that contains 0 undo / redo items that very likely 

--- a/Test/VimCoreTest/CommandUtilTest.cs
+++ b/Test/VimCoreTest/CommandUtilTest.cs
@@ -555,7 +555,7 @@ namespace Vim.UnitTest
                 var transaction = new Mock<ILinkedUndoTransaction>(MockBehavior.Strict);
                 transaction.Setup(x => x.Dispose()).Verifiable();
                 _undoRedoOperations
-                    .Setup(x => x.CreateLinkedUndoTransaction(It.IsAny<string>()))
+                    .Setup(x => x.CreateLinkedUndoTransactionWithFlags(It.IsAny<string>(), It.IsAny<LinkedUndoTransactionFlags>()))
                     .Returns(transaction.Object)
                     .Verifiable();
                 _undoRedoOperations
@@ -592,7 +592,7 @@ namespace Vim.UnitTest
                 var transaction = new Mock<ILinkedUndoTransaction>(MockBehavior.Strict);
                 transaction.Setup(x => x.Dispose()).Verifiable();
                 _undoRedoOperations
-                    .Setup(x => x.CreateLinkedUndoTransaction(It.IsAny<string>()))
+                    .Setup(x => x.CreateLinkedUndoTransactionWithFlags(It.IsAny<string>(), It.IsAny<LinkedUndoTransactionFlags>()))
                     .Returns(transaction.Object)
                     .Verifiable();
                 _undoRedoOperations

--- a/Test/VimCoreTest/UndoRedoOperationsTest.cs
+++ b/Test/VimCoreTest/UndoRedoOperationsTest.cs
@@ -46,6 +46,16 @@ namespace Vim.UnitTest
                     _mockUndoHistory = _factory.Create<ITextUndoHistory>();
                     _mockUndoHistory.Setup(x => x.Undo(It.IsAny<int>())).Callback<int>(count => { _undoCount += count; });
                     _mockUndoHistory.Setup(x => x.Redo(It.IsAny<int>())).Callback<int>(count => { _redoCount += count; });
+                    _mockUndoHistory.Setup(x => x.CreateTransaction(It.IsAny<string>()))
+                        .Returns<string>(
+                            name =>
+                            {
+                                var transaction = _factory.Create<ITextUndoTransaction>();
+                                transaction.Setup(x => x.Complete());
+                                transaction.Setup(x => x.Dispose());
+                                return transaction.Object;
+                            }
+                        );
                     textUndoHistory = FSharpOption.Create(_mockUndoHistory.Object);
                     break;
 
@@ -167,7 +177,7 @@ namespace Vim.UnitTest
                 }
 
                 _undoRedoOperations.Undo(1);
-                Assert.Equal(3, _undoCount);
+                Assert.Equal(4, _undoCount);
             }
 
             [WpfFact]
@@ -180,9 +190,9 @@ namespace Vim.UnitTest
                 }
 
                 _undoRedoOperations.Undo(1);
-                Assert.Equal(3, _undoCount);
+                Assert.Equal(4, _undoCount);
                 _undoRedoOperations.Redo(1);
-                Assert.Equal(3, _redoCount);
+                Assert.Equal(4, _redoCount);
             }
 
             [WpfFact]
@@ -369,7 +379,7 @@ namespace Vim.UnitTest
                 }
 
                 _undoRedoOperationsRaw.Undo(1);
-                Assert.Equal(10, _undoCount);
+                Assert.Equal(11, _undoCount);
                 Assert.Equal(0, _undoRedoOperationsRaw.UndoStack.Length);
             }
 
@@ -469,7 +479,7 @@ namespace Vim.UnitTest
                 }
                 _undoRedoOperations.Undo(count: 1);
                 _undoRedoOperationsRaw.Redo(1);
-                Assert.Equal(10, _redoCount);
+                Assert.Equal(11, _redoCount);
                 Assert.Equal(0, _undoRedoOperationsRaw.RedoStack.Length);
                 Assert.Equal(1, _undoRedoOperationsRaw.UndoStack.Length);
             }

--- a/Test/VimCoreTest/UndoRedoOperationsTest.cs
+++ b/Test/VimCoreTest/UndoRedoOperationsTest.cs
@@ -177,6 +177,19 @@ namespace Vim.UnitTest
                 }
 
                 _undoRedoOperations.Undo(1);
+                Assert.Equal(3, _undoCount);
+            }
+
+            [WpfFact]
+            public void UndoGroupEndsWithInsert()
+            {
+                Create();
+                using (var transaction = _undoRedoOperations.CreateLinkedUndoTransactionWithFlags("test", LinkedUndoTransactionFlags.EndsWithInsert))
+                {
+                    RaiseUndoTransactionCompleted(count: 3);
+                }
+
+                _undoRedoOperations.Undo(1);
                 Assert.Equal(4, _undoCount);
             }
 
@@ -190,9 +203,9 @@ namespace Vim.UnitTest
                 }
 
                 _undoRedoOperations.Undo(1);
-                Assert.Equal(4, _undoCount);
+                Assert.Equal(3, _undoCount);
                 _undoRedoOperations.Redo(1);
-                Assert.Equal(4, _redoCount);
+                Assert.Equal(3, _redoCount);
             }
 
             [WpfFact]
@@ -379,7 +392,7 @@ namespace Vim.UnitTest
                 }
 
                 _undoRedoOperationsRaw.Undo(1);
-                Assert.Equal(11, _undoCount);
+                Assert.Equal(10, _undoCount);
                 Assert.Equal(0, _undoRedoOperationsRaw.UndoStack.Length);
             }
 
@@ -479,7 +492,7 @@ namespace Vim.UnitTest
                 }
                 _undoRedoOperations.Undo(count: 1);
                 _undoRedoOperationsRaw.Redo(1);
-                Assert.Equal(11, _redoCount);
+                Assert.Equal(10, _redoCount);
                 Assert.Equal(0, _undoRedoOperationsRaw.RedoStack.Length);
                 Assert.Equal(1, _undoRedoOperationsRaw.UndoStack.Length);
             }


### PR DESCRIPTION
Fixes #2225
