### PR TITLE
Fix g8 display to use hex

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -883,8 +883,8 @@ type internal CommandUtil
             let builder = StringBuilder()
             for i = 0 to bytes.Length - 1 do
                 let str = sprintf "%02x" bytes.[i]
-                builder.AppendString str
                 if i > 0 then builder.AppendChar ' '
+                builder.AppendString str
             _statusUtil.OnStatus (builder.ToString())
         CommandResult.Completed ModeSwitch.NoSwitch
 

--- a/Test/VimCoreTest/CommandUtilTest.cs
+++ b/Test/VimCoreTest/CommandUtilTest.cs
@@ -166,6 +166,37 @@ namespace Vim.UnitTest
             }
         }
 
+        public sealed class DisplayCharacterBytesTest : CommandUtilTest
+        {
+            private void Check(string expected)
+            {
+                _statusUtil.Setup(x => x.OnStatus(expected)).Verifiable();
+                _commandUtil.DisplayCharacterBytes();
+                _statusUtil.Verify();
+            }
+
+            [WpfFact]
+            public void AsciiSimple()
+            {
+                Create("cat");
+                Check("63");
+            }
+
+            [WpfFact]
+            public void ZeroFillSimple()
+            {
+                Create("\t");
+                Check("09");
+            }
+
+            [WpfFact]
+            public void SurrogatePair()
+            {
+                Create("𠈓");
+                Check("f0 a0 88 93");
+            }
+        }
+
         /// <summary>
         /// The majority of the fold functions are just pass throughs to the IFoldManager
         /// implementation.  Make sure they are actually passed through

--- a/Test/VimCoreTest/CommandUtilTest.cs
+++ b/Test/VimCoreTest/CommandUtilTest.cs
@@ -194,6 +194,23 @@ namespace Vim.UnitTest
                 Create("𠈓");
                 Check("f0 a0 88 93");
             }
+
+            [WpfFact]
+            public void SurrogatePairLowSurrogae()
+            {
+                Create("𠈓");
+                _textView.MoveCaretTo(1);
+                Check("f0 a0 88 93");
+            }
+
+            [WpfFact]
+            public void EndPoint()
+            {
+                Create("hello");
+                _textView.MoveCaretTo(_textBuffer.CurrentSnapshot.Length);
+                _commandUtil.DisplayCharacterBytes();
+                Assert.Equal(1, VimHost.BeepCount);
+            }
         }
 
         /// <summary>

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -4532,6 +4532,29 @@ namespace Vim.UnitTest
                 _vimBuffer.ProcessNotation("j");
                 Assert.Equal(3, _textView.GetCaretPoint().GetColumn().Column);
             }
+
+            [WpfFact]
+            public void SurrogatePairToHighCharacterBelow()
+            {
+                Create("A𠈓C", "tree");
+                _textView.MoveCaretTo(1);
+                _vimBuffer.ProcessNotation("j");
+                Assert.Equal(_textBuffer.GetPointInLine(line: 1, column: 1), _textView.GetCaretPoint());
+                _vimBuffer.ProcessNotation("k");
+                Assert.Equal(_textBuffer.GetPointInLine(line: 0, column: 1), _textView.GetCaretPoint());
+                _textView.MoveCaretToLine(lineNumber: 1, column: 2);
+            }
+
+            [WpfFact]
+            public void SurrogatePairFromLowCharacterBelow()
+            {
+                Create("A𠈓C", "tree");
+                _textView.MoveCaretToLine(lineNumber: 1, column: 2);
+                _vimBuffer.ProcessNotation("k");
+                Assert.Equal(_textBuffer.GetPointInLine(line: 0, column: 1), _textView.GetCaretPoint());
+                _vimBuffer.ProcessNotation("j");
+                Assert.Equal(_textBuffer.GetPointInLine(line: 1, column: 2), _textView.GetCaretPoint());
+            }
         }
 
         public sealed class ChangeCaseMotionTest : NormalModeIntegrationTest


### PR DESCRIPTION
Changes the g8 command to both:

- Display values in hex not decimal
- Display surrogate pairs properly