### PR TITLE
Prevent dot from matching part of a linebreak

### DIFF
--- a/Src/VimCore/VimRegex.fs
+++ b/Src/VimCore/VimRegex.fs
@@ -398,6 +398,7 @@ type VimRegexBuilder
 
 module VimRegexFactory =
 
+    let DotRegex = @"[^\r\n]"
     let DollarRegex = @"(?<!\r)(?=\r?$)"
     let NewLineRegex = @"(?<!\r)\r?\n"
 
@@ -543,7 +544,11 @@ module VimRegexFactory =
     /// magic setting.
     let ConvertCharAsSpecial (data: VimRegexBuilder) c = 
         match c with
-        | '.' -> data.AppendChar '.'
+        | '.' ->
+            if data.IsCollectionOpen then
+                ConvertCharAsNormal data '.'
+            else
+                data.AppendString DotRegex
         | '+' -> data.AppendChar '+'
         | '=' -> data.AppendChar '?'
         | '?' -> data.AppendChar '?'

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -1268,6 +1268,19 @@ namespace Vim.UnitTest
                     RunCommandRaw(@":s/\*6/\*7/g");
                     Assert.Equal("*7", _textBuffer.GetLine(0).GetText());
                 }
+
+                /// <summary>
+                /// A dot cannot match any portion of the linebreak
+                /// </summary>
+                [WpfFact]
+                public void DotCannotMatchTheLineBreak()
+                {
+                    /// Reported in issue #2236.
+                    Create("abc", "def", "");
+                    Assert.Equal("abc\r\ndef\r\n", _textView.TextSnapshot.GetText());
+                    RunCommandRaw(":s/.*/xxx");
+                    Assert.Equal("xxx\r\ndef\r\n", _textView.TextSnapshot.GetText());
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #2236