### PR TITLE
Put fixes

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -2178,6 +2178,8 @@ type internal CommandUtil
                     match command with
                     | NormalCommand.PutAfterCaret _
                     | NormalCommand.PutBeforeCaret _
+                    | NormalCommand.PutAfterCaretWithIndent
+                    | NormalCommand.PutBeforeCaretWithIndent
                         ->
 
                         // Special case when redoing positive numbered register puts:

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -4880,6 +4880,20 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
+            /// Short lines should be padded on the right
+            /// </summary>
+            [WpfFact]
+            public void BlockWithShortLines()
+            {
+                // Reported in issue #2231.
+                Create("xxx dog", "cat", "");
+                _textView.MoveCaretTo(6);
+                UnnamedRegister.UpdateBlockValues("aa", "bb");
+                _vimBuffer.Process("p");
+                Assert.Equal(new[] { "xxx dogaa", "cat    bb", "", }, _textBuffer.GetLines());
+            }
+
+            /// <summary>
             /// The new text should be on new lines at the same indetn and the caret posion should
             /// be the same as puting over existing lines
             /// </summary>


### PR DESCRIPTION
#### Changes

- Apply redo-register feature to put before/after with indent
- Fix insertion point when padding short lines in block put
- Fix block put to correctly handle lines containing surrogate pairs

#### Fixes

- Partially fixes #2231