### PR TITLE
Command margin edit fixes

### DIFF
--- a/Src/VimCore/IncrementalSearch.fs
+++ b/Src/VimCore/IncrementalSearch.fs
@@ -5,6 +5,7 @@ open Microsoft.VisualStudio.Text.Operations
 open Microsoft.VisualStudio.Text.Editor
 open Microsoft.VisualStudio.Text.Outlining
 open NullableUtil
+open Vim.VimCoreExtensions
 
 type IncrementalSearchData = { 
 
@@ -132,8 +133,8 @@ type internal IncrementalSearch
                 member this.Completed (data: ITrackingPoint) _ = runActive (fun session -> x.RunCompleted session data) IncrementalSearchData.Default.SearchResult
                 member this.Cancelled (data: ITrackingPoint) = runActive (fun session -> x.RunCancelled session) ()
             }
-
-        let historySession = HistoryUtil.CreateHistorySession historyClient startPoint StringUtil.Empty None
+        let vimBuffer = _vimBufferData.Vim.GetVimBuffer _textView
+        let historySession = HistoryUtil.CreateHistorySession historyClient startPoint StringUtil.Empty vimBuffer
         _incrementalSearchSession <- Some (IncrementalSearchSession(key, historySession, incrementalSearchData))
 
         // Raise the event

--- a/Src/VimTestUtils/Mock/MockKeyboardDevice.cs
+++ b/Src/VimTestUtils/Mock/MockKeyboardDevice.cs
@@ -158,26 +158,25 @@ namespace Vim.UnitTest.Mock
                 key = Key.Space;
                 return true;
             }
-            
-            if ((char)18 == keyInput.Char)
-            {
-                key = Key.R;
-                modKeys = ModifierKeys.Control;
-                return true;
-            }
 
-            if ((char)21 == keyInput.Char)
+            switch ((int) keyInput.Char) 
             {
-                key = Key.U;
-                modKeys = ModifierKeys.Control;
-                return true;
-            }
-            
-            if ((char)23 == keyInput.Char)
-            {
-                key = Key.W;
-                modKeys = ModifierKeys.Control;
-                return true;
+                case 1:
+                    key = Key.A;
+                    modKeys = ModifierKeys.Control;
+                    return true;
+                case 18:
+                    key = Key.R;
+                    modKeys = ModifierKeys.Control;
+                    return true;
+                case 21:
+                    key = Key.U;
+                    modKeys = ModifierKeys.Control;
+                    return true;
+                case 23:
+                    key = Key.W;
+                    modKeys = ModifierKeys.Control;
+                    return true;
             }
 
             return false;

--- a/Src/VimTestUtils/Mock/MockKeyboardDevice.cs
+++ b/Src/VimTestUtils/Mock/MockKeyboardDevice.cs
@@ -153,6 +153,12 @@ namespace Vim.UnitTest.Mock
                 return true;
             }
 
+            if (keyInput.Char == ' ')
+            {
+                key = Key.Space;
+                return true;
+            }
+            
             if ((char)18 == keyInput.Char)
             {
                 key = Key.R;
@@ -163,6 +169,13 @@ namespace Vim.UnitTest.Mock
             if ((char)21 == keyInput.Char)
             {
                 key = Key.U;
+                modKeys = ModifierKeys.Control;
+                return true;
+            }
+            
+            if ((char)23 == keyInput.Char)
+            {
+                key = Key.W;
                 modKeys = ModifierKeys.Control;
                 return true;
             }

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -436,7 +436,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     break;
                 case Key.Back:
                     // Backspacing past the beginning aborts the command/search.
-                    if (_margin.CommandLineTextBox.Text.Length <= 1)
+                    if (_margin.CommandLineTextBox.SelectionStart < 2 && _margin.CommandLineTextBox.SelectionLength == 0)
                     {
                         _vimBuffer.Process(KeyInputUtil.EscapeKey);
                         ChangeEditKind(EditKind.None);
@@ -464,10 +464,15 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     if (e.KeyboardDevice.Modifiers == ModifierKeys.Control)
                     {
                         var textBox = _margin.CommandLineTextBox;
-                        var text = textBox.Text.Substring(textBox.SelectionStart);
-                        textBox.Text = text;
+                        if(textBox.SelectionStart > 1)
+                        {
+                            var text = textBox.Text.Substring(textBox.SelectionStart);
+                            textBox.Text = text;
 
-                        UpdateVimBufferStateWithCommandText(text);
+                            UpdateVimBufferStateWithCommandText(text);
+                            textBox.Select(1, 0);
+                        }
+                        e.Handled = true;
                     }
                     break;
                 case Key.P:
@@ -484,7 +489,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     break;
             }
         }
-
+        
         /// <summary>
         /// If we're in command mode and a key is processed which effects the edit we should handle
         /// it here
@@ -898,7 +903,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         private void UpdateForPasteWait(WpfTextChangedEventArgs e)
         {
             Debug.Assert(InPasteWait);
-
+            
             var command = _margin.CommandLineTextBox.Text ?? "";
             if (e.Changes.Count == 1 && command.Length > 0)
             {
@@ -915,7 +920,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     // for manually updating the command line state.  Also we have to keep the caret postion
                     // correct
                     var name = RegisterName.OfChar(c);
-                    if (name.IsSome())
+                     if (name.IsSome())
                     {
                         var toPaste = _vimBuffer.GetRegister(name.Value).StringValue;
                         var builder = new StringBuilder();

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -443,10 +443,15 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                     break;
                 case Key.Back:
                     // Backspacing past the beginning aborts the command/search.
-                    if (_margin.CommandLineTextBox.SelectionStart < 2 && _margin.CommandLineTextBox.SelectionLength == 0)
+                    if (_margin.CommandLineTextBox.Text.Length <= 1)
                     {
                         _vimBuffer.Process(KeyInputUtil.EscapeKey);
                         ChangeEditKind(EditKind.None);
+                        e.Handled = true;
+                    }
+                    else if (_margin.CommandLineTextBox.CaretIndex == 1)
+                    {
+                        // don't let the caret get behind the initial character
                         e.Handled = true;
                     }
                     break;

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -458,6 +458,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
 
                         // Now move the buffer into paste wait 
                         _vimBuffer.Process(KeyInputUtil.ApplyKeyModifiersToChar('r', VimKeyModifiers.Control));
+                        e.Handled = true;
                     }
                     break;
                 case Key.U:
@@ -472,6 +473,13 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                             UpdateVimBufferStateWithCommandText(text);
                             textBox.Select(1, 0);
                         }
+                        e.Handled = true;
+                    }
+                    break;
+                case Key.W:
+                    if (e.KeyboardDevice.Modifiers == ModifierKeys.Control)
+                    {
+                        DeleteWordBeforeCursor();
                         e.Handled = true;
                     }
                     break;
@@ -939,6 +947,23 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             // the operation.  Just pass Escape down to the buffer so it will cancel out
             // of paste wait and go back to a known state
             _vimBuffer.Process(KeyInputUtil.EscapeKey);
+        }
+
+        private void DeleteWordBeforeCursor()
+        {
+            var textBox = _margin.CommandLineTextBox;
+            var end = textBox.SelectionStart;
+            if (end < 2)
+                return;
+            var begin = end;
+            while (begin > 1 && char.IsWhiteSpace(textBox.Text, begin - 1))
+                begin--;
+            while (begin > 1 && !char.IsWhiteSpace(textBox.Text, begin - 1))
+                begin--;
+            var text = textBox.Text.Substring(0, begin) + textBox.Text.Substring(end);
+            textBox.Text = text;
+            UpdateVimBufferStateWithCommandText(text);
+            textBox.Select(begin, 0);
         }
     }
 }

--- a/Test/VimWpfTest/CommandLineEditIntegrationTest.cs
+++ b/Test/VimWpfTest/CommandLineEditIntegrationTest.cs
@@ -226,18 +226,27 @@ namespace Vim.UI.Wpf.UnitTest
             }
 
             /// <summary>
-            /// Backspacing over first character should clear the command line and return to normal mode.
+            /// Backspacing over first character should clear the command line and return to normal mode,
+            /// but only if there are no characters after the cursor (i.e. length is 1).
             /// </summary>
             [WpfFact]
             public void BackspaceOverFirstCharacter()
             {
                 Create("");
-                ProcessNotation(@":e");
+                
+                ProcessNotation(":");
+                Assert.Equal(":", _marginControl.CommandLineTextBox.Text);
+                Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
+                ProcessNotation("<bs>");
+                Assert.Equal("", _marginControl.CommandLineTextBox.Text);
+                Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+                
+                ProcessNotation(":e");
                 Assert.Equal(":e", _marginControl.CommandLineTextBox.Text);
                 Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
                 ProcessNotation("<left><bs>");
-                Assert.Equal("", _marginControl.CommandLineTextBox.Text);
-                Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+                Assert.Equal(":e", _marginControl.CommandLineTextBox.Text);
+                Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
             }
             
             /// <summary>

--- a/Test/VimWpfTest/CommandLineEditIntegrationTest.cs
+++ b/Test/VimWpfTest/CommandLineEditIntegrationTest.cs
@@ -152,6 +152,45 @@ namespace Vim.UI.Wpf.UnitTest
             }
         }
         
+        public sealed class DeleteWordTest : CommandLineEditIntegrationTest
+        {
+            [WpfFact]
+            public void DeleteEditStart()
+            {
+                Create();
+                ProcessNotation(@":foo<Left><c-w>");
+                Assert.Equal(":o", _marginControl.CommandLineTextBox.Text);
+                Assert.Equal("o", _vimBuffer.CommandMode.Command);
+            }
+
+            [WpfFact]
+            public void DeleteCommand()
+            {
+                Create();
+                ProcessNotation(@":foo <c-w>");
+                Assert.Equal(":", _marginControl.CommandLineTextBox.Text);
+                Assert.Equal("", _vimBuffer.CommandMode.Command);
+            }
+
+            [WpfFact]
+            public void DeleteSearch()
+            {
+                Create();
+                ProcessNotation(@"/foo bar  <c-w>");
+                Assert.Equal("/foo ", _marginControl.CommandLineTextBox.Text);
+                Assert.Equal("foo ", _vimBuffer.IncrementalSearch.CurrentSearchText);
+            }
+
+            [WpfFact]
+            public void DeleteSearchEdit()
+            {
+                Create();
+                ProcessNotation(@"/foo bar<Left><c-w>");
+                Assert.Equal("/foo r", _marginControl.CommandLineTextBox.Text);
+                Assert.Equal("foo r", _vimBuffer.IncrementalSearch.CurrentSearchText);
+            }
+        }
+
         public sealed class CommandModeTest : CommandLineEditIntegrationTest
         {
             [WpfFact]

--- a/Test/VimWpfTest/CommandLineEditIntegrationTest.cs
+++ b/Test/VimWpfTest/CommandLineEditIntegrationTest.cs
@@ -375,6 +375,23 @@ namespace Vim.UI.Wpf.UnitTest
                     ProcessNotation(@":<C-R>c");
                     Assert.Equal(":test", _marginControl.CommandLineTextBox.Text);
                 }
+                
+                [WpfFact]
+                public void SpecialWord()
+                {
+                    Create("cat");
+                    ProcessNotation(@":<C-R><C-w>");
+                    Assert.Equal(":cat", _marginControl.CommandLineTextBox.Text);
+                }
+                
+                [WpfFact]
+                public void SpecialWORD()
+                {
+                    Create("cat.dog");
+
+                    ProcessNotation(@":<C-R><C-a>");
+                    Assert.Equal(":cat.dog", _marginControl.CommandLineTextBox.Text);
+                }
 
                 [WpfFact]
                 public void InPasteWait()
@@ -382,6 +399,17 @@ namespace Vim.UI.Wpf.UnitTest
                     Create("cat");
                     ProcessNotation(@":<C-R>");
                     Assert.True(_controller.InPasteWait);
+                }
+                
+                [WpfFact]
+                public void CtrlR_IgnoredInPasteWait()
+                {
+                    Create("");
+                    ProcessNotation(@":cat<C-R>");
+                    Assert.True(_controller.InPasteWait);
+                    ProcessNotation("<C-R>");
+                    Assert.True(_controller.InPasteWait);
+                    Assert.Equal(":cat\"", _marginControl.CommandLineTextBox.Text);
                 }
             }
 
@@ -394,6 +422,22 @@ namespace Vim.UI.Wpf.UnitTest
                     Vim.RegisterMap.GetRegister('c').UpdateValue("ca");
                     ProcessNotation(@":t<Left><C-r>c");
                     Assert.Equal(":cat", _marginControl.CommandLineTextBox.Text);
+                }
+                
+                [WpfFact]
+                public void SpecialWord()
+                {
+                    Create("cat");
+                    ProcessNotation(@":s<Left><C-R><C-w>");
+                    Assert.Equal(":cats", _marginControl.CommandLineTextBox.Text);
+                }
+                
+                [WpfFact]
+                public void SpecialWORD()
+                {
+                    Create("cat.dog");
+                    ProcessNotation(@":s<Left><C-R><C-a>");
+                    Assert.Equal(":cat.dogs", _marginControl.CommandLineTextBox.Text);
                 }
                 
                 [WpfFact]

--- a/Test/VimWpfTest/CommandLineEditIntegrationTest.cs
+++ b/Test/VimWpfTest/CommandLineEditIntegrationTest.cs
@@ -151,7 +151,7 @@ namespace Vim.UI.Wpf.UnitTest
                 Assert.Equal("o", _vimBuffer.IncrementalSearch.CurrentSearchText);
             }
         }
-
+        
         public sealed class CommandModeTest : CommandLineEditIntegrationTest
         {
             [WpfFact]
@@ -186,6 +186,21 @@ namespace Vim.UI.Wpf.UnitTest
                 Assert.Equal(":e", _marginControl.CommandLineTextBox.Text);
             }
 
+            /// <summary>
+            /// Backspacing over first character should clear the command line and return to normal mode.
+            /// </summary>
+            [WpfFact]
+            public void BackspaceOverFirstCharacter()
+            {
+                Create("");
+                ProcessNotation(@":e");
+                Assert.Equal(":e", _marginControl.CommandLineTextBox.Text);
+                Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
+                ProcessNotation("<left><bs>");
+                Assert.Equal("", _marginControl.CommandLineTextBox.Text);
+                Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+            }
+            
             /// <summary>
             /// Previously keys like caused issues because their literal char value was being appended to the
             /// beginning of the edit box
@@ -341,7 +356,7 @@ namespace Vim.UI.Wpf.UnitTest
                     ProcessNotation(@":t<Left><C-r>c");
                     Assert.Equal(":cat", _marginControl.CommandLineTextBox.Text);
                 }
-
+                
                 [WpfFact]
                 public void InPasteWait()
                 {


### PR DESCRIPTION
Fixes: #1099 

### Other Issues Fixed
This PR also addresses a number of minor command margin editing issues that I've run into.  I thought it would be preferable to include these in one PR since they are so closely related to one another.

- Repeated typing of CTRL-R will insert an equal number of double-quote characters.
- ESC in paste-wait mode cancels command mode instead of just canceling paste-wait.
- CTRL-U leaves the cursor before the initial character.
- CTRL-W does not delete the word before the cursor.
- BS over initial character does nothing if there are characters after the cursor.

### Issues Not Fixed
There are a few additional issues with keyboard focus, which anyone who has worked in this area  of the code is probably familiar with.  These issues generally occur when the keyboard focus moves from the command margin TextBox to the editor so that keystrokes are processed directly by the VimBuffer.  At this point, a number of keyboard operations cease to function as expected.  These are operations that require knowledge of or control over the command margin's caret index, of which VimBuffer has neither.  I didn't attempt to fix these issues, as any robust solution that I could envision would involve heavy changes to the command margin, and possibly abandoning the use of the WPF TextBox entirely.

**Example**
1. Type `:ab<left><c-r>`
2. Observe `:a"b` displayed in the command margin.
3. Mouse-click in the document editor so that the command margin loses keyboard focus.
4. Observe `:ab"` displayed in the command margin.