### PR TITLE
Prevent adjusting for 'scrolloff' during buffer construction or view layout

### DIFF
--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -294,12 +294,8 @@ type internal CommonOperations
                 let lastVisibleLineNumber = SnapshotPointUtil.GetLineNumber textViewLines.LastVisibleLine.End 
                 let topLineNumber = SnapshotPointUtil.GetLineNumber topPoint
                 let bottomLineNumber = SnapshotPointUtil.GetLineNumber bottomPoint
-                let contextLineNumber = SnapshotPointUtil.GetLineNumber contextPoint
 
-                if contextLineNumber < firstVisibleLineNumber || contextLineNumber > lastVisibleLineNumber then
-                    let span = SnapshotSpan(contextPoint, 0)
-                    _textView.ViewScroller.EnsureSpanVisible(span, EnsureSpanVisibleOptions.AlwaysCenter)
-                elif topLineNumber < firstVisibleLineNumber then
+                if topLineNumber < firstVisibleLineNumber then
                     _textView.DisplayTextLineContainingBufferPosition(topPoint, 0.0, ViewRelativePosition.Top)
                 elif bottomLineNumber > lastVisibleLineNumber then
                     _textView.DisplayTextLineContainingBufferPosition(bottomPoint, 0.0, ViewRelativePosition.Bottom)

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -272,6 +272,9 @@ type internal CommonOperations
     member x.AdjustTextViewForScrollOffsetAtPointCore contextPoint offset = 
         Contract.Requires(offset > 0)
 
+        // If the text view is still being initialized, the viewport will have zero height
+        // which will force offset to zero. Likewise, if there are no text view lines,
+        // trying to scroll is pointless.
         match _textView.ViewportHeight, TextViewUtil.GetTextViewLines _textView with
         | height, Some textViewLines when height <> 0.0 && textViewLines.Count <> 0 ->
 

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -270,11 +270,10 @@ type internal CommonOperations
     /// have to approximate the number of lines that can be on the screen in order to calculate the proper 
     /// offset to use.  
     member x.AdjustTextViewForScrollOffsetAtPointCore contextPoint offset = 
-        Contract.Requires(offset >= 0)
+        Contract.Requires(offset > 0)
 
-        match TextViewUtil.GetTextViewLines _textView with
-        | None -> ()
-        | Some textViewLines ->
+        match _textView.ViewportHeight, TextViewUtil.GetTextViewLines _textView with
+        | height, Some textViewLines when height <> 0.0 && textViewLines.Count <> 0 ->
 
             // First calculate the actual offset.  The actual offset can't be more than half of the lines which
             // are visible on the screen.  It's tempting to use the ITextViewLinesCollection.Count to see how
@@ -282,15 +281,11 @@ type internal CommonOperations
             // to the bottom because it will be displaying the last few lines and several blanks which don't
             // count.  Instead we average out the height of the lines and divide that into the height of 
             // the view port 
-            let calcOffset () = 
-                if textViewLines.Count = 0 then
-                    0
-                else
-                    let lineHeight = textViewLines |> Seq.averageBy (fun l -> l.Height)
-                    let lineCount = int (_textView.ViewportHeight / lineHeight) 
-                    let maxOffset = lineCount / 2
-                    min maxOffset offset
-            let offset = calcOffset ()
+            let offset =
+                let lineHeight = textViewLines |> Seq.averageBy (fun l -> l.Height)
+                let lineCount = int (_textView.ViewportHeight / lineHeight)
+                let maxOffset = lineCount / 2
+                min maxOffset offset
 
             // This function will do the actual positioning of the scroll based on the calculated lines 
             // in the buffer
@@ -299,8 +294,12 @@ type internal CommonOperations
                 let lastVisibleLineNumber = SnapshotPointUtil.GetLineNumber textViewLines.LastVisibleLine.End 
                 let topLineNumber = SnapshotPointUtil.GetLineNumber topPoint
                 let bottomLineNumber = SnapshotPointUtil.GetLineNumber bottomPoint
+                let contextLineNumber = SnapshotPointUtil.GetLineNumber contextPoint
 
-                if topLineNumber < firstVisibleLineNumber then
+                if contextLineNumber < firstVisibleLineNumber || contextLineNumber > lastVisibleLineNumber then
+                    let span = SnapshotSpan(contextPoint, 0)
+                    _textView.ViewScroller.EnsureSpanVisible(span, EnsureSpanVisibleOptions.AlwaysCenter)
+                elif topLineNumber < firstVisibleLineNumber then
                     _textView.DisplayTextLineContainingBufferPosition(topPoint, 0.0, ViewRelativePosition.Top)
                 elif bottomLineNumber > lastVisibleLineNumber then
                     _textView.DisplayTextLineContainingBufferPosition(bottomPoint, 0.0, ViewRelativePosition.Bottom)
@@ -327,6 +326,7 @@ type internal CommonOperations
                 match editTopPoint, editBottomPoint with
                 | Some p1, Some p2 -> doScroll p1 p2
                 | _ -> ()
+        | _ -> ()
 
     /// This is the same function as AdjustTextViewForScrollOffsetAtPoint except that it moves the caret 
     /// not the view port.  Make the caret consistent with the setting not the display 

--- a/Src/VimCore/SelectionChangeTracker.fs
+++ b/Src/VimCore/SelectionChangeTracker.fs
@@ -104,8 +104,15 @@ type internal SelectionChangeTracker
         // Don't update the caret if a selection is occuring.  This could be a user double clicking, 
         // dragging, etc ...  Don't want to update the caret in that case, let the mode change handle
         // that.
-        if _textView.HasAggregateFocus && not _vimBuffer.IsProcessingInput then
-            _commonOperations.EnsureAtCaret ViewFlags.ScrollOffset
+        if not _textView.InLayout && not _vimBuffer.IsProcessingInput then
+
+            let doUpdate () =
+                if not _textView.IsClosed then
+                    _commonOperations.EnsureAtCaret ViewFlags.ScrollOffset
+
+            let context = System.Threading.SynchronizationContext.Current
+            if context <> null then
+                context.Post((fun _ -> doUpdate()), null)
 
     member x.OnBufferClosed() = 
         _bag.DisposeAll()

--- a/Src/VimCore/SelectionChangeTracker.fs
+++ b/Src/VimCore/SelectionChangeTracker.fs
@@ -114,8 +114,8 @@ type internal SelectionChangeTracker
         then
 
             // Do the update being cautious that anything could have
-            // happened between when we posted the it and when it
-            // actually runs.
+            // happened between when we posted it and when it actually
+            // runs.
             let doUpdate () =
                 try
                     if not _textView.IsClosed then

--- a/Src/VimCore/SelectionChangeTracker.fs
+++ b/Src/VimCore/SelectionChangeTracker.fs
@@ -110,6 +110,13 @@ type internal SelectionChangeTracker
                 if not _textView.IsClosed then
                     _commonOperations.EnsureAtCaret ViewFlags.ScrollOffset
 
+            // Delay the update to give whoever changed the caret position the
+            // opportunity to scroll the view according to their own needs.
+            // If another extension moves the caret far offscreen and then
+            // centers it if the caret is not onscreen, then reacting too
+            // early to the caret position will defeat their offscreen
+            // handling. An example is double-clicking on an test in an
+            // unopened document is "Test Explorer".
             let context = System.Threading.SynchronizationContext.Current
             if context <> null then
                 context.Post((fun _ -> doUpdate()), null)

--- a/Src/VimCore/SelectionChangeTracker.fs
+++ b/Src/VimCore/SelectionChangeTracker.fs
@@ -104,7 +104,7 @@ type internal SelectionChangeTracker
         // Don't update the caret if a selection is occuring.  This could be a user double clicking, 
         // dragging, etc ...  Don't want to update the caret in that case, let the mode change handle
         // that.
-        if not _vimBuffer.IsProcessingInput then
+        if _textView.HasAggregateFocus && not _vimBuffer.IsProcessingInput then
             _commonOperations.EnsureAtCaret ViewFlags.ScrollOffset
 
     member x.OnBufferClosed() = 

--- a/Src/VimCore/SelectionChangeTracker.fs
+++ b/Src/VimCore/SelectionChangeTracker.fs
@@ -101,10 +101,17 @@ type internal SelectionChangeTracker
     /// If the caret changes position and it wasn't initiated by VsVim then we should be 
     /// adjusting the screen to account for 'scrolloff'
     member x.OnPositionChanged() = 
-        // Don't update the caret if a selection is occuring.  This could be a user double clicking, 
-        // dragging, etc ...  Don't want to update the caret in that case, let the mode change handle
-        // that.
-        if not _textView.InLayout && not _vimBuffer.IsProcessingInput then
+
+        // Don't apply the scroll offset if it isn't applicable, if the
+        // text view is currently being laid out, or if we in the middle
+        // of process input. If we are processing input then the mode is
+        // is responsible for ensuring that the scroll offset is obeyed,
+        // so let the mode handle it.
+        if
+            _vimBuffer.GlobalSettings.ScrollOffset > 0
+            && not _textView.InLayout
+            && not _vimBuffer.IsProcessingInput
+        then
 
             let doUpdate () =
                 if not _textView.IsClosed then

--- a/Test/VimCoreTest/CommonOperationsIntegrationTest.cs
+++ b/Test/VimCoreTest/CommonOperationsIntegrationTest.cs
@@ -73,6 +73,7 @@ namespace Vim.UnitTest
                     _textView.ScrollToBottom();
                     _textView.MoveCaretToLine(2);
                     _commonOperationsRaw.AdjustTextViewForScrollOffset();
+                    TestableSynchronizationContext.RunOne();
                     AssertFirstLine(1);
                 }
 

--- a/Test/VimCoreTest/CommonOperationsIntegrationTest.cs
+++ b/Test/VimCoreTest/CommonOperationsIntegrationTest.cs
@@ -44,12 +44,14 @@ namespace Vim.UnitTest
 
             private void AssertFirstLine(int lineNumber)
             {
+                TestableSynchronizationContext.RunAll();
                 var actual = _textView.GetFirstVisibleLineNumber();
                 Assert.Equal(lineNumber, actual);
             }
 
             private void AssertLastLine(int lineNumber)
             {
+                TestableSynchronizationContext.RunAll();
                 var actual = _textView.GetLastVisibleLineNumber();
                 Assert.Equal(lineNumber, actual);
             }
@@ -73,7 +75,6 @@ namespace Vim.UnitTest
                     _textView.ScrollToBottom();
                     _textView.MoveCaretToLine(2);
                     _commonOperationsRaw.AdjustTextViewForScrollOffset();
-                    TestableSynchronizationContext.RunOne();
                     AssertFirstLine(1);
                 }
 

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -6301,6 +6301,7 @@ namespace Vim.UnitTest
             {
                 _textView.ScrollToTop();
                 _textView.MoveCaretToLine(4);
+                TestableSynchronizationContext.RunOne();
                 AssertFirstLine(2);
             }
         }

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -5973,6 +5973,7 @@ namespace Vim.UnitTest
                 {
                     _textView.DisplayTextLineContainingBufferPosition(_textBuffer.GetLine(1).Start, 0.0, ViewRelativePosition.Top);
                     _textView.MoveCaretToLine(2);
+                    TestableSynchronizationContext.RunAll();
                     _vimBuffer.ProcessNotation("<C-u>");
                     Assert.Equal(1, _textView.GetCaretLine().LineNumber);
                     Assert.Equal(0, _textView.GetFirstVisibleLineNumber());
@@ -5985,6 +5986,7 @@ namespace Vim.UnitTest
                 public void UpMovesCaretWithoutScroll()
                 {
                     _textView.MoveCaretToLine(2);
+                    TestableSynchronizationContext.RunAll();
                     _vimBuffer.ProcessNotation("<C-u>");
                     Assert.Equal(1, _textView.GetCaretLine().LineNumber);
                 }
@@ -6115,6 +6117,7 @@ namespace Vim.UnitTest
                     _globalSettings.ScrollOffset = 2;
                     var caretLine = 4;
                     _textView.MoveCaretToLine(caretLine);
+                    TestableSynchronizationContext.RunAll();
                     var topLine = 0;
                     PutLineAtTop(topLine);
                     _vimBuffer.ProcessNotation("H");
@@ -6212,12 +6215,14 @@ namespace Vim.UnitTest
 
             private void AssertFirstLine(int lineNumber)
             {
+                TestableSynchronizationContext.RunAll();
                 var actual = _textView.GetFirstVisibleLineNumber();
                 Assert.Equal(lineNumber, actual);
             }
 
             private void AssertLastLine(int lineNumber)
             {
+                TestableSynchronizationContext.RunAll();
                 var actual = _textView.GetLastVisibleLineNumber();
                 Assert.Equal(lineNumber, actual);
             }
@@ -6301,7 +6306,7 @@ namespace Vim.UnitTest
             {
                 _textView.ScrollToTop();
                 _textView.MoveCaretToLine(4);
-                TestableSynchronizationContext.RunOne();
+                TestableSynchronizationContext.RunAll();
                 AssertFirstLine(2);
             }
         }


### PR DESCRIPTION
Fixes #2240

This also incidentally fixes a problem where double-clicking on a test in an unopened document in Test Explorer would cause the caret to be moved to exactly `scrolloff` lines from the top or bottom of the window, whereas without VsVim, the Test Explorer would center the caret in the window of its own accord.

Because delaying the scroll offset adjustment uses the synchronization context, any test that uses a non-zero scroll offset and manually moves the caret needs to run the testable synchronization context queue in order to effect the actual adjustment.