### PR TITLE
Fix race condition on startup

### DIFF
--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -329,8 +329,8 @@ type internal VimBufferFactory
         // The ITextView is initialized and no one has forced the IVimBuffer out of
         // the uninitialized state.  Do the switch now to the correct mode
         let runInit () =
-            Contract.Assert(isReady())
             if not textView.IsClosed && vimBuffer.ModeKind = ModeKind.Uninitialized then
+                Contract.Assert(isReady())
                 vimBuffer.SwitchMode vimBufferData.VimTextBuffer.ModeKind ModeArgument.None |> ignore
 
         if isReady () then


### PR DESCRIPTION
The behavior here is that we get an `ITextView.LayoutChanged` event but
by the time we can react the `ITextView` is already closed. The fix is to
move our contract check that the `ITextView` is in a proper state to
after we've checked to see if it has been closed.

closes #2250