### PR TITLE
Support for 'virtualedit' for visual character mode and for marks

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -233,7 +233,7 @@ type internal CommandUtil
             VisualSpan.Line range
 
         | StoredVisualSpan.Character (lineCount = lineCount; lastLineLength = lastLineLength) ->
-            let characterSpan = CharacterSpan(x.CaretPoint, lineCount, lastLineLength)
+            let characterSpan = CharacterSpan(x.CaretVirtualPoint, lineCount, lastLineLength)
             VisualSpan.Character characterSpan
         | StoredVisualSpan.Block (width = width; height = height) ->
             // Need to rehydrate spans of length 'length' on 'count' lines from the

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1444,7 +1444,7 @@ type internal CommandUtil
     /// since they embed caret information.  Marks are special though because they have the ability
     /// to cross files hence we special case them here
     member x.JumpToMarkCore mark exact =
-        let before = x.CaretPoint
+        let before = x.CaretVirtualPoint
 
         // If not exact, adjust point to first non-blank or start.
         let adjustPointForExact (virtualPoint: VirtualSnapshotPoint) =
@@ -1537,7 +1537,7 @@ type internal CommandUtil
     member x.JumpToTagCore () =
         match _jumpList.Current with
         | None -> _commonOperations.Beep()
-        | Some point -> _commonOperations.MoveCaretToPoint point ViewFlags.Standard
+        | Some point -> _commonOperations.MoveCaretToVirtualPoint point ViewFlags.Standard
 
     /// Move the caret to start of a line which is deleted.  Needs to preserve the original
     /// indent if 'autoindent' is set.

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -233,7 +233,7 @@ type internal CommandUtil
             VisualSpan.Line range
 
         | StoredVisualSpan.Character (lineCount = lineCount; lastLineLength = lastLineLength) ->
-            let characterSpan = CharacterSpan(x.CaretVirtualPoint, lineCount, lastLineLength)
+            let characterSpan = CharacterSpan(x.CaretPoint, lineCount, lastLineLength)
             VisualSpan.Character characterSpan
         | StoredVisualSpan.Block (width = width; height = height) ->
             // Need to rehydrate spans of length 'length' on 'count' lines from the

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -3409,7 +3409,14 @@ type internal CommandUtil
 
     /// Yank the selection into the specified register
     member x.YankSelection registerName (visualSpan: VisualSpan) =
-        let data = StringData.OfEditSpan visualSpan.EditSpan
+        let data =
+            match visualSpan with
+            | VisualSpan.Character characterSpan when characterSpan.UseVirtualSpace ->
+                characterSpan.VirtualSpan
+                |> VirtualSnapshotSpanUtil.GetText
+                |> StringData.Simple
+            | _ ->
+                StringData.OfEditSpan visualSpan.EditSpan
         let value = x.CreateRegisterValue data visualSpan.OperationKind
         _commonOperations.SetRegisterValue registerName RegisterOperation.Yank value
         _commonOperations.RecordLastYank visualSpan.EditSpan.OverarchingSpan

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -3243,11 +3243,12 @@ type internal CommandUtil
     /// upon the values of 'keymodel' and 'selectmode'.  It will either move the caret potentially as
     /// a motion or initiate a select in the editor
     member x.SwitchToSelection caretMovement =
-        let anchorPoint = x.CaretPoint
+        let anchorPoint = x.CaretVirtualPoint
         if not (_commonOperations.MoveCaretWithArrow caretMovement) then
             CommandResult.Error
         else
-            let visualSelection = VisualSelection.CreateForPoints VisualKind.Character anchorPoint x.CaretPoint _localSettings.TabStop
+            let useVirtualSpace = _vimTextBuffer.UseVirtualSpace
+            let visualSelection = VisualSelection.CreateForVirtualPoints VisualKind.Character anchorPoint x.CaretVirtualPoint _localSettings.TabStop useVirtualSpace
             let visualSelection = visualSelection.AdjustForSelectionKind _globalSettings.SelectionKind
             let modeKind =
                 if Util.IsFlagSet _globalSettings.SelectModeOptions SelectModeOptions.Keyboard then

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -1857,6 +1857,7 @@ type internal CommonOperations
         member x.MoveCaret caretMovement = x.MoveCaret caretMovement
         member x.MoveCaretWithArrow caretMovement = x.MoveCaretWithArrow caretMovement
         member x.MoveCaretToPoint point viewFlags =  x.MoveCaretToPoint point viewFlags
+        member x.MoveCaretToVirtualPoint point viewFlags =  x.MoveCaretToVirtualPoint point viewFlags
         member x.MoveCaretToMotionResult data = x.MoveCaretToMotionResult data
         member x.NavigateToPoint point = x.NavigateToPoint point
         member x.NormalizeBlanks text = x.NormalizeBlanks text

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -836,7 +836,7 @@ type internal CommonOperations
             Count = VimRegexReplaceCount.One }
 
     member x.GoToDefinition() =
-        let before = TextViewUtil.GetCaretPoint _textView
+        let before = TextViewUtil.GetCaretVirtualPoint _textView
         if _vimHost.GoToDefinition() then
             _jumpList.Add before
             Result.Succeeded
@@ -848,14 +848,14 @@ type internal CommonOperations
             | None ->  Result.Failed(Resources.Common_GotoDefNoWordUnderCursor) 
 
     member x.GoToLocalDeclaration() = 
-        let caretPoint = x.CaretPoint
+        let caretPoint = x.CaretVirtualPoint
         if _vimHost.GoToLocalDeclaration _textView x.WordUnderCursorOrEmpty then
             _jumpList.Add caretPoint
         else
             _vimHost.Beep()
 
     member x.GoToGlobalDeclaration () = 
-        let caretPoint = x.CaretPoint
+        let caretPoint = x.CaretVirtualPoint
         if _vimHost.GoToGlobalDeclaration _textView x.WordUnderCursorOrEmpty then 
             _jumpList.Add caretPoint
         else

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1554,23 +1554,26 @@ type CharacterSpan =
         CharacterSpan(span.Start, lineCount, lastLineLength)
 
     new (span: VirtualSnapshotSpan, useVirtualSpace: bool) =
-        let lineCount = VirtualSnapshotSpanUtil.GetLineCount span
-        let lastLine = VirtualSnapshotSpanUtil.GetLastLine span
-        let endColumnNumber = VirtualSnapshotPointUtil.GetColumnNumber span.End
-        let lastLineLength =
-            if lineCount = 1 then
-                let startColumnNumber = VirtualSnapshotPointUtil.GetColumnNumber span.Start
-                let endColumnNumberInLastLine =
-                    if span.Length <> 0 && endColumnNumber = 0 then
-                        lastLine.LengthIncludingLineBreak
-                    else
-                        endColumnNumber
-                endColumnNumberInLastLine - startColumnNumber
-            else
-                let startColumnNumber = SnapshotPointUtil.GetColumn lastLine.Start
-                let diff = endColumnNumber - startColumnNumber
-                max 0 diff
-        CharacterSpan(span.Start, lineCount, lastLineLength, useVirtualSpace)
+        if span.Start.IsInVirtualSpace || span.End.IsInVirtualSpace then
+            let lineCount = VirtualSnapshotSpanUtil.GetLineCount span
+            let lastLine = VirtualSnapshotSpanUtil.GetLastLine span
+            let endColumnNumber = VirtualSnapshotPointUtil.GetColumnNumber span.End
+            let lastLineLength =
+                if lineCount = 1 then
+                    let startColumnNumber = VirtualSnapshotPointUtil.GetColumnNumber span.Start
+                    let endColumnNumberInLastLine =
+                        if span.Length <> 0 && endColumnNumber = 0 then
+                            lastLine.LengthIncludingLineBreak
+                        else
+                            endColumnNumber
+                    endColumnNumberInLastLine - startColumnNumber
+                else
+                    let startColumnNumber = SnapshotPointUtil.GetColumn lastLine.Start
+                    let diff = endColumnNumber - startColumnNumber
+                    max 0 diff
+            CharacterSpan(span.Start, lineCount, lastLineLength, useVirtualSpace)
+        else
+            CharacterSpan(span.SnapshotSpan)
 
     new (startPoint: SnapshotPoint, endPoint: SnapshotPoint) =
         let span = SnapshotSpan(startPoint, endPoint)

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3887,7 +3887,7 @@ type IJumpList =
 
     /// Current value in the jump list.  Will be None if we are not currently traversing the
     /// jump list
-    abstract Current: SnapshotPoint option
+    abstract Current: VirtualSnapshotPoint option
 
     /// Current index into the jump list.  Will be None if we are not currently traversing
     /// the jump list
@@ -3904,7 +3904,7 @@ type IJumpList =
 
     /// Add a given SnapshotPoint to the jump list.  This will reset Current to point to 
     /// the begining of the jump list
-    abstract Add: SnapshotPoint -> unit
+    abstract Add: VirtualSnapshotPoint -> unit
 
     /// Clear out all of the stored jump information.  Removes all tracking information from
     /// the IJumpList

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1610,7 +1610,7 @@ type CharacterSpan =
     /// The last virtual point included in the CharacterSpan
     member x.VirtualLast =
         let endPoint: VirtualSnapshotPoint = x.VirtualEnd
-        if endPoint.Position = x.Start then
+        if endPoint = x.VirtualStart then
             None
         else
             endPoint
@@ -2178,17 +2178,16 @@ type VisualSelection =
         | SelectionKind.Exclusive -> 
             match x with
             | Character (characterSpan, path) -> 
-                if SnapshotPointUtil.IsEndPoint characterSpan.End then
+                if
+                    not characterSpan.UseVirtualSpace
+                    && SnapshotPointUtil.IsEndPoint characterSpan.End
+                then
                     x
                 else
                     // The span decreases by a single character in exclusive
                     let characterSpan =
-                        if characterSpan.UseVirtualSpace then
-                            let endPoint = characterSpan.VirtualLast |> OptionUtil.getOrDefault characterSpan.VirtualStart
-                            CharacterSpan(VirtualSnapshotSpan(characterSpan.VirtualStart, endPoint), characterSpan.UseVirtualSpace)
-                        else
-                            let endPoint = characterSpan.VirtualLast |> OptionUtil.getOrDefault characterSpan.VirtualStart
-                            CharacterSpan(VirtualSnapshotSpan(characterSpan.VirtualStart, endPoint), characterSpan.UseVirtualSpace)
+                        let endPoint = characterSpan.VirtualLast |> OptionUtil.getOrDefault characterSpan.VirtualStart
+                        CharacterSpan(VirtualSnapshotSpan(characterSpan.VirtualStart, endPoint), characterSpan.UseVirtualSpace)
                     VisualSelection.Character (characterSpan, path)
             | Line _ ->
                 // The span isn't effected

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1522,6 +1522,7 @@ type CharacterSpan =
         CharacterSpan(virtualStart, lineCount, lastLineLength, false)
 
     new (start: VirtualSnapshotPoint, lineCount: int, lastLineLength: int, useVirtualSpace: bool) =
+        Contract.Requires(lineCount > 0)
 
         // Don't let the last line of the CharacterSpan end partially into a line 
         // break.  Encompass the entire line break instead 
@@ -1530,8 +1531,6 @@ type CharacterSpan =
         let lastLineLength = 
             if useVirtualSpace then
                 lastLineLength
-            elif line.Length = 0 then
-                line.LengthIncludingLineBreak
             elif lastLineLength > line.Length then
                 line.LengthIncludingLineBreak
             else

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1652,6 +1652,8 @@ type CharacterSpan =
 
     member x.Length = x.Span.Length
 
+    member x.VirtualLength = x.VirtualSpan.Length
+
     member x.IncludeLastLineLineBreak = x.End.Position > x.LastLine.End.Position
 
     member internal x.MaybeAdjustToIncludeLastLineLineBreak() = 
@@ -2067,7 +2069,11 @@ type VisualSpan =
             // Need to special case the selection ending in, and encompassing, an empty line.  Once you 
             // get rid of the virtual points here it's impossible to distinguish from the case where the 
             // selection ends in the line above instead.  
-            if visualKind = VisualKind.Character && selection.End.Position.GetContainingLine().Length = 0 then
+            if
+                not useVirtualSpace
+                && visualKind = VisualKind.Character
+                && selection.End.Position.GetContainingLine().Length = 0
+            then
                 let endPoint = SnapshotPointUtil.AddOneOrCurrent selection.End.Position 
                 let characterSpan = CharacterSpan(selection.Start.Position, endPoint)
                 Character characterSpan

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1675,7 +1675,11 @@ type CharacterSpan =
         else
             x
 
-    override x.ToString() = x.Span.ToString()
+    override x.ToString() =
+        if x.UseVirtualSpace then
+            x.VirtualSpan.ToString()
+        else
+            x.Span.ToString()
 
     static member op_Equality(this,other) = System.Collections.Generic.EqualityComparer<CharacterSpan>.Default.Equals(this,other)
     static member op_Inequality(this,other) = not (System.Collections.Generic.EqualityComparer<CharacterSpan>.Default.Equals(this,other))

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1616,7 +1616,7 @@ type CharacterSpan =
             None
         else
             endPoint
-            |> VirtualSnapshotPointUtil.SubtractOneOrCurrent
+            |> VirtualSnapshotPointUtil.GetPreviousCharacterSpanWithWrap
             |> Some
 
     /// Get the End point of the Character Span.
@@ -1678,10 +1678,7 @@ type CharacterSpan =
             x
 
     override x.ToString() =
-        if x.UseVirtualSpace then
-            x.VirtualSpan.ToString()
-        else
-            x.Span.ToString()
+        x.VirtualSpan.ToString()
 
     static member op_Equality(this,other) = System.Collections.Generic.EqualityComparer<CharacterSpan>.Default.Equals(this,other)
     static member op_Inequality(this,other) = not (System.Collections.Generic.EqualityComparer<CharacterSpan>.Default.Equals(this,other))
@@ -2395,7 +2392,8 @@ type VisualSelection =
     static member CreateForPoints (visualKind : VisualKind) (anchorPoint: SnapshotPoint) (caretPoint: SnapshotPoint) (tabStop: int) =
         let virtualAnchorPoint = VirtualSnapshotPointUtil.OfPoint anchorPoint
         let virtualCaretPoint = VirtualSnapshotPointUtil.OfPoint caretPoint
-        VisualSelection.CreateForVirtualPoints visualKind virtualAnchorPoint virtualCaretPoint tabStop false
+        let useVirtualSpace = false
+        VisualSelection.CreateForVirtualPoints visualKind virtualAnchorPoint virtualCaretPoint tabStop useVirtualSpace
 
     /// Create a VisualSelection based off of the current selection and position of the caret.  The
     /// SelectionKind should specify what the current mode is (or the mode which produced the 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2432,16 +2432,21 @@ type VisualSelection =
 
     /// Create the initial Visual Selection information for the specified Kind started at 
     /// the specified point
-    static member CreateInitial visualKind (caretVirtualPoint: VirtualSnapshotPoint) tabStop selectionKind =
+    static member CreateInitial visualKind (caretVirtualPoint: VirtualSnapshotPoint) tabStop selectionKind useVirtualSpace =
         let caretPoint = caretVirtualPoint.Position
         match visualKind with
         | VisualKind.Character ->
             let characterSpan = 
                 let endPoint = 
                     match selectionKind with
-                    | SelectionKind.Inclusive -> SnapshotPointUtil.AddOneOrCurrent caretPoint
-                    | SelectionKind.Exclusive -> caretPoint
-                CharacterSpan(caretPoint, endPoint)
+                    | SelectionKind.Inclusive ->
+                        if useVirtualSpace then
+                            VirtualSnapshotPointUtil.AddOneOnSameLine caretVirtualPoint
+                        else
+                            SnapshotPointUtil.AddOneOrCurrent caretPoint
+                            |> VirtualSnapshotPointUtil.OfPoint
+                    | SelectionKind.Exclusive -> caretVirtualPoint
+                CharacterSpan(caretVirtualPoint, endPoint, useVirtualSpace)
             VisualSelection.Character (characterSpan, SearchPath.Forward)
         | VisualKind.Line ->
             let lineRange = 

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -2055,6 +2055,13 @@ module VirtualSnapshotPointUtil =
         let spaces = SnapshotPointUtil.GetSpacesToPoint point.Position tabStop
         spaces + point.VirtualSpaces
 
+    /// Get the previous character span in the buffer with wrap
+    let GetPreviousCharacterSpanWithWrap (point: VirtualSnapshotPoint) =
+        if point.IsInVirtualSpace then
+            VirtualSnapshotPoint(point.Position, point.VirtualSpaces - 1)
+        else
+            VirtualSnapshotPoint(SnapshotPointUtil.GetPreviousCharacterSpanWithWrap point.Position)
+
 /// Contains operations that act on snapshot lines but return virtual snapshot points
 module VirtualSnapshotLineUtil =
 

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -2055,6 +2055,13 @@ module VirtualSnapshotPointUtil =
         let spaces = SnapshotPointUtil.GetSpacesToPoint point.Position tabStop
         spaces + point.VirtualSpaces
 
+    /// Get the next character span in the buffer with wrap
+    let GetNextCharacterSpanWithWrap (point: VirtualSnapshotPoint) =
+        if point.IsInVirtualSpace then
+            VirtualSnapshotPoint(point.Position, point.VirtualSpaces + 1)
+        else
+            VirtualSnapshotPoint(SnapshotPointUtil.GetNextCharacterSpanWithWrap point.Position)
+
     /// Get the previous character span in the buffer with wrap
     let GetPreviousCharacterSpanWithWrap (point: VirtualSnapshotPoint) =
         if point.IsInVirtualSpace then

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -2080,6 +2080,9 @@ module VirtualSnapshotLineUtil =
         let virtualSpaces = columnCount - realColumnCount
         realSpacesToColumn + virtualSpaces
 
+    let GetColumn columnNumber (line: ITextSnapshotLine) =
+        VirtualSnapshotPoint(line, columnNumber)
+
 /// Contains operations to help fudge the Editor APIs to be more F# friendly.  Does not
 /// include any Vim specific logic
 module VirtualSnapshotSpanUtil =
@@ -2098,6 +2101,12 @@ module VirtualSnapshotSpanUtil =
         let startPoint = VirtualSnapshotPointUtil.OfPoint span.Start
         let endPoint = VirtualSnapshotPointUtil.OfPoint span.End
         VirtualSnapshotSpan(startPoint, endPoint)
+
+    let GetLineCount (span: VirtualSnapshotSpan) =
+        SnapshotSpanUtil.GetLineCount span.SnapshotSpan
+
+    let GetLastLine (span: VirtualSnapshotSpan) =
+        SnapshotSpanUtil.GetLastLine span.SnapshotSpan
 
 /// Contains operations to make it easier to use SnapshotLineRange from a type inference
 /// context

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -2102,11 +2102,31 @@ module VirtualSnapshotSpanUtil =
         let endPoint = VirtualSnapshotPointUtil.OfPoint span.End
         VirtualSnapshotSpan(startPoint, endPoint)
 
-    let GetLineCount (span: VirtualSnapshotSpan) =
-        SnapshotSpanUtil.GetLineCount span.SnapshotSpan
+    /// Get the first line in the VirtualSnapshotSpan
+    let GetStartLine (span: VirtualSnapshotSpan) =
+        span.Start.Position.GetContainingLine()
 
+    /// Get the end line in the VirtualSnapshotSpan
     let GetLastLine (span: VirtualSnapshotSpan) =
-        SnapshotSpanUtil.GetLastLine span.SnapshotSpan
+        if span.End.IsInVirtualSpace then
+            span.End.Position.GetContainingLine()
+        elif span.Length > 0 then
+            span.End.Position.Subtract(1).GetContainingLine()
+        else
+            GetStartLine span
+
+    /// Get the start and end line of the VirtualSnapshotSpan
+    let GetStartAndLastLine span = GetStartLine span, GetLastLine span
+
+    /// Get the number of lines in this VirtualSnapshotSpan
+    let GetLineCount span =
+        let startLine, lastLine = GetStartAndLastLine span
+        (lastLine.LineNumber - startLine.LineNumber) + 1
+
+    /// Whether this a multiline VirtualSnapshotSpan
+    let IsMultiline span =
+        let startLine, lastLine = GetStartAndLastLine span
+        startLine.LineNumber < lastLine.LineNumber
 
 /// Contains operations to make it easier to use SnapshotLineRange from a type inference
 /// context

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -2128,6 +2128,11 @@ module VirtualSnapshotSpanUtil =
         let startLine, lastLine = GetStartAndLastLine span
         startLine.LineNumber < lastLine.LineNumber
 
+    let GetText (span: VirtualSnapshotSpan) =
+        let spanText = SnapshotSpanUtil.GetText span.SnapshotSpan
+        let virtualSpaces = StringUtil.RepeatChar span.End.VirtualSpaces ' '
+        spanText + virtualSpaces
+
 /// Contains operations to make it easier to use SnapshotLineRange from a type inference
 /// context
 module SnapshotLineRangeUtil = 

--- a/Src/VimCore/JumpList.fs
+++ b/Src/VimCore/JumpList.fs
@@ -44,7 +44,7 @@ type internal JumpList
     member x.Current = 
         match _current with
         | None -> None
-        | Some (current, _) -> current.Value.Point
+        | Some (current, _) -> current.Value.VirtualPoint
 
     /// Return the current index
     member x.CurrentIndex =
@@ -95,7 +95,7 @@ type internal JumpList
         // traversal
         _current <- None
 
-        let line, column = SnapshotPointUtil.GetLineColumn point
+        let line, column = VirtualSnapshotPointUtil.GetLineColumn point
 
         let trackingLineColumn = 
             match x.FindNodeTrackingLine line with
@@ -125,7 +125,7 @@ type internal JumpList
         // traversal
         _current <- None
 
-        let line, column = SnapshotPointUtil.GetLineColumn point
+        let line, column = VirtualSnapshotPointUtil.GetLineColumn point
         x.SetLastJumpLocation line column
 
         x.AddCore point |> ignore
@@ -190,7 +190,7 @@ type internal JumpList
 
     /// Start a traversal of the jump list
     member x.StartTraversal() = 
-        let caretPoint = TextViewUtil.GetCaretPoint _textView
+        let caretPoint = TextViewUtil.GetCaretVirtualPoint _textView
         let node = x.AddCore caretPoint
         _current <- Some (node, 0)
 

--- a/Src/VimCore/MefComponents.fs
+++ b/Src/VimCore/MefComponents.fs
@@ -233,7 +233,7 @@ type internal TrackingVisualSpan =
             // in the span and the length of the final line
             let textBuffer = characterSpan.Snapshot.TextBuffer
             let trackingLineColumn = 
-                let line, column = SnapshotPointUtil.GetLineColumn characterSpan.Start
+                let line, column = VirtualSnapshotPointUtil.GetLineColumn characterSpan.VirtualStart
                 bufferTrackingService.CreateLineColumn textBuffer line column LineColumnTrackingMode.Default
 
             TrackingVisualSpan.Character (trackingLineColumn, characterSpan.LineCount, characterSpan.LastLineLength)
@@ -251,7 +251,7 @@ type internal TrackingVisualSpan =
             // Setup an ITrackLineColumn at the top left of the block selection
             let trackingLineColumn =
                 let textBuffer = blockSpan.TextBuffer
-                let lineNumber, column = SnapshotPointUtil.GetLineColumn blockSpan.Start
+                let lineNumber, column = VirtualSnapshotPointUtil.GetLineColumn blockSpan.VirtualStart
 
                 bufferTrackingService.CreateLineColumn textBuffer lineNumber column LineColumnTrackingMode.Default
 

--- a/Src/VimCore/MefInterfaces.fs
+++ b/Src/VimCore/MefInterfaces.fs
@@ -431,6 +431,10 @@ type ICommonOperations =
     /// properties at that point 
     abstract MoveCaretToPoint: point: SnapshotPoint -> viewFlags: ViewFlags -> unit
 
+    /// Move the caret to a given virtual point on the screen and ensure the view has the specified
+    /// properties at that point
+    abstract MoveCaretToVirtualPoint: point: VirtualSnapshotPoint -> viewFlags: ViewFlags -> unit
+
     /// Move the caret to the MotionResult value
     abstract MoveCaretToMotionResult: motionResult: MotionResult -> unit
 

--- a/Src/VimCore/Modes_Visual_SelectionTracker.fs
+++ b/Src/VimCore/Modes_Visual_SelectionTracker.fs
@@ -52,13 +52,14 @@ type internal SelectionTracker
         if x.IsRunning then invalidOp Vim.Resources.SelectionTracker_AlreadyRunning
         _textChangedHandler.Add()
 
+        let useVirtualSpace = _vimBufferData.VimTextBuffer.UseVirtualSpace
         let selection = _textView.Selection
         if selection.IsEmpty then
 
             // Set the selection.  If this is line mode we need to select the entire line 
             // here
             let caretPoint = TextViewUtil.GetCaretVirtualPoint _textView
-            let visualSelection = VisualSelection.CreateInitial _visualKind caretPoint _localSettings.TabStop _globalSettings.SelectionKind
+            let visualSelection = VisualSelection.CreateInitial _visualKind caretPoint _localSettings.TabStop _globalSettings.SelectionKind useVirtualSpace
             visualSelection.VisualSpan.Select _textView SearchPath.Forward
 
             _anchorPoint <- Some caretPoint
@@ -81,7 +82,6 @@ type internal SelectionTracker
                     Some anchorPoint
             _extendIntoLineBreak <- _visualKind = VisualKind.Character && selection.AnchorPoint.IsInVirtualSpace
 
-            let useVirtualSpace = _vimBufferData.VimTextBuffer.UseVirtualSpace
             let visualSelection = VisualSelection.CreateForVirtualSelection _textView _visualKind _globalSettings.SelectionKind _vimBufferData.LocalSettings.TabStop useVirtualSpace
             _vimBufferData.VimTextBuffer.LastVisualSelection <- Some visualSelection
 

--- a/Src/VimCore/Modes_Visual_SelectionTracker.fs
+++ b/Src/VimCore/Modes_Visual_SelectionTracker.fs
@@ -83,6 +83,7 @@ type internal SelectionTracker
             _extendIntoLineBreak <- _visualKind = VisualKind.Character && selection.AnchorPoint.IsInVirtualSpace
 
             let visualSelection = VisualSelection.CreateForVirtualSelection _textView _visualKind _globalSettings.SelectionKind _vimBufferData.LocalSettings.TabStop useVirtualSpace
+            let visualSelection = visualSelection.AdjustForSelectionKind _globalSettings.SelectionKind
             _vimBufferData.VimTextBuffer.LastVisualSelection <- Some visualSelection
 
     /// Called when selection should no longer be tracked.  Must be paired with Start calls or

--- a/Src/VimCore/Modes_Visual_SelectionTracker.fs
+++ b/Src/VimCore/Modes_Visual_SelectionTracker.fs
@@ -81,7 +81,8 @@ type internal SelectionTracker
                     Some anchorPoint
             _extendIntoLineBreak <- _visualKind = VisualKind.Character && selection.AnchorPoint.IsInVirtualSpace
 
-            let visualSelection = VisualSelection.CreateForSelection _textView _visualKind _globalSettings.SelectionKind _vimBufferData.LocalSettings.TabStop
+            let useVirtualSpace = _vimBufferData.VimTextBuffer.UseVirtualSpace
+            let visualSelection = VisualSelection.CreateForVirtualSelection _textView _visualKind _globalSettings.SelectionKind _vimBufferData.LocalSettings.TabStop useVirtualSpace
             _vimBufferData.VimTextBuffer.LastVisualSelection <- Some visualSelection
 
     /// Called when selection should no longer be tracked.  Must be paired with Start calls or

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -1380,7 +1380,7 @@ type internal MotionUtil
         | Some virtualPoint ->
 
             // Found the motion so update the jump list
-            _jumpList.Add x.CaretPoint
+            _jumpList.Add x.CaretVirtualPoint
 
             let caretPoint = TextViewUtil.GetCaretPoint _textView
             let markPoint = virtualPoint.Position
@@ -1407,7 +1407,7 @@ type internal MotionUtil
         | Some virtualPoint ->
 
             // Found the motion so update the jump list
-            _jumpList.Add x.CaretPoint
+            _jumpList.Add x.CaretVirtualPoint
 
             let startPoint, endPoint = SnapshotPointUtil.OrderAscending x.CaretPoint virtualPoint.Position
             let startLine = SnapshotPointUtil.GetContainingLine startPoint
@@ -1427,7 +1427,7 @@ type internal MotionUtil
         | Some 0 -> None
         | Some x when x > 100 -> None
         | Some count -> 
-            _jumpList.Add x.CaretPoint
+            _jumpList.Add x.CaretVirtualPoint
 
             let lineCount = x.CurrentSnapshot.LineCount
             let line = (count * lineCount + 99) / 100
@@ -1448,7 +1448,7 @@ type internal MotionUtil
         | Some matchingTokenSpan ->
 
             // Search succeeded so update the jump list before moving
-            _jumpList.Add x.CaretPoint
+            _jumpList.Add x.CaretVirtualPoint
 
             // Order the tokens appropriately to get the span 
             let span, isForward = 
@@ -1466,7 +1466,7 @@ type internal MotionUtil
         | Some matchingPoint ->
 
             // Search succeeded so update the jump list before moving
-            _jumpList.Add x.CaretPoint
+            _jumpList.Add x.CaretVirtualPoint
 
             // Order the tokens appropriately to get the span 
             let span, isForward = 
@@ -2479,7 +2479,7 @@ type internal MotionUtil
     /// Because this uses specific line numbers instead of counts we don't want to operate
     /// on the visual buffer here as vim line numbers always apply to the edit buffer. 
     member x.LineOrFirstToFirstNonBlank numberOpt = 
-        _jumpList.Add x.CaretPoint
+        _jumpList.Add x.CaretVirtualPoint
 
         let endLine = 
             match numberOpt with
@@ -2493,7 +2493,7 @@ type internal MotionUtil
     /// Because this uses specific line numbers instead of counts we don't want to operate
     /// on the visual buffer here as vim line numbers always apply to the edit buffer. 
     member x.LineOrLastToFirstNonBlank numberOpt = 
-        _jumpList.Add x.CaretPoint
+        _jumpList.Add x.CaretVirtualPoint
 
         let endLine = 
             match numberOpt with
@@ -2529,7 +2529,7 @@ type internal MotionUtil
 
     // Line from the top of the visual buffer
     member x.LineFromTopOfVisibleWindow countOpt = 
-        _jumpList.Add x.CaretPoint 
+        _jumpList.Add x.CaretVirtualPoint 
 
         match TextViewUtil.GetVisibleVisualSnapshotLineRange _textView with 
         | NullableUtil.Null -> None
@@ -2560,7 +2560,7 @@ type internal MotionUtil
 
     // Line from the top of the visual buffer
     member x.LineFromBottomOfVisibleWindow countOpt =
-        _jumpList.Add x.CaretPoint 
+        _jumpList.Add x.CaretVirtualPoint 
 
         match TextViewUtil.GetVisibleVisualSnapshotLineRange _textView with
         | NullableUtil.Null -> None
@@ -2594,7 +2594,7 @@ type internal MotionUtil
 
     /// Motion to put the caret in the middle of the visible window.  
     member x.LineInMiddleOfVisibleWindow () =
-        _jumpList.Add x.CaretPoint 
+        _jumpList.Add x.CaretVirtualPoint 
 
         match TextViewUtil.GetVisibleVisualSnapshotLineRange _textView with
         | NullableUtil.Null -> None
@@ -2618,7 +2618,7 @@ type internal MotionUtil
 
     /// Implements the core portion of section backward motions
     member x.SectionBackwardCore sectionKind count = 
-        _jumpList.Add x.CaretPoint
+        _jumpList.Add x.CaretVirtualPoint
 
         let startPoint = 
             x.CaretPoint
@@ -2640,7 +2640,7 @@ type internal MotionUtil
 
     /// Implements the core parts of section forward operators
     member x.SectionForwardCore sectionKind context count =
-        _jumpList.Add x.CaretPoint
+        _jumpList.Add x.CaretVirtualPoint
 
         let endPoint = 
             x.CaretPoint
@@ -2689,7 +2689,7 @@ type internal MotionUtil
         x.SectionBackwardCore SectionKind.OnCloseBrace count
 
     member x.SentenceForward count = 
-        _jumpList.Add x.CaretPoint
+        _jumpList.Add x.CaretVirtualPoint
         let endPoint =
             x.GetSentences SentenceKind.Default SearchPath.Forward x.CaretPoint
             |> SeqUtil.skipMax count
@@ -2699,7 +2699,7 @@ type internal MotionUtil
         MotionResult.Create(span, MotionKind.CharacterWiseExclusive, isForward = true, motionResultFlags = MotionResultFlags.BigDelete)
 
     member x.SentenceBackward count = 
-        _jumpList.Add x.CaretPoint
+        _jumpList.Add x.CaretVirtualPoint
         let startPoint = 
             x.GetSentences SentenceKind.Default SearchPath.Backward x.CaretPoint
             |> SeqUtil.skipMax (count - 1)
@@ -2710,7 +2710,7 @@ type internal MotionUtil
 
     /// Implements the '}' motion
     member x.ParagraphForward count = 
-        _jumpList.Add x.CaretPoint
+        _jumpList.Add x.CaretVirtualPoint
 
         let endPoint = 
             x.GetParagraphs SearchPath.Forward x.CaretPoint
@@ -2722,7 +2722,7 @@ type internal MotionUtil
 
     /// Implements the '{' motion
     member x.ParagraphBackward count = 
-        _jumpList.Add x.CaretPoint
+        _jumpList.Add x.CaretVirtualPoint
 
         let startPoint = 
             x.GetParagraphs SearchPath.Backward x.CaretPoint
@@ -2777,7 +2777,7 @@ type internal MotionUtil
     member x.SearchCore (searchData: SearchData) searchPoint count =
 
         // All search operations update the jump list
-        _jumpList.Add x.CaretPoint
+        _jumpList.Add x.CaretVirtualPoint
 
         // The search operation should also update the search history
         _vimData.SearchHistory.Add searchData.Pattern
@@ -2937,7 +2937,7 @@ type internal MotionUtil
     member x.NextWordCore path count isWholeWord = 
 
         // Next word motions should update the jump list
-        _jumpList.Add x.CaretPoint
+        _jumpList.Add x.CaretVirtualPoint
 
         // Pick the start point of the word.  If there are any words on this line after
         // the caret then we choose them.  Else we stick with the first non-blank.

--- a/Test/VimCoreTest/CharacterSpanTest.cs
+++ b/Test/VimCoreTest/CharacterSpanTest.cs
@@ -46,7 +46,7 @@ namespace Vim.UnitTest
                 public void IntoLineBreak()
                 {
                     Create("cat", "", "dog");
-                    var characterSpan = new CharacterSpan(_textBuffer.GetLine(0).Start, 1, 4);
+                    var characterSpan = new CharacterSpan(_textBuffer.GetPoint(0), _textBuffer.GetPoint(4));
                     Assert.Equal(5, characterSpan.LastLineLength);
                 }
 

--- a/Test/VimCoreTest/CharacterSpanTest.cs
+++ b/Test/VimCoreTest/CharacterSpanTest.cs
@@ -24,8 +24,19 @@ namespace Vim.UnitTest
                 {
                     Create("cat", "", "dog");
                     var characterSpan = new CharacterSpan(_textBuffer.GetLine(1).Start, 1, 0);
-                    Assert.Equal(2, characterSpan.Length);
-                    Assert.Equal(2, characterSpan.LastLineLength);
+                    Assert.Equal(0, characterSpan.Length);
+                    Assert.Equal(0, characterSpan.LastLineLength);
+                }
+
+                /// <summary>
+                /// A character span can end before the line break
+                /// </summary>
+                [WpfFact]
+                public void AtLineBreak()
+                {
+                    Create("cat", "", "dog");
+                    var characterSpan = new CharacterSpan(_textBuffer.GetLine(0).Start, 1, 3);
+                    Assert.Equal(3, characterSpan.LastLineLength);
                 }
 
                 /// <summary>
@@ -35,21 +46,20 @@ namespace Vim.UnitTest
                 public void IntoLineBreak()
                 {
                     Create("cat", "", "dog");
-                    var characterSpan = new CharacterSpan(_textBuffer.GetLine(0).Start, 0, 4);
-                    Assert.Equal(3, characterSpan.LastLineLength);
+                    var characterSpan = new CharacterSpan(_textBuffer.GetLine(0).Start, 1, 4);
+                    Assert.Equal(5, characterSpan.LastLineLength);
                 }
 
                 [WpfFact]
                 public void IntoLineBreakDeep()
                 {
                     Create("cat", "", "dog");
-                    var characterSpan = new CharacterSpan(_textBuffer.GetLine(0).Start, 0, 5);
-                    Assert.Equal(3, characterSpan.LastLineLength);
+                    var characterSpan = new CharacterSpan(_textBuffer.GetLine(0).Start, 1, 5);
+                    Assert.Equal(5, characterSpan.LastLineLength);
                 }
 
                 /// <summary>
-                /// If the last line is empty it should still be included in the CharacterSpan.  This is
-                /// an odd special case we have to handle
+                /// If the last line is empty it should not be included in the CharacterSpan
                 /// </summary>
                 [WpfFact]
                 public void LastLineEmpty()
@@ -57,8 +67,8 @@ namespace Vim.UnitTest
                     Create("cat", "", "dog");
                     var characterSpan = new CharacterSpan(_textBuffer.GetPoint(0), 2, 0);
                     Assert.Equal(2, characterSpan.LineCount);
-                    Assert.Equal(2, characterSpan.LastLineLength);
-                    Assert.Equal(_textBuffer.GetLine(2).Start, characterSpan.End);
+                    Assert.Equal(0, characterSpan.LastLineLength);
+                    Assert.Equal(_textBuffer.GetLine(1).Start, characterSpan.End);
                 }
             }
 
@@ -120,7 +130,7 @@ namespace Vim.UnitTest
             {
                 Create("cat", "", "dog");
                 var characterSpan = new CharacterSpan(_textBuffer.GetPoint(0), 2, 0);
-                Assert.True(characterSpan.IncludeLastLineLineBreak);
+                Assert.False(characterSpan.IncludeLastLineLineBreak);
             }
 
             [WpfFact]
@@ -128,7 +138,7 @@ namespace Vim.UnitTest
             {
                 Create("cat", "", "dog");
                 var characterSpan = new CharacterSpan(_textBuffer.GetLine(1).Start, 1, 0);
-                Assert.True(characterSpan.IncludeLastLineLineBreak);
+                Assert.False(characterSpan.IncludeLastLineLineBreak);
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/CommandUtilTest.cs
+++ b/Test/VimCoreTest/CommandUtilTest.cs
@@ -428,8 +428,8 @@ namespace Vim.UnitTest
             {
                 Create("cat", "dog");
                 Vim.MarkMap.SetGlobalMark(Letter.A, _vimTextBuffer, 0, 1);
-                var point = _textBuffer.GetPoint(1);
-                _commonOperations.Setup(x => x.MoveCaretToPoint(point, ViewFlags.Standard)).Verifiable();
+                var point = _textBuffer.GetVirtualPoint(1);
+                _commonOperations.Setup(x => x.MoveCaretToVirtualPoint(point, ViewFlags.Standard)).Verifiable();
                 _commandUtil.JumpToMark(Mark.NewGlobalMark(Letter.A));
                 _commonOperations.Verify();
             }

--- a/Test/VimCoreTest/CommandUtilTest.cs
+++ b/Test/VimCoreTest/CommandUtilTest.cs
@@ -2650,7 +2650,7 @@ namespace Vim.UnitTest
             public void JumpToOlderPosition_FromLocationNotInList()
             {
                 Create("cat", "dog", "fish");
-                _jumpList.Add(_textView.GetLine(1).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(1, 0));
                 _commandUtil.JumpToOlderPosition(1);
                 Assert.Equal(2, _jumpList.Jumps.Length);
                 Assert.Equal(_textView.GetPoint(0), _jumpList.Jumps.Head.Position);
@@ -2665,9 +2665,9 @@ namespace Vim.UnitTest
             public void JumpToOlderPosition_FromLocationInList()
             {
                 Create("cat", "dog", "fish");
-                _jumpList.Add(_textView.GetLine(2).Start);
-                _jumpList.Add(_textView.GetLine(1).Start);
-                _jumpList.Add(_textView.GetLine(0).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(2, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(1, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(0, 0));
                 _textView.MoveCaretToLine(1);
                 _commandUtil.JumpToOlderPosition(1);
                 Assert.Equal(3, _jumpList.Jumps.Length);
@@ -2690,8 +2690,8 @@ namespace Vim.UnitTest
             public void JumpToOlderPosition_FromLocationNotInListDuringTraversal()
             {
                 Create("cat", "dog", "fish");
-                _jumpList.Add(_textView.GetLine(1).Start);
-                _jumpList.Add(_textView.GetLine(0).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(1, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(0, 0));
                 _jumpList.StartTraversal();
                 Assert.True(_jumpList.MoveOlder(1));
                 _textView.MoveCaretToLine(2);
@@ -2708,9 +2708,9 @@ namespace Vim.UnitTest
             public void JumpToNextPosition_FromMiddle()
             {
                 Create("cat", "dog", "fish");
-                _jumpList.Add(_textView.GetLine(2).Start);
-                _jumpList.Add(_textView.GetLine(1).Start);
-                _jumpList.Add(_textView.GetLine(0).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(2, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(1, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(0, 0));
                 _jumpList.StartTraversal();
                 _jumpList.MoveOlder(1);
                 _commandUtil.JumpToNewerPosition(1);

--- a/Test/VimCoreTest/CommonOperationsTest.cs
+++ b/Test/VimCoreTest/CommonOperationsTest.cs
@@ -378,7 +378,7 @@ namespace Vim.UnitTest
             public void GoToDefinition1()
             {
                 Create("foo");
-                _jumpList.Setup(x => x.Add(_textView.GetCaretPoint())).Verifiable();
+                _jumpList.Setup(x => x.Add(_textView.GetCaretVirtualPoint())).Verifiable();
                 _vimHost.Setup(x => x.GoToDefinition()).Returns(true);
                 var res = _operations.GoToDefinition();
                 Assert.True(res.IsSucceeded);
@@ -1375,7 +1375,7 @@ namespace Vim.UnitTest
             public void GoToGlobalDeclaration1()
             {
                 Create("foo bar");
-                _jumpList.Setup(x => x.Add(It.IsAny<SnapshotPoint>()));
+                _jumpList.Setup(x => x.Add(It.IsAny<VirtualSnapshotPoint>()));
                 _vimHost.Setup(x => x.GoToGlobalDeclaration(_textView, "foo")).Returns(true).Verifiable();
                 _operations.GoToGlobalDeclaration();
                 _vimHost.Verify();
@@ -1395,7 +1395,7 @@ namespace Vim.UnitTest
             public void GoToLocalDeclaration1()
             {
                 Create("foo bar");
-                _jumpList.Setup(x => x.Add(It.IsAny<SnapshotPoint>()));
+                _jumpList.Setup(x => x.Add(It.IsAny<VirtualSnapshotPoint>()));
                 _vimHost.Setup(x => x.GoToLocalDeclaration(_textView, "foo")).Returns(true).Verifiable();
                 _operations.GoToLocalDeclaration();
                 _vimHost.Verify();

--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -1380,6 +1380,17 @@ namespace Vim.UnitTest
             }
 
             [WpfFact]
+            public void LineDownVirtualToVirtualWithTab()
+            {
+                Create("foo", "\tx", "");
+                _vimBuffer.LocalSettings.TabStop = 4;
+                _textView.MoveCaretTo(3, virtualSpaces: 3);
+                _vimBuffer.ProcessNotation("<Down>");
+                Assert.Equal(new VirtualSnapshotPoint(_textBuffer.GetLine(1), 3),
+                    _textView.Caret.Position.VirtualBufferPosition);
+            }
+
+            [WpfFact]
             public void LineDownVirtualToReal()
             {
                 Create("", "bar", "");
@@ -1404,6 +1415,17 @@ namespace Vim.UnitTest
             {
                 Create("foo", "bar", "");
                 _textView.MoveCaretToLine(1, 3, virtualSpaces: 3);
+                _vimBuffer.ProcessNotation("<Up>");
+                Assert.Equal(new VirtualSnapshotPoint(_textBuffer.GetLine(0), 6),
+                    _textView.Caret.Position.VirtualBufferPosition);
+            }
+
+            [WpfFact]
+            public void LineUpVirtualToVirtualWithTab()
+            {
+                Create("foo", "\tx", "");
+                _localSettings.TabStop = 4;
+                _textView.MoveCaretToLine(1, 2, virtualSpaces: 1);
                 _vimBuffer.ProcessNotation("<Up>");
                 Assert.Equal(new VirtualSnapshotPoint(_textBuffer.GetLine(0), 6),
                     _textView.Caret.Position.VirtualBufferPosition);

--- a/Test/VimCoreTest/JumpListTest.cs
+++ b/Test/VimCoreTest/JumpListTest.cs
@@ -43,8 +43,8 @@ namespace Vim.UnitTest
             public void CountTooBig()
             {
                 Create("cat", "dog");
-                _jumpList.Add(_textBuffer.GetPoint(0));
-                _jumpList.Add(_textBuffer.GetLine(1).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(0, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(1, 0));
                 _jumpList.StartTraversal();
                 Assert.False(_jumpList.MoveOlder(10));
                 Assert.True(_jumpList.CurrentIndex.IsSome(0));
@@ -57,10 +57,10 @@ namespace Vim.UnitTest
             public void Valid()
             {
                 Create("cat", "dog");
-                _jumpList.Add(_textBuffer.GetPoint(0));
-                _jumpList.Add(_textBuffer.GetLine(1).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(0, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(1, 0));
                 _jumpList.StartTraversal();
-                Assert.True(_jumpList.Current.IsSome(_textBuffer.GetLine(0).Start));
+                Assert.True(_jumpList.Current.IsSome(_textBuffer.GetVirtualPointInLine(0, 0)));
                 Assert.True(_jumpList.CurrentIndex.IsSome(0));
                 Assert.True(_jumpList.MoveOlder(1));
                 Assert.True(_jumpList.CurrentIndex.IsSome(1));
@@ -73,9 +73,9 @@ namespace Vim.UnitTest
             public void DontChangeLastJumpLocation()
             {
                 Create("dog", "cat", "fish", "bear");
-                _jumpList.Add(_textBuffer.GetLine(1).Start);
-                _jumpList.Add(_textBuffer.GetLine(2).Start);
-                _jumpList.Add(_textBuffer.GetLine(3).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(1, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(2, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(3, 0));
                 _jumpList.SetLastJumpLocation(1, 0);
                 _jumpList.StartTraversal();
                 Assert.True(_jumpList.MoveOlder(1));
@@ -103,8 +103,8 @@ namespace Vim.UnitTest
             public void CountTooBig()
             {
                 Create("cat", "dog");
-                _jumpList.Add(_textBuffer.GetLine(0).Start);
-                _jumpList.Add(_textBuffer.GetLine(1).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(0, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(1, 0));
                 _jumpList.StartTraversal();
                 Assert.True(_jumpList.MoveOlder(1));
                 Assert.False(_jumpList.MoveNewer(2));
@@ -118,8 +118,8 @@ namespace Vim.UnitTest
             public void CountValid()
             {
                 Create("cat", "dog");
-                _jumpList.Add(_textBuffer.GetLine(0).Start);
-                _jumpList.Add(_textBuffer.GetLine(1).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(0, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(1, 0));
                 _jumpList.StartTraversal();
                 Assert.True(_jumpList.MoveOlder(1));
                 Assert.True(_jumpList.MoveNewer(1));
@@ -133,9 +133,9 @@ namespace Vim.UnitTest
             public void DontChangeLastJumpLocation()
             {
                 Create("dog", "cat", "fish", "bear");
-                _jumpList.Add(_textBuffer.GetLine(1).Start);
-                _jumpList.Add(_textBuffer.GetLine(2).Start);
-                _jumpList.Add(_textBuffer.GetLine(3).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(1, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(2, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(3, 0));
                 _jumpList.SetLastJumpLocation(1, 0);
                 _jumpList.StartTraversal();
                 _jumpList.MoveOlder(1);
@@ -153,7 +153,7 @@ namespace Vim.UnitTest
             public void First()
             {
                 Create("");
-                _jumpList.Add(_textBuffer.GetLine(0).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(0, 0));
                 Assert.True(_jumpList.Current.IsNone());
                 Assert.True(_jumpList.CurrentIndex.IsNone());
             }
@@ -167,9 +167,9 @@ namespace Vim.UnitTest
                 Create("a", "b", "c", "d", "e");
                 for (var i = 0; i < 5; i++)
                 {
-                    var point = _textBuffer.GetLine(i).Start;
+                    var point = _textBuffer.GetVirtualPointInLine(i, 0);
                     _jumpList.Add(point);
-                    Assert.Equal(point, _jumpList.Jumps.First().Position);
+                    Assert.Equal(point, _jumpList.Jumps.First());
                 }
 
                 Assert.Equal(5, _jumpList.Jumps.Count());
@@ -183,9 +183,9 @@ namespace Vim.UnitTest
             public void SameLine()
             {
                 Create("a", "b", "c", "d", "e");
-                _jumpList.Add(_textBuffer.GetLine(0).Start);
-                _jumpList.Add(_textBuffer.GetLine(1).Start);
-                _jumpList.Add(_textBuffer.GetLine(0).Start);
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(0, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(1, 0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(0, 0));
                 Assert.Equal(2, _jumpList.Jumps.Count());
                 Assert.Equal(_textBuffer.GetLine(0).Start, _jumpList.Jumps.ElementAt(0).Position);
                 Assert.Equal(_textBuffer.GetLine(1).Start, _jumpList.Jumps.ElementAt(1).Position);
@@ -198,9 +198,9 @@ namespace Vim.UnitTest
             public void UpdateLastJumpLocation()
             {
                 Create("cat", "dog", "fish");
-                var point = _textBuffer.GetLine(1).Start.Add(2);
+                var point = _textBuffer.GetVirtualPointInLine(1, 2);
                 _jumpList.Add(point);
-                Assert.Equal(point, _jumpList.LastJumpLocation.Value.Position);
+                Assert.Equal(point, _jumpList.LastJumpLocation.Value);
             }
         }
 

--- a/Test/VimCoreTest/MotionUtilTest.cs
+++ b/Test/VimCoreTest/MotionUtilTest.cs
@@ -4002,7 +4002,7 @@ more";
             [WpfFact]
             public void LineDownVirtualToVirtual()
             {
-                Create("foo", "baz", "");
+                Create("foo", "bar", "");
                 _textView.MoveCaretTo(3, virtualSpaces: 1);
                 var data = _motionUtil.LineDown(1);
                 AssertData(
@@ -4010,6 +4010,20 @@ more";
                     _textBuffer.GetLineRange(0, 1).ExtentIncludingLineBreak,
                     motionKind: MotionKind.LineWise,
                     caretColumn: CaretColumn.NewInLastLine(4));
+            }
+
+            [WpfFact]
+            public void LineDownVirtualToVirtualWithTab()
+            {
+                Create("\tx", "bar", "");
+                _localSettings.TabStop = 4;
+                _textView.MoveCaretTo(2, virtualSpaces: 1);
+                var data = _motionUtil.LineDown(1);
+                AssertData(
+                    data,
+                    _textBuffer.GetLineRange(0, 1).ExtentIncludingLineBreak,
+                    motionKind: MotionKind.LineWise,
+                    caretColumn: CaretColumn.NewInLastLine(3));
             }
 
             [WpfFact]
@@ -4052,9 +4066,22 @@ more";
             }
 
             [WpfFact]
+            public void LineUpVirtualToRealWithTab()
+            {
+                Create("foo", "\tx", "");
+                _textView.MoveCaretToLine(1, 2, virtualSpaces: 1);
+                var data = _motionUtil.LineUp(1);
+                AssertData(
+                    data,
+                    _textBuffer.GetLineRange(0, 1).ExtentIncludingLineBreak,
+                    motionKind: MotionKind.LineWise,
+                    caretColumn: CaretColumn.NewInLastLine(3));
+            }
+
+            [WpfFact]
             public void LineUpVirtualToVirtual()
             {
-                Create("foo", "baz", "");
+                Create("foo", "bar", "");
                 _textView.MoveCaretToLine(1, 3, virtualSpaces: 1);
                 var data = _motionUtil.LineUp(1);
                 AssertData(

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -8419,6 +8419,7 @@ namespace Vim.UnitTest
             [InlineData("exclusive")]
             public void SwitchPreviousVisualMode_Character(string selection)
             {
+                // Reported for 'exclusive' in issue #2186.
                 Create("cat dog fish", "");
                 _globalSettings.Selection = selection;
                 _vimBuffer.ProcessNotation("wve");

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -8412,6 +8412,27 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
+            /// Make sure we handle the 'gv' command to switch to the previous visual mode
+            /// </summary>
+            [WpfTheory]
+            [InlineData("inclusive")]
+            [InlineData("exclusive")]
+            public void SwitchPreviousVisualMode_Character(string selection)
+            {
+                Create("cat dog fish", "");
+                _globalSettings.Selection = selection;
+                _vimBuffer.ProcessNotation("wve");
+                var span = _textBuffer.GetSpan(4, 3);
+                Assert.Equal(span, _textView.GetSelectionSpan());
+                _vimBuffer.ProcessNotation("<Esc>");
+                _vimBuffer.ProcessNotation("gv");
+                Assert.Equal(span, _textView.GetSelectionSpan());
+                _vimBuffer.ProcessNotation("<Esc>");
+                _vimBuffer.ProcessNotation("gv");
+                Assert.Equal(span, _textView.GetSelectionSpan());
+            }
+
+            /// <summary>
             /// Make sure the caret is positioned properly during undo
             /// </summary>
             [WpfFact]

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -7081,7 +7081,7 @@ namespace Vim.UnitTest
             public void FromLocationNotInList()
             {
                 Create("cat", "dog", "fish");
-                _jumpList.Add(_textView.GetPoint(0));
+                _jumpList.Add(_textBuffer.GetVirtualPointInLine(0, 0));
                 _textView.MoveCaretToLine(1);
                 _vimBuffer.Process(KeyInputUtil.CharWithControlToKeyInput('o'));
                 Assert.Equal(_textView.GetLine(0).Start, _textView.GetCaretPoint());

--- a/Test/VimCoreTest/SelectionTrackerTest.cs
+++ b/Test/VimCoreTest/SelectionTrackerTest.cs
@@ -95,6 +95,7 @@ namespace Vim.UnitTest
             view.SetupGet(x => x.Selection).Returns(selection.Object);
             var vimTextBuffer = new Mock<IVimTextBuffer>(MockBehavior.Strict);
             vimTextBuffer.SetupGet(x => x.LocalSettings).Returns(new LocalSettings(_globalSettings));
+            vimTextBuffer.SetupGet(x => x.UseVirtualSpace).Returns(false);
             vimTextBuffer.SetupSet(x => x.LastVisualSelection = It.IsAny<Microsoft.FSharp.Core.FSharpOption<VisualSelection>>());
             var vimBufferData = MockObjectFactory.CreateVimBufferData(vimTextBuffer.Object, view.Object);
             var tracker = new SelectionTracker(vimBufferData, _incrementalSearch.Object, VisualKind.Character);
@@ -113,6 +114,7 @@ namespace Vim.UnitTest
             view.Selection.Select(new SnapshotSpan(view.TextSnapshot, 1, 3), false);
             var vimTextBuffer = new Mock<IVimTextBuffer>(MockBehavior.Strict);
             vimTextBuffer.SetupGet(x => x.LocalSettings).Returns(new LocalSettings(_globalSettings));
+            vimTextBuffer.SetupGet(x => x.UseVirtualSpace).Returns(false);
             vimTextBuffer.SetupSet(x => x.LastVisualSelection = It.IsAny<Microsoft.FSharp.Core.FSharpOption<VisualSelection>>());
             var vimBufferData = MockObjectFactory.CreateVimBufferData(vimTextBuffer.Object, view);
             var tracker = new SelectionTracker(vimBufferData, _incrementalSearch.Object, VisualKind.Character);

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -829,6 +829,18 @@ namespace Vim.UnitTest
                 Assert.Equal(point1, _textView.Selection.Start);
                 Assert.Equal(point2, _textView.Selection.End);
             }
+
+            [WpfFact]
+            public void RightToEndOfLine()
+            {
+                // Reported in issue #1507.
+                Create("cat", "dog", "");
+                _vimBuffer.Process("v3l");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 3);
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
         }
 
         public sealed class VirtualInclusiveSelection : VisualModeIntegrationTest

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -839,6 +839,17 @@ namespace Vim.UnitTest
                 Assert.Equal(point1, _textView.Selection.Start);
                 Assert.Equal(point2, _textView.Selection.End);
             }
+
+            [WpfFact]
+            public void DownToEmptyLine()
+            {
+                Create("cat", "", "");
+                _vimBuffer.Process("vj");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
+                var point2 = _textBuffer.GetVirtualPointInLine(1, 1);
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
         }
 
         public sealed class VirtualExclusiveSelection : VisualModeIntegrationTest
@@ -868,6 +879,17 @@ namespace Vim.UnitTest
                 _vimBuffer.Process("vl");
                 var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
                 var point2 = _textBuffer.GetVirtualPointInLine(0, 1);
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
+
+            [WpfFact]
+            public void DownToEmptyLine()
+            {
+                Create("cat", "", "");
+                _vimBuffer.Process("vj");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 4); // or is (1, 0) better?
                 Assert.Equal(point1, _textView.Selection.Start);
                 Assert.Equal(point2, _textView.Selection.End);
             }

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -850,6 +850,17 @@ namespace Vim.UnitTest
                 Assert.Equal(point1, _textView.Selection.Start);
                 Assert.Equal(point2, _textView.Selection.End);
             }
+
+            [WpfFact]
+            public void RightToVirtualSpace()
+            {
+                Create("cat", "", "");
+                _vimBuffer.Process("v4l");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 5);
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
         }
 
         public sealed class VirtualExclusiveSelection : VisualModeIntegrationTest
@@ -890,6 +901,17 @@ namespace Vim.UnitTest
                 _vimBuffer.Process("vj");
                 var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
                 var point2 = _textBuffer.GetVirtualPointInLine(0, 4); // or is (1, 0) better?
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
+
+            [WpfFact]
+            public void RightToVirtualSpace()
+            {
+                Create("cat", "", "");
+                _vimBuffer.Process("v4l");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 4);
                 Assert.Equal(point1, _textView.Selection.Start);
                 Assert.Equal(point2, _textView.Selection.End);
             }

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -841,6 +841,17 @@ namespace Vim.UnitTest
                 Assert.Equal(point1, _textView.Selection.Start);
                 Assert.Equal(point2, _textView.Selection.End);
             }
+
+            [WpfFact]
+            public void RightToEndOfLineFromMiddle()
+            {
+                Create("cat", "dog", "");
+                _vimBuffer.Process("lv2l");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 1);
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 3);
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
         }
 
         public sealed class VirtualInclusiveSelection : VisualModeIntegrationTest

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -3219,6 +3219,29 @@ namespace Vim.UnitTest
                 }
             }
 
+            public sealed class VirtualCharacterTest : YankSelectionTest
+            {
+                [WpfFact]
+                public void InclusiveVirtualSpaces()
+                {
+                    Create("cat", "");
+                    _globalSettings.VirtualEdit = "all";
+                    _globalSettings.Selection = "inclusive";
+                    _vimBuffer.Process("v6ly");
+                    Assert.Equal("cat    ", UnnamedRegister.StringValue);
+                }
+
+                [WpfFact]
+                public void ExclusiveVirtualSpaces()
+                {
+                    Create("cat", "");
+                    _globalSettings.VirtualEdit = "all";
+                    _globalSettings.Selection = "exclusive";
+                    _vimBuffer.Process("v6ly");
+                    Assert.Equal("cat   ", UnnamedRegister.StringValue);
+                }
+            }
+
             public sealed class LineTest : YankSelectionTest
             {
                 /// <summary>

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -818,6 +818,17 @@ namespace Vim.UnitTest
                 Assert.Equal(point1, _textView.Selection.Start);
                 Assert.Equal(point2, _textView.Selection.End);
             }
+
+            [WpfFact]
+            public void DownToEmptyLine()
+            {
+                Create("cat", "", "dog", "");
+                _vimBuffer.Process("vj");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 4);
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
         }
 
         public sealed class VirtualInclusiveSelection : VisualModeIntegrationTest
@@ -911,7 +922,7 @@ namespace Vim.UnitTest
                 Create("cat", "", "");
                 _vimBuffer.Process("vj");
                 var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
-                var point2 = _textBuffer.GetVirtualPointInLine(0, 4); // or is (1, 0) better?
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 4);
                 Assert.Equal(point1, _textView.Selection.Start);
                 Assert.Equal(point2, _textView.Selection.End);
             }

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -809,6 +809,70 @@ namespace Vim.UnitTest
             }
         }
 
+        public sealed class VirtualInclusiveSelection : VisualModeIntegrationTest
+        {
+            protected override void Create(params string[] lines)
+            {
+                base.Create(lines);
+                _globalSettings.Selection = "inclusive";
+                _globalSettings.VirtualEdit = "all";
+            }
+
+            [WpfFact]
+            public void AtStartOfEmptyLine()
+            {
+                Create("", "");
+                _vimBuffer.Process("v");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 1);
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
+
+            [WpfFact]
+            public void RightOnEmptyLine()
+            {
+                Create("", "");
+                _vimBuffer.Process("vl");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 2);
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
+        }
+
+        public sealed class VirtualExclusiveSelection : VisualModeIntegrationTest
+        {
+            protected override void Create(params string[] lines)
+            {
+                base.Create(lines);
+                _globalSettings.Selection = "exclusive";
+                _globalSettings.VirtualEdit = "all";
+            }
+
+            [WpfFact]
+            public void AtStartOfEmptyLine()
+            {
+                Create("", "");
+                _vimBuffer.Process("v");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 0);
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
+
+            [WpfFact]
+            public void RightOnEmptyLine()
+            {
+                Create("", "");
+                _vimBuffer.Process("vl");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 1);
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
+        }
+
         public abstract class BlockInsertTest : VisualModeIntegrationTest
         {
             /// <summary>

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -807,6 +807,17 @@ namespace Vim.UnitTest
                 _vimBuffer.Process("vi(");
                 Assert.Equal(new SnapshotSpan(caretPoint, 0), _textView.GetSelectionSpan());
             }
+
+            [WpfFact]
+            public void AtStartOfEmptyLine()
+            {
+                Create("", "");
+                _vimBuffer.Process("v");
+                var point1 = _textBuffer.GetVirtualPointInLine(0, 0);
+                var point2 = _textBuffer.GetVirtualPointInLine(0, 0);
+                Assert.Equal(point1, _textView.Selection.Start);
+                Assert.Equal(point2, _textView.Selection.End);
+            }
         }
 
         public sealed class VirtualInclusiveSelection : VisualModeIntegrationTest

--- a/Test/VimCoreTest/VisualSelectionTest.cs
+++ b/Test/VimCoreTest/VisualSelectionTest.cs
@@ -194,7 +194,7 @@ namespace Vim.UnitTest
                 {
                     Create("cat", "dog");
                     var visualSelection = VisualSelection.NewCharacter(
-                        new CharacterSpan(_textBuffer.GetPoint(0), 1, 4),
+                        new CharacterSpan(_textBuffer.GetPoint(0), _textBuffer.GetPoint(4)),
                         SearchPath.Forward);
                     Assert.Equal(4, visualSelection.GetCaretPoint(SelectionKind.Inclusive));
                 }
@@ -204,7 +204,7 @@ namespace Vim.UnitTest
                 {
                     Create("cat", "dog");
                     var visualSelection = VisualSelection.NewCharacter(
-                        new CharacterSpan(_textBuffer.GetPoint(0), 1, 5),
+                        new CharacterSpan(_textBuffer.GetPoint(0), _textBuffer.GetPoint(5)),
                         SearchPath.Forward);
                     Assert.Equal(4, visualSelection.GetCaretPoint(SelectionKind.Inclusive));
                 }

--- a/Test/VimCoreTest/VisualSelectionTest.cs
+++ b/Test/VimCoreTest/VisualSelectionTest.cs
@@ -503,7 +503,7 @@ namespace Vim.UnitTest
                 public void SelectionExclusive()
                 {
                     Create("hello world");
-                    var visualSelection = VisualSelection.CreateInitial(VisualKind.Character, _textBuffer.GetVirtualPoint(0), 4, SelectionKind.Exclusive);
+                    var visualSelection = VisualSelection.CreateInitial(VisualKind.Character, _textBuffer.GetVirtualPoint(0), 4, SelectionKind.Exclusive, false);
                     Assert.Equal(0, visualSelection.AsCharacter().Item1.Length);
                 }
 
@@ -511,8 +511,30 @@ namespace Vim.UnitTest
                 public void SelectionInclusive()
                 {
                     Create("hello world");
-                    var visualSelection = VisualSelection.CreateInitial(VisualKind.Character, _textBuffer.GetVirtualPoint(0), 4, SelectionKind.Inclusive);
+                    var visualSelection = VisualSelection.CreateInitial(VisualKind.Character, _textBuffer.GetVirtualPoint(0), 4, SelectionKind.Inclusive, false);
                     Assert.Equal(1, visualSelection.AsCharacter().Item1.Length);
+                }
+
+                [WpfFact]
+                public void VirtualSelectionExclusive()
+                {
+                    Create("hello world");
+                    var virtualPoint = _textBuffer.GetVirtualPointInLine(0, 20);
+                    var visualSelection = VisualSelection.CreateInitial(VisualKind.Character,
+                        virtualPoint, 4, SelectionKind.Exclusive, true);
+                    Assert.Equal(virtualPoint, visualSelection.AsCharacter().Item1.VirtualStart);
+                    Assert.Equal(0, visualSelection.AsCharacter().Item1.VirtualLength);
+                }
+
+                [WpfFact]
+                public void VirtualSelectionInclusive()
+                {
+                    Create("hello world");
+                    var virtualPoint = _textBuffer.GetVirtualPointInLine(0, 20);
+                    var visualSelection = VisualSelection.CreateInitial(VisualKind.Character,
+                        virtualPoint, 4, SelectionKind.Inclusive, true);
+                    Assert.Equal(virtualPoint, visualSelection.AsCharacter().Item1.VirtualStart);
+                    Assert.Equal(1, visualSelection.AsCharacter().Item1.VirtualLength);
                 }
             }
         }


### PR DESCRIPTION
#### Changes

- Extend `CharacterSpan` to support character selections beginning or ending in virtual space
- Extend setting marks, jumping to marks and the jump list to support marks in virtual space
- Support yanking a characterwise selection that ends in virtual space
- Fix problems with exclusive characterwise selections wrongly including the linebreak
- Fix last visual selection after putting over selection

#### Fixes

- Fixes #1507
- Fixes #2186
- Fixes #2260

#### Discussion

This is most of the rest of the 'virtualedit' setting. The main feature missing is restoring a characterwise visual selection that starts in virtual space and the last selection end point when the selection ends in virtual space. Both of these features require considerable work for special marks, which can be part of a subsequent PR.

To avoid a large number of changes, particularly to the unit tests, we support both virtual (e.g. `VirtualSnapshotPoint`) and non-virtual (e.g. `SnapshotPoint`) in the API to `CharacterSpan`. It would be possible to remove the non-virtual API and use the virtual one exclusively. However, changing all callers, especially when those callers know for a fact that the specified points are not in virtual space, would require many trivial changes and complicate the callers.

My current opinion is that the dual virtual/non-virtual API is, at least for now, beneficial because it ensures that most code continues to use the same code paths when virtual space is not in use while allowing the support for virtual space to evolve and mature.

I do not doubt that daily use by a user who uses `virtualedit` heavily will uncover further areas that need to be virtualized, but I think this change does most of the groundwork and that those kinds of issues can be best uncovered with field testing.