### PR TITLE
Format text lines

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1035,24 +1035,16 @@ type internal CommandUtil
 
     /// Format the selected code lines
     member x.FormatCodeLinesVisual (visualSpan: VisualSpan) =
-
-        // Use a transaction so the formats occur as a single operation
-        x.EditWithUndoTransaction "Format" (fun () ->
-            visualSpan.Spans
-            |> Seq.map SnapshotLineRangeUtil.CreateForSpan
-            |> Seq.iter _commonOperations.FormatCodeLines)
-
+        visualSpan.EditSpan.OverarchingSpan
+        |> SnapshotLineRangeUtil.CreateForSpan
+        |> _commonOperations.FormatCodeLines
         CommandResult.Completed ModeSwitch.SwitchPreviousMode
 
     /// Format the selected text lines
     member x.FormatTextLinesVisual (visualSpan: VisualSpan) (preserveCaretPosition: bool) =
-
-        // Use a transaction so the formats occur as a single operation
-        x.EditWithUndoTransaction "Format" (fun () ->
-            visualSpan.Spans
-            |> Seq.map SnapshotLineRangeUtil.CreateForSpan
-            |> Seq.iter (fun lineRange -> _commonOperations.FormatTextLines lineRange preserveCaretPosition))
-
+        visualSpan.EditSpan.OverarchingSpan
+        |> SnapshotLineRangeUtil.CreateForSpan
+        |> (fun lineRange -> _commonOperations.FormatTextLines lineRange preserveCaretPosition)
         CommandResult.Completed ModeSwitch.SwitchPreviousMode
 
     /// Format the code lines in the Motion

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -248,6 +248,7 @@ type internal CommonOperations
             else
                 _localSettings.TextWidth
         let comments = _localSettings.Comments
+        let tabStop = _localSettings.TabStop
 
         // Extract the lines to be formatted and the first line.
         let lines = range.Lines |> Seq.map SnapshotLineUtil.GetText
@@ -331,13 +332,18 @@ type internal CommonOperations
             else
                 concatWords words :: lines
 
+        // Calculate the length of the leader with tabs expanded.
+        let leaderLength =
+            StringUtil.ExpandTabsForColumn leader 0 tabStop
+            |> StringUtil.GetLength
+
         // Aggregrate individual words into lines of limited length.
         let takeWord ((column: int), (words: string list), (lines: string list)) (word: string) =
 
             // Calculate the working limit for line length.
             let limit =
                 if lines.IsEmpty || useLeaderForAllLines then
-                    textWidth - leader.Length
+                    textWidth - leaderLength
                 else
                     textWidth
 

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -296,7 +296,7 @@ type internal CommonOperations
             not (StringUtil.IsWhiteSpace leader) || autoIndent
 
         // Strip the leader from a line.
-        let trimLine (line: string) =
+        let stripLeader (line: string) =
             let capture = Regex.Match(line, pattern)
             if capture.Success then
                 line.Substring(capture.Length)
@@ -304,9 +304,9 @@ type internal CommonOperations
                 line
 
         // Strip the leader from all the lines.
-        let trimmedLines =
+        let strippedLines =
             lines
-            |> Seq.map trimLine
+            |> Seq.map stripLeader
 
         // Split a line into words on whitespace.
         let splitWords (line: string) =
@@ -363,7 +363,7 @@ type internal CommonOperations
         // Split the lines into words and then format them into lines using the aggregator.
         let formattedLines =
             let _, words, lines =
-                trimmedLines
+                strippedLines
                 |> Seq.collect splitWords
                 |> Seq.fold takeWord (0, List.Empty, List.Empty)
             prependLine words lines

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -262,7 +262,7 @@ type internal CommonOperations
             else
                 spec.Substring(colonIndex + 1)
 
-        // Get the leader pattern for a leader string
+        // Get the leader pattern for a leader string.
         let getLeaderPattern (leader: string) =
             if leader = "" then
                 @"^\s*"
@@ -325,7 +325,7 @@ type internal CommonOperations
             |> String.concat ""
             |> (fun line -> line.TrimEnd())
 
-        // Concatenate words into a line a prepend it to a list of lines.
+        // Concatenate words into a line and prepend it to a list of lines.
         let prependLine (words: string list) (lines: string list) =
             if words.IsEmpty then
                 lines
@@ -375,7 +375,7 @@ type internal CommonOperations
         let newLine = EditUtil.NewLine _editorOptions
         let replacement = formattedLines |> String.concat newLine
 
-        // Replace the old lines with the sorted lines.
+        // Replace the old lines with the formatted lines.
         _textBuffer.Replace(range.Extent.Span, replacement) |> ignore
 
 

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -244,7 +244,7 @@ type internal CommonOperations
         let autoIndent = _localSettings.AutoIndent
         let textWidth =
             if _localSettings.TextWidth = 0 then
-                79
+                VimConstants.DefaultFormatTextWidth
             else
                 _localSettings.TextWidth
         let comments = _localSettings.Comments

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -229,7 +229,16 @@ type internal CommonOperations
             _editorOperations.MoveToStartOfLineAfterWhiteSpace(false)
 
     /// Format the specified line range
-    member x.FormatLines range =
+    member x.FormatCodeLines range =
+        _vimHost.FormatLines _textView range
+
+        // Place the cursor on the first non-blank character of the first line formatted.
+        let firstLine = SnapshotUtil.GetLine _textView.TextSnapshot range.StartLineNumber
+        TextViewUtil.MoveCaretToPoint _textView firstLine.Start
+        _editorOperations.MoveToStartOfLineAfterWhiteSpace(false)
+
+    /// Format the specified line range
+    member x.FormatTextLines range preserveCaretPosition =
         _vimHost.FormatLines _textView range
 
         // Place the cursor on the first non-blank character of the first line formatted.
@@ -1843,7 +1852,8 @@ type internal CommonOperations
         member x.EnsureAtPoint point viewFlags = x.EnsureAtPoint point viewFlags
         member x.FillInVirtualSpace() = x.FillInVirtualSpace()
         member x.FilterLines range command = x.FilterLines range command
-        member x.FormatLines range = x.FormatLines range
+        member x.FormatCodeLines range = x.FormatCodeLines range
+        member x.FormatTextLines range preserveCaretPosition = x.FormatTextLines range preserveCaretPosition
         member x.GetRegister registerName = x.GetRegister registerName
         member x.GetNewLineText point = x.GetNewLineText point
         member x.GetNewLineIndent contextLine newLine = x.GetNewLineIndent contextLine newLine

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -343,7 +343,7 @@ type internal CommonOperations
 
             if word = "" then
                 0, List.Empty, "" :: prependLine words lines
-            elif column = 0 || column + word.Length <= limit then
+            elif column = 0 || column + word.TrimEnd().Length <= limit then
                 column + word.Length, word :: words, lines
             else
                 word.Length, word :: List.Empty, concatWords words :: lines

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -285,11 +285,10 @@ type internal CommonOperations
                 false, pattern, ""
 
         // Choose a pattern and a leader.
-        let pattern, leader =
+        let _, pattern, leader =
             patterns
             |> Seq.map checkPattern
             |> Seq.filter (fun (matches, _, _) -> matches)
-            |> Seq.map (fun (_, pattern, leader) -> (pattern, leader))
             |> Seq.head
 
         // Decide whether to use the leader for all lines.

--- a/Src/VimCore/Constants.fs
+++ b/Src/VimCore/Constants.fs
@@ -19,6 +19,11 @@ module VimConstants =
     [<Literal>]
     let DefaultHistoryLength = 20
 
+    /// The default text width that FormatTextLines will use if the 'textwidth'
+    /// setting is zero (see vim ':help gq')
+    [<Literal>]
+    let DefaultFormatTextWidth = 79
+
     [<Literal>]
     let IncrementalSearchTagName = "vsvim_incrementalsearch"
 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2721,11 +2721,17 @@ type NormalCommand =
     /// Create a fold over the specified motion 
     | FoldMotion of MotionData
 
-    /// Format the specified lines
-    | FormatLines
+    /// Format the code in the specified lines
+    | FormatCodeLines
 
-    /// Format the specified motion
-    | FormatMotion of MotionData
+    /// Format the code in the specified motion
+    | FormatCodeMotion of MotionData
+
+    /// Format the text in the specified lines, optionally preserving the caret position
+    | FormatTextLines of bool
+
+    /// Format the text in the specified motion
+    | FormatTextMotion of bool * MotionData
 
     /// Go to the definition of hte word under the caret.
     | GoToDefinition
@@ -2940,11 +2946,13 @@ type NormalCommand =
 
     member private x.GetMotionDataCore() = 
         match x with
+        | NormalCommand.ChangeCaseMotion (changeCharacterKind, motion) -> Some ((fun motion -> NormalCommand.ChangeCaseMotion (changeCharacterKind, motion)), motion)
         | NormalCommand.ChangeMotion motion -> Some (NormalCommand.ChangeMotion, motion)
         | NormalCommand.DeleteMotion motion -> Some (NormalCommand.DeleteMotion, motion)
         | NormalCommand.FilterMotion motion -> Some (NormalCommand.FilterMotion, motion)
         | NormalCommand.FoldMotion motion -> Some (NormalCommand.FoldMotion, motion)
-        | NormalCommand.FormatMotion motion -> Some (NormalCommand.FormatMotion, motion)
+        | NormalCommand.FormatCodeMotion motion -> Some (NormalCommand.FormatCodeMotion, motion)
+        | NormalCommand.FormatTextMotion (preserveCaretPosition, motion) -> Some ((fun motion -> NormalCommand.FormatTextMotion (preserveCaretPosition, motion)), motion)
         | NormalCommand.ShiftMotionLinesLeft motion -> Some (NormalCommand.ShiftMotionLinesLeft, motion)
         | NormalCommand.ShiftMotionLinesRight motion -> Some (NormalCommand.ShiftMotionLinesRight, motion)
         | NormalCommand.Yank motion -> Some (NormalCommand.Yank, motion)
@@ -2953,7 +2961,6 @@ type NormalCommand =
         | NormalCommand.AddToWord _ -> None
         | NormalCommand.ChangeCaseCaretLine _ -> None
         | NormalCommand.ChangeCaseCaretPoint _ -> None
-        | NormalCommand.ChangeCaseMotion _ -> None
         | NormalCommand.ChangeLines -> None
         | NormalCommand.ChangeTillEndOfLine -> None
         | NormalCommand.CloseAllFolds -> None
@@ -2972,7 +2979,8 @@ type NormalCommand =
         | NormalCommand.DisplayCharacterCodePoint ->None
         | NormalCommand.FilterLines -> None
         | NormalCommand.FoldLines -> None
-        | NormalCommand.FormatLines -> None
+        | NormalCommand.FormatCodeLines -> None
+        | NormalCommand.FormatTextLines _ -> None
         | NormalCommand.GoToDefinition -> None
         | NormalCommand.GoToFileUnderCaret _ -> None
         | NormalCommand.GoToGlobalDeclaration -> None
@@ -3081,8 +3089,11 @@ type VisualCommand =
     /// Fold the current selected lines
     | FoldSelection
 
-    /// Format the selected text
-    | FormatLines
+    /// Format the selected code lines
+    | FormatCodeLines
+
+    /// Format the selected text lines, optionally preserving the caret position
+    | FormatTextLines of bool
 
     /// GoTo the file under the cursor in a new window
     | GoToFileInSelectionInNewWindow

--- a/Src/VimCore/MefInterfaces.fs
+++ b/Src/VimCore/MefInterfaces.fs
@@ -349,7 +349,10 @@ type ICommonOperations =
     abstract FilterLines: SnapshotLineRange -> command: string -> unit
 
     /// Format the specified line range
-    abstract FormatLines: SnapshotLineRange -> unit
+    abstract FormatCodeLines: SnapshotLineRange -> unit
+
+    /// Format the specified line range
+    abstract FormatTextLines: SnapshotLineRange -> preserveCaretPosition: bool -> unit
 
     /// Get the new line text which should be used for new lines at the given SnapshotPoint
     abstract GetNewLineText: SnapshotPoint -> string

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -166,7 +166,11 @@ type internal NormalMode
                 yield (".", CommandFlags.Special, NormalCommand.RepeatLastCommand)
                 yield ("<lt><lt>", CommandFlags.Repeatable, NormalCommand.ShiftLinesLeft)
                 yield (">>", CommandFlags.Repeatable, NormalCommand.ShiftLinesRight)
-                yield ("==", CommandFlags.Repeatable, NormalCommand.FormatLines)
+                yield ("==", CommandFlags.Repeatable, NormalCommand.FormatCodeLines)
+                yield ("gqgq", CommandFlags.Repeatable, NormalCommand.FormatTextLines false)
+                yield ("gqq", CommandFlags.Repeatable, NormalCommand.FormatTextLines false)
+                yield ("gwgw", CommandFlags.Repeatable, NormalCommand.FormatTextLines true)
+                yield ("gww", CommandFlags.Repeatable, NormalCommand.FormatTextLines true)
                 yield ("!!", CommandFlags.Repeatable, NormalCommand.FilterLines)
                 yield (":", CommandFlags.Special, NormalCommand.SwitchMode (ModeKind.Command, ModeArgument.None))
                 yield ("<C-^>", CommandFlags.None, NormalCommand.GoToRecentView)
@@ -187,7 +191,9 @@ type internal NormalMode
                 yield ("<lt>", CommandFlags.Repeatable ||| CommandFlags.ShiftLeft, NormalCommand.ShiftMotionLinesLeft)
                 yield (">", CommandFlags.Repeatable ||| CommandFlags.ShiftRight, NormalCommand.ShiftMotionLinesRight)
                 yield ("!", CommandFlags.Repeatable, NormalCommand.FilterMotion)
-                yield ("=", CommandFlags.Repeatable, NormalCommand.FormatMotion)
+                yield ("=", CommandFlags.Repeatable, NormalCommand.FormatCodeMotion)
+                yield ("gq", CommandFlags.Repeatable, (fun motion -> NormalCommand.FormatTextMotion (false, motion)))
+                yield ("gw", CommandFlags.Repeatable, (fun motion -> NormalCommand.FormatTextMotion (true, motion)))
             } |> Seq.map (fun (str, flags, command) -> 
                 let keyInputSet = KeyNotationUtil.StringToKeyInputSet str
                 CommandBinding.MotionBinding (keyInputSet, flags, command))

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -92,7 +92,9 @@ type internal VisualMode
                 yield ("<lt>", CommandFlags.Repeatable, VisualCommand.ShiftLinesLeft)
                 yield (">", CommandFlags.Repeatable, VisualCommand.ShiftLinesRight)
                 yield ("~", CommandFlags.Repeatable, VisualCommand.ChangeCase ChangeCharacterKind.ToggleCase)
-                yield ("=", CommandFlags.Repeatable, VisualCommand.FormatLines)
+                yield ("=", CommandFlags.Repeatable, VisualCommand.FormatCodeLines)
+                yield ("gq", CommandFlags.Repeatable, VisualCommand.FormatTextLines false)
+                yield ("gw", CommandFlags.Repeatable, VisualCommand.FormatTextLines true)
                 yield ("!", CommandFlags.Repeatable, VisualCommand.FilterLines)
             } |> Seq.map (fun (str, flags, command) -> 
                 let keyInputSet = KeyNotationUtil.StringToKeyInputSet str

--- a/Src/VimCore/StringUtil.fs
+++ b/Src/VimCore/StringUtil.fs
@@ -8,6 +8,8 @@ module internal StringUtil =
 
     let Empty = System.String.Empty
 
+    let GetLength (input: string) = input.Length
+
     let FindFirst (input:seq<char>) index del =
         let found = 
             input 

--- a/Src/VimCore/VimSettings.fs
+++ b/Src/VimCore/VimSettings.fs
@@ -496,6 +496,7 @@ type internal LocalSettings
             (QuoteEscapeName, "qe", SettingValue.String @"\", SettingOptions.None)
             (EndOfLineName, "eol", SettingValue.Toggle true, SettingOptions.None)
             (FixEndOfLineName, "fixeol", SettingValue.Toggle false, SettingOptions.None)
+            (TextWidthName, "tw", SettingValue.Number 0, SettingOptions.None)
             (HideMarksName, "vsvim_hidemarks", SettingValue.String "", SettingOptions.None)
         |]
 
@@ -578,6 +579,9 @@ type internal LocalSettings
         member x.FixEndOfLine
             with get() = _map.GetBoolValue FixEndOfLineName
             and set value = _map.TrySetValue FixEndOfLineName (SettingValue.Toggle value) |> ignore
+        member x.TextWidth
+            with get() = _map.GetNumberValue TextWidthName
+            and set value = _map.TrySetValue TextWidthName (SettingValue.Number value) |> ignore
         member x.HideMarks
             with get() = _map.GetStringValue HideMarksName
             and set value = _map.TrySetValue HideMarksName (SettingValue.String value) |> ignore

--- a/Src/VimCore/VimSettings.fs
+++ b/Src/VimCore/VimSettings.fs
@@ -497,6 +497,7 @@ type internal LocalSettings
             (EndOfLineName, "eol", SettingValue.Toggle true, SettingOptions.None)
             (FixEndOfLineName, "fixeol", SettingValue.Toggle false, SettingOptions.None)
             (TextWidthName, "tw", SettingValue.Number 0, SettingOptions.None)
+            (CommentsName, "com", SettingValue.String ":*,://,:#,:;", SettingOptions.None)
             (HideMarksName, "vsvim_hidemarks", SettingValue.String "", SettingOptions.None)
         |]
 
@@ -582,6 +583,9 @@ type internal LocalSettings
         member x.TextWidth
             with get() = _map.GetNumberValue TextWidthName
             and set value = _map.TrySetValue TextWidthName (SettingValue.Number value) |> ignore
+        member x.Comments
+            with get() = _map.GetStringValue CommentsName
+            and set value = _map.TrySetValue CommentsName (SettingValue.String value) |> ignore
         member x.HideMarks
             with get() = _map.GetStringValue HideMarksName
             and set value = _map.TrySetValue HideMarksName (SettingValue.String value) |> ignore

--- a/Src/VimCore/VimSettingsInterface.fs
+++ b/Src/VimCore/VimSettingsInterface.fs
@@ -63,6 +63,7 @@ module LocalSettingNames =
     let EndOfLineName = "endofline"
     let FixEndOfLineName = "fixendofline"
     let TextWidthName = "textwidth"
+    let CommentsName = "comments"
     let HideMarksName = "vsvim_hidemarks"
 
 module WindowSettingNames =
@@ -544,6 +545,9 @@ and IVimLocalSettings =
 
     /// Text width used when formatting text
     abstract TextWidth: int with get, set
+
+    /// Comma separated list of strings that can start a comment line
+    abstract Comments: string with get, set
 
     /// Which marks to hide from the indicator margin
     abstract HideMarks: string with get, set

--- a/Src/VimCore/VimSettingsInterface.fs
+++ b/Src/VimCore/VimSettingsInterface.fs
@@ -62,6 +62,7 @@ module LocalSettingNames =
     let QuoteEscapeName = "quoteescape"
     let EndOfLineName = "endofline"
     let FixEndOfLineName = "fixendofline"
+    let TextWidthName = "textwidth"
     let HideMarksName = "vsvim_hidemarks"
 
 module WindowSettingNames =
@@ -540,6 +541,9 @@ and IVimLocalSettings =
 
     /// Whether or not to fix any missing final newline
     abstract FixEndOfLine: bool with get, set
+
+    /// Text width used when formatting text
+    abstract TextWidth: int with get, set
 
     /// Which marks to hide from the indicator margin
     abstract HideMarks: string with get, set

--- a/Test/VimCoreTest/CommandUtilTest.cs
+++ b/Test/VimCoreTest/CommandUtilTest.cs
@@ -384,34 +384,34 @@ namespace Vim.UnitTest
             }
 
             [WpfFact]
-            public void FormatLines()
+            public void FormatCodeLines()
             {
                 Create("cat", "dog", "tree");
                 var range = _textBuffer.GetLineRange(0, 1);
-                _commonOperations.Setup(x => x.FormatLines(range)).Verifiable();
-                _commandUtil.FormatLines(2);
+                _commonOperations.Setup(x => x.FormatCodeLines(range)).Verifiable();
+                _commandUtil.FormatCodeLines(2);
                 _commonOperations.Verify();
             }
 
             [WpfFact]
-            public void FormatLinesVisual()
+            public void FormatCodeLinesVisual()
             {
                 Create("cat", "dog", "tree");
                 var range = _textBuffer.GetLineRange(0, 1);
                 var visualSpan = VisualSpan.CreateForSpan(range.Extent, VisualKind.Character, tabStop: 4);
-                _commonOperations.Setup(x => x.FormatLines(range)).Verifiable();
-                _commandUtil.FormatLinesVisual(visualSpan);
+                _commonOperations.Setup(x => x.FormatCodeLines(range)).Verifiable();
+                _commandUtil.FormatCodeLinesVisual(visualSpan);
                 _commonOperations.Verify();
             }
 
             [WpfFact]
-            public void FormatLinesMotion()
+            public void FormatCodeLinesMotion()
             {
                 Create("cat", "dog", "tree");
                 var range = _textBuffer.GetLineRange(0, 1);
                 var motionResult = MotionResult.Create(range.Extent, MotionKind.CharacterWiseExclusive, isForward: true);
-                _commonOperations.Setup(x => x.FormatLines(range)).Verifiable();
-                _commandUtil.FormatMotion(motionResult);
+                _commonOperations.Setup(x => x.FormatCodeLines(range)).Verifiable();
+                _commandUtil.FormatCodeMotion(motionResult);
                 _commonOperations.Verify();
             }
 

--- a/Test/VimCoreTest/NormalModeTest.cs
+++ b/Test/VimCoreTest/NormalModeTest.cs
@@ -1535,20 +1535,65 @@ namespace Vim.UnitTest
         }
 
         [WpfFact]
-        public void Bind_FormatLines()
+        public void Bind_FormatCodeLines()
         {
             Create("foo", "bar");
-            _commandUtil.SetupCommandNormal(NormalCommand.FormatLines);
+            _commandUtil.SetupCommandNormal(NormalCommand.FormatCodeLines);
             _mode.Process("==");
             _commandUtil.Verify();
         }
 
         [WpfFact]
-        public void Bind_FormatMotion()
+        public void Bind_FormatCodeMotion()
         {
             Create("the dog chased the ball");
-            _commandUtil.SetupCommandMotion<NormalCommand.FormatMotion>();
+            _commandUtil.SetupCommandMotion<NormalCommand.FormatCodeMotion>();
             _mode.Process("=w");
+            _commandUtil.Verify();
+        }
+
+        [WpfFact]
+        public void Bind_FormatTextLines1()
+        {
+            Create("foo", "bar");
+            _commandUtil.SetupCommandNormal(NormalCommand.NewFormatTextLines(false));
+            _mode.Process("gqgq");
+            _commandUtil.Verify();
+        }
+
+        [WpfFact]
+        public void Bind_FormatTextLines2()
+        {
+            Create("foo", "bar");
+            _commandUtil.SetupCommandNormal(NormalCommand.NewFormatTextLines(false));
+            _mode.Process("gqq");
+            _commandUtil.Verify();
+        }
+
+        [WpfFact]
+        public void Bind_FormatTextMotion()
+        {
+            Create("the dog chased the ball");
+            _commandUtil.SetupCommandMotion<NormalCommand.FormatTextMotion>();
+            _mode.Process("gqw");
+            _commandUtil.Verify();
+        }
+
+        [WpfFact]
+        public void Bind_FormatTextLines1_PreservingCaretPosition()
+        {
+            Create("foo", "bar");
+            _commandUtil.SetupCommandNormal(NormalCommand.NewFormatTextLines(true));
+            _mode.Process("gwgw");
+            _commandUtil.Verify();
+        }
+
+        [WpfFact]
+        public void Bind_FormatTextLines2_PreservingCaretPosition()
+        {
+            Create("foo", "bar");
+            _commandUtil.SetupCommandNormal(NormalCommand.NewFormatTextLines(true));
+            _mode.Process("gww");
             _commandUtil.Verify();
         }
 

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -1776,6 +1776,104 @@ namespace Vim.UnitTest
             }
         }
 
+        public sealed class FormatTextLines : VisualModeIntegrationTest
+        {
+            [WpfFact]
+            public void PlainText()
+            {
+                Create("cat", "dog", "bear", "bat", "");
+                _vimBuffer.LocalSettings.TextWidth = 10;
+                _vimBuffer.ProcessNotation("VGgq");
+                Assert.Equal(new[] { "cat dog", "bear bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void LongLine()
+            {
+                Create("cat dog bear bat", "");
+                _vimBuffer.LocalSettings.TextWidth = 10;
+                _vimBuffer.ProcessNotation("VGgq");
+                Assert.Equal(new[] { "cat dog", "bear bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void PreserveSpacing()
+            {
+                Create("cat  dog bear bat", "");
+                _vimBuffer.LocalSettings.TextWidth = 10;
+                _vimBuffer.ProcessNotation("VGgq");
+                Assert.Equal(new[] { "cat  dog", "bear bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void TinyWidth()
+            {
+                Create("cat dog bear bat", "");
+                _vimBuffer.LocalSettings.TextWidth = 1;
+                _vimBuffer.ProcessNotation("VGgq");
+                Assert.Equal(new[] { "cat", "dog", "bear", "bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void NoAutoIndent()
+            {
+                Create("  cat", "dog", "bear", "bat", "");
+                _vimBuffer.LocalSettings.TextWidth = 10;
+                _vimBuffer.LocalSettings.AutoIndent = false;
+                _vimBuffer.ProcessNotation("VGgq");
+                Assert.Equal(new[] { "  cat dog", "bear bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void AutoIndent()
+            {
+                Create("  cat", "dog", "bear", "bat", "");
+                _vimBuffer.LocalSettings.TextWidth = 10;
+                _vimBuffer.LocalSettings.AutoIndent = true;
+                _vimBuffer.ProcessNotation("VGgq");
+                Assert.Equal(new[] { "  cat dog", "  bear bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfTheory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void SlashSlash(bool autoIndent)
+            {
+                Create("  // cat", "// dog", "// bear", "// bat", "");
+                _vimBuffer.LocalSettings.TextWidth = 15;
+                _vimBuffer.LocalSettings.AutoIndent = autoIndent;
+                _vimBuffer.ProcessNotation("VGgq");
+                Assert.Equal(new[] { "  // cat dog", "  // bear bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void TripleSlash()
+            {
+                Create("  /// cat", "/// dog", "/// bear", "/// bat", "");
+                _vimBuffer.LocalSettings.TextWidth = 15;
+                _vimBuffer.ProcessNotation("VGgq");
+                Assert.Equal(new[] { "  /// cat dog", "  /// bear bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void BlankParagraph()
+            {
+                Create("  // cat", "//", "// dog", "// bear", "// bat", "");
+                _vimBuffer.LocalSettings.TextWidth = 15;
+                _vimBuffer.ProcessNotation("VGgq");
+                Assert.Equal(new[] { "  // cat", "  //", "  // dog bear", "  // bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void WhitespaceParagraph()
+            {
+                Create("  // cat", "// ", "// dog", "// bear", "// bat", "");
+                _vimBuffer.LocalSettings.TextWidth = 15;
+                _vimBuffer.ProcessNotation("VGgq");
+                Assert.Equal(new[] { "  // cat", "  //", "  // dog bear", "  // bat", "" }, _textBuffer.GetLines());
+            }
+        }
+
         public sealed class MiscAllTest : VisualModeIntegrationTest
         {
             /// <summary>

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -1788,6 +1788,35 @@ namespace Vim.UnitTest
             }
 
             [WpfFact]
+            public void InclusiveCharacterSelection()
+            {
+                Create("cat", "dog", "bear", "bat", "");
+                _globalSettings.Selection = "inclusive";
+                _vimBuffer.LocalSettings.TextWidth = 10;
+                _vimBuffer.ProcessNotation("v3jgq");
+                Assert.Equal(new[] { "cat dog", "bear bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void ExclusiveCharacterSelection()
+            {
+                Create("cat", "dog", "bear", "bat", "");
+                _globalSettings.Selection = "exclusive";
+                _vimBuffer.LocalSettings.TextWidth = 10;
+                _vimBuffer.ProcessNotation("v3jgq");
+                Assert.Equal(new[] { "cat dog", "bear", "bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
+            public void BlockSelection()
+            {
+                Create("cat", "dog", "bear", "bat", "");
+                _vimBuffer.LocalSettings.TextWidth = 10;
+                _vimBuffer.ProcessNotation("<C-v>3jgq");
+                Assert.Equal(new[] { "cat dog", "bear bat", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfFact]
             public void LongLine()
             {
                 Create("cat dog bear bat", "");

--- a/Test/VimCoreTest/VisualModeTest.cs
+++ b/Test/VimCoreTest/VisualModeTest.cs
@@ -446,11 +446,29 @@ namespace Vim.UnitTest
         }
 
         [WpfFact]
-        public void Bind_FormatLines()
+        public void Bind_FormatCodeLines()
         {
             Create("");
-            _commandUtil.SetupCommandVisual(VisualCommand.FormatLines);
+            _commandUtil.SetupCommandVisual(VisualCommand.FormatCodeLines);
             _mode.Process("=");
+            _commandUtil.Verify();
+        }
+
+        [WpfFact]
+        public void Bind_FormatTextLines()
+        {
+            Create("");
+            _commandUtil.SetupCommandVisual(VisualCommand.NewFormatTextLines(false));
+            _mode.Process("gq");
+            _commandUtil.Verify();
+        }
+
+        [WpfFact]
+        public void Bind_FormatTextLinesPreservingCaretPosition()
+        {
+            Create("");
+            _commandUtil.SetupCommandVisual(VisualCommand.NewFormatTextLines(true));
+            _mode.Process("gw");
             _commandUtil.Verify();
         }
 


### PR DESCRIPTION
#### Changes

- Rename functions associated with `=` formatting to be named `FormatCodeLines`
- Add a new common operation to format text lines called `FormatTextLines`
- Add `gq` and `gw` operations to format text lines in visual mode
- Add `gqgq`, `gqq`, `gwgw` and `gww` operations to format text lines in normal mode
- Add `textwidth` setting defaulting to 0
- Add `comments` setting defaulting to line comments in C, C++, C#, F#, Java, Javascript, Python, Lisp, Shell

#### Fixes

- Fixes #333

#### Discussion

This is a "bare-bones" implementation of formatting text lines that omits many of the more esoteric vim features but adds the crucially missing capability to intuitively reformat comments in the most used programming languages. Subsequent more ambitious PRs can address the missing functionality.

#### Limitations

- The `formatoptions` variable is not implemented
- None of the comment specification flags in `comments` are implemented
- Tabs in the leader are properly accounted for but tabs in the text are not
- All the lines being formatted in one operation must have the same leader
- `gw` is currently the same as `gq`, i.e. it doesn't preserve the caret position