### PR TITLE
Work around restore bug

### DIFF
--- a/Src/VimCore/VimCore.fsproj
+++ b/Src/VimCore/VimCore.fsproj
@@ -6,6 +6,7 @@
     <TargetFramework>net45</TargetFramework>
     <OtherFlags>--standalone</OtherFlags>
     <NoWarn>2011</NoWarn>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Resources.fs" />


### PR DESCRIPTION
Disable the implicit reference to FSharp.Core the F# targets add to
projects. This lets the PackageReference in VimCore specify the version
and control items like private assets fully.

Related: https://github.com/NuGet/Home/issues/6367