### PR TITLE
Next match

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -808,7 +808,7 @@ type internal CommandUtil
                     else
                         motionResult.Span.Start
             _commonOperations.MoveCaretToPoint caretPoint ViewFlags.Standard
-        | _ ->
+        | None ->
             ()
         CommandResult.Completed ModeSwitch.NoSwitch
 
@@ -3104,7 +3104,7 @@ type internal CommandUtil
             let modeKind = ModeKind.VisualCharacter
             let modeArgument = ModeArgument.InitialVisualSelection (visualSelection, None)
             x.SwitchMode modeKind modeArgument
-        | _ ->
+        | None ->
             CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Shift the given line range left by the specified value.  The caret will be

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -2593,6 +2593,7 @@ type internal CommandUtil
         | NormalCommand.ScrollCaretLineToTop keepCaretColumn -> x.ScrollCaretLineToTop keepCaretColumn
         | NormalCommand.ScrollCaretLineToMiddle keepCaretColumn -> x.ScrollCaretLineToMiddle keepCaretColumn
         | NormalCommand.ScrollCaretLineToBottom keepCaretColumn -> x.ScrollCaretLineToBottom keepCaretColumn
+        | NormalCommand.SelectNextMatch searchPath -> x.SelectNextMatch searchPath
         | NormalCommand.SubstituteCharacterAtCaret -> x.SubstituteCharacterAtCaret count registerName
         | NormalCommand.SubtractFromWord -> x.SubtractFromWord count
         | NormalCommand.ShiftLinesLeft -> x.ShiftLinesLeft count
@@ -3044,6 +3045,10 @@ type internal CommandUtil
         if not keepCaretColumn then
             _commonOperations.EditorOperations.MoveToStartOfLineAfterWhiteSpace(false)
         _commonOperations.EnsureAtCaret ViewFlags.ScrollOffset
+        CommandResult.Completed ModeSwitch.NoSwitch
+
+    /// Select the next match for the last pattern searched for
+    member x.SelectNextMatch searchPath =
         CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Shift the given line range left by the specified value.  The caret will be

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -413,6 +413,9 @@ type SearchOptions =
     /// Consider the "smartcase" option when doing the search
     | ConsiderSmartCase = 0x2
 
+    /// Whether to include the start point when doing the search
+    | IncludeStartPoint = 0x4
+
     /// ConsiderIgnoreCase ||| ConsiderSmartCase
     | Default = 0x3
 
@@ -1147,6 +1150,9 @@ type Motion =
 
     /// Get the motion to the nearest lowercase mark line in the specified direction
     | NextMarkLine of SearchPath
+
+    /// Operate on the next occurrence of last pattern searched for
+    | NextSearch of SearchPath
 
     /// Search for the next occurrence of the word under the caret
     | NextWord of SearchPath

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1151,8 +1151,8 @@ type Motion =
     /// Get the motion to the nearest lowercase mark line in the specified direction
     | NextMarkLine of SearchPath
 
-    /// Operate on the next occurrence of last pattern searched for
-    | NextSearch of SearchPath
+    /// Operate on the next match for last pattern searched for
+    | NextMatch of SearchPath
 
     /// Search for the next occurrence of the word under the caret
     | NextWord of SearchPath
@@ -2892,6 +2892,9 @@ type NormalCommand =
     /// to leave the caret in the same column
     | ScrollCaretLineToBottom of bool
 
+    /// Select the next match for the last pattern searched for
+    | SelectNextMatch of SearchPath
+
     /// Shift 'count' lines from the cursor left
     | ShiftLinesLeft
 
@@ -3028,6 +3031,7 @@ type NormalCommand =
         | NormalCommand.ScrollCaretLineToTop _ -> None
         | NormalCommand.ScrollCaretLineToMiddle _ -> None
         | NormalCommand.ScrollCaretLineToBottom _ -> None
+        | NormalCommand.SelectNextMatch _ -> None
         | NormalCommand.ShiftLinesLeft -> None
         | NormalCommand.ShiftLinesRight -> None
         | NormalCommand.SplitViewHorizontally -> None

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3085,6 +3085,9 @@ type VisualCommand =
     /// Delete the selected text and put it into a register
     | DeleteSelection
 
+    /// Extend the selection to the next match for the last pattern searched for
+    | ExtendSelectionToNextMatch of SearchPath
+
     /// Filter the selected text
     | FilterLines
 

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -67,6 +67,8 @@ type internal NormalMode
                 yield ("gt", CommandFlags.Special, NormalCommand.GoToNextTab SearchPath.Forward)
                 yield ("gT", CommandFlags.Special, NormalCommand.GoToNextTab SearchPath.Backward)
                 yield ("gv", CommandFlags.Special, NormalCommand.SwitchPreviousVisualMode)
+                yield ("gn", CommandFlags.Special, NormalCommand.SelectNextMatch SearchPath.Forward)
+                yield ("gN", CommandFlags.Special, NormalCommand.SelectNextMatch SearchPath.Backward)
                 yield ("gugu", CommandFlags.Repeatable, NormalCommand.ChangeCaseCaretLine ChangeCharacterKind.ToLowerCase)
                 yield ("guu", CommandFlags.Repeatable, NormalCommand.ChangeCaseCaretLine ChangeCharacterKind.ToLowerCase)
                 yield ("gUgU", CommandFlags.Repeatable, NormalCommand.ChangeCaseCaretLine ChangeCharacterKind.ToUpperCase)

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -55,6 +55,8 @@ type internal VisualMode
                 yield ("gp", CommandFlags.Repeatable, VisualCommand.PutOverSelection true)
                 yield ("gP", CommandFlags.Repeatable, VisualCommand.PutOverSelection true)
                 yield ("g?", CommandFlags.Repeatable, VisualCommand.ChangeCase ChangeCharacterKind.Rot13)
+                yield ("gn", CommandFlags.Repeatable, VisualCommand.ExtendSelectionToNextMatch SearchPath.Forward)
+                yield ("gN", CommandFlags.Repeatable, VisualCommand.ExtendSelectionToNextMatch SearchPath.Backward)
                 yield ("J", CommandFlags.Repeatable, VisualCommand.JoinSelection JoinKind.RemoveEmptySpaces)
                 yield ("o", CommandFlags.Movement ||| CommandFlags.ResetAnchorPoint, VisualCommand.InvertSelection false)
                 yield ("O", CommandFlags.Movement ||| CommandFlags.ResetAnchorPoint, VisualCommand.InvertSelection true)

--- a/Src/VimCore/MotionCapture.fs
+++ b/Src/VimCore/MotionCapture.fs
@@ -129,6 +129,8 @@ type internal MotionCapture
                 yield ("[`", MotionFlags.CaretMovement, Motion.NextMark SearchPath.Backward)
                 yield ("]'", MotionFlags.CaretMovement, Motion.NextMarkLine SearchPath.Forward)
                 yield ("['", MotionFlags.CaretMovement, Motion.NextMarkLine SearchPath.Backward)
+                yield ("gn", MotionFlags.CaretMovement, Motion.NextSearch SearchPath.Forward)
+                yield ("gN", MotionFlags.CaretMovement, Motion.NextSearch SearchPath.Backward)
             } 
             
         motionSeq 

--- a/Src/VimCore/MotionCapture.fs
+++ b/Src/VimCore/MotionCapture.fs
@@ -129,8 +129,8 @@ type internal MotionCapture
                 yield ("[`", MotionFlags.CaretMovement, Motion.NextMark SearchPath.Backward)
                 yield ("]'", MotionFlags.CaretMovement, Motion.NextMarkLine SearchPath.Forward)
                 yield ("['", MotionFlags.CaretMovement, Motion.NextMarkLine SearchPath.Backward)
-                yield ("gn", MotionFlags.CaretMovement, Motion.NextSearch SearchPath.Forward)
-                yield ("gN", MotionFlags.CaretMovement, Motion.NextSearch SearchPath.Backward)
+                yield ("gn", MotionFlags.None, Motion.NextMatch SearchPath.Forward)
+                yield ("gN", MotionFlags.None, Motion.NextMatch SearchPath.Backward)
             } 
             
         motionSeq 

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -2937,7 +2937,7 @@ type internal MotionUtil
             let searchData = SearchData(last.Pattern, last.Offset, searchKind, options)
 
             // All search operations update the jump list.
-            _jumpList.Add x.CaretPoint
+            _jumpList.Add x.CaretVirtualPoint
 
             let searchResult = _search.FindNextPattern x.CaretPoint searchData _wordNavigator count
 

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -2925,8 +2925,8 @@ type internal MotionUtil
             else
                 x.MarkLine mark
 
-    /// Operate on the next occurrence of last pattern searched for
-    member x.NextSearch path count =
+    /// Operate on the next match for last pattern searched for
+    member x.NextMatch path count =
         let last = _vimData.LastSearchData
         if StringUtil.IsNullOrEmpty last.Pattern then
             _statusUtil.OnError Resources.NormalMode_NoPreviousSearch
@@ -3183,7 +3183,7 @@ type internal MotionUtil
             | Motion.NextMark path -> x.NextMark path motionArgument.CountOrDefault
             | Motion.NextMarkLine path -> x.NextMarkLine path motionArgument.CountOrDefault
             | Motion.NextPartialWord path -> x.NextPartialWord path motionArgument.CountOrDefault
-            | Motion.NextSearch path -> x.NextSearch path motionArgument.CountOrDefault
+            | Motion.NextMatch path -> x.NextMatch path motionArgument.CountOrDefault
             | Motion.NextWord path -> x.NextWord path motionArgument.CountOrDefault
             | Motion.ParagraphBackward -> x.ParagraphBackward motionArgument.CountOrDefault |> Some
             | Motion.ParagraphForward -> x.ParagraphForward motionArgument.CountOrDefault |> Some

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -2925,6 +2925,38 @@ type internal MotionUtil
             else
                 x.MarkLine mark
 
+    /// Operate on the next occurrence of last pattern searched for
+    member x.NextSearch path count =
+        let last = _vimData.LastSearchData
+        if StringUtil.IsNullOrEmpty last.Pattern then
+            _statusUtil.OnError Resources.NormalMode_NoPreviousSearch
+            None
+        else
+            let searchKind = SearchKind.OfPathAndWrap path _globalSettings.WrapScan
+            let options = last.Options ||| SearchOptions.IncludeStartPoint
+            let searchData = SearchData(last.Pattern, last.Offset, searchKind, options)
+
+            // All search operations update the jump list
+            _jumpList.Add x.CaretPoint
+
+            let searchResult = _search.FindNextPattern x.CaretPoint searchData _wordNavigator count
+
+            // Raise the messages that go with this given result
+            CommonUtil.RaiseSearchResultMessage _statusUtil searchResult
+
+            let motionResult = 
+                match searchResult with
+                | SearchResult.Error _ -> None
+                | SearchResult.NotFound _ -> None
+                | SearchResult.Found (_, span, _, _) ->
+
+                    let motionKind = MotionKind.CharacterWiseExclusive
+                    let isForward = path = SearchPath.Forward
+                    MotionResult.Create(span, motionKind, isForward) |> Some
+
+            _vimData.ResumeDisplayPattern()
+            motionResult
+
     /// Motion from the caret to the next occurrence of the partial word under the caret
     member x.NextPartialWord path count =
         x.NextWordCore path count false
@@ -3151,6 +3183,7 @@ type internal MotionUtil
             | Motion.NextMark path -> x.NextMark path motionArgument.CountOrDefault
             | Motion.NextMarkLine path -> x.NextMarkLine path motionArgument.CountOrDefault
             | Motion.NextPartialWord path -> x.NextPartialWord path motionArgument.CountOrDefault
+            | Motion.NextSearch path -> x.NextSearch path motionArgument.CountOrDefault
             | Motion.NextWord path -> x.NextWord path motionArgument.CountOrDefault
             | Motion.ParagraphBackward -> x.ParagraphBackward motionArgument.CountOrDefault |> Some
             | Motion.ParagraphForward -> x.ParagraphForward motionArgument.CountOrDefault |> Some

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -2936,12 +2936,12 @@ type internal MotionUtil
             let options = last.Options ||| SearchOptions.IncludeStartPoint
             let searchData = SearchData(last.Pattern, last.Offset, searchKind, options)
 
-            // All search operations update the jump list
+            // All search operations update the jump list.
             _jumpList.Add x.CaretPoint
 
             let searchResult = _search.FindNextPattern x.CaretPoint searchData _wordNavigator count
 
-            // Raise the messages that go with this given result
+            // Raise the messages that go with this given result.
             CommonUtil.RaiseSearchResultMessage _statusUtil searchResult
 
             let motionResult = 

--- a/Src/VimTestUtils/VimTestBase.cs
+++ b/Src/VimTestUtils/VimTestBase.cs
@@ -586,5 +586,17 @@ namespace Vim.UnitTest
                 yield return new object[] { "onemore" };
             }
         }
+
+        /// <summary>
+        /// Both selection settings
+        /// </summary>
+        public static IEnumerable<object[]> SelectionOptions
+        {
+            get
+            {
+                yield return new object[] { "inclusive" };
+                yield return new object[] { "exclusive" };
+            }
+        }
     }
 }

--- a/Test/VimCoreTest/MotionCaptureTest.cs
+++ b/Test/VimCoreTest/MotionCaptureTest.cs
@@ -324,6 +324,18 @@ namespace Vim.UnitTest
         }
 
         [WpfFact]
+        public void NextMatch_Forward()
+        {
+            AssertMotion("gn", Motion.NewNextMatch(SearchPath.Forward));
+        }
+
+        [WpfFact]
+        public void NextMatch_Backward()
+        {
+            AssertMotion("gN", Motion.NewNextMatch(SearchPath.Backward));
+        }
+
+        [WpfFact]
         public void QuotedString()
         {
             AssertMotion(@"a""", Motion.NewQuotedString('"'));

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -7518,8 +7518,7 @@ namespace Vim.UnitTest
             }
 
             [WpfTheory]
-            [InlineData("inclusive")]
-            [InlineData("exclusive")]
+            [MemberData(nameof(SelectionOptions))]
             public void SelectNextMatchForward(string selection)
             {
                 Create("cat", "dog", "cat", "dog", "cat", "dog", "");
@@ -7532,8 +7531,7 @@ namespace Vim.UnitTest
             }
 
             [WpfTheory]
-            [InlineData("inclusive")]
-            [InlineData("exclusive")]
+            [MemberData(nameof(SelectionOptions))]
             public void SelectNextMatchForwardWithCount(string selection)
             {
                 Create("cat", "dog", "cat", "dog", "cat", "dog", "");
@@ -7546,8 +7544,7 @@ namespace Vim.UnitTest
             }
 
             [WpfTheory]
-            [InlineData("inclusive")]
-            [InlineData("exclusive")]
+            [MemberData(nameof(SelectionOptions))]
             public void SelectNextMatchBackward(string selection)
             {
                 Create("cat", "dog", "cat", "dog", "cat", "dog", "");
@@ -7560,8 +7557,7 @@ namespace Vim.UnitTest
             }
 
             [WpfTheory]
-            [InlineData("inclusive")]
-            [InlineData("exclusive")]
+            [MemberData(nameof(SelectionOptions))]
             public void SelectNextMatchBackwardWithCount(string selection)
             {
                 Create("cat", "dog", "cat", "dog", "cat", "dog", "");

--- a/Test/VimCoreTest/NormalModeTest.cs
+++ b/Test/VimCoreTest/NormalModeTest.cs
@@ -529,6 +529,24 @@ namespace Vim.UnitTest
             _commandUtil.Verify();
         }
 
+        [WpfFact]
+        public void Bind_SelectNextMatch_Forward()
+        {
+            Create("");
+            _commandUtil.SetupCommandNormal(NormalCommand.NewSelectNextMatch(SearchPath.Forward));
+            _mode.Process("gn");
+            _commandUtil.Verify();
+        }
+
+        [WpfFact]
+        public void Bind_SelectNextMatch_Backward()
+        {
+            Create("");
+            _commandUtil.SetupCommandNormal(NormalCommand.NewSelectNextMatch(SearchPath.Backward));
+            _mode.Process("gN");
+            _commandUtil.Verify();
+        }
+
         #endregion
 
         #region Motion

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -3081,8 +3081,7 @@ namespace Vim.UnitTest
                 }
 
                 [WpfTheory]
-                [InlineData("inclusive")]
-                [InlineData("exclusive")]
+                [MemberData(nameof(SelectionOptions))]
                 public void YankBlock(string selection)
                 {
                     Create("cat", "dog bear", "tree", "");

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -3012,6 +3012,92 @@ namespace Vim.UnitTest
             }
         }
 
+        public sealed class NextMatchTest : VisualModeIntegrationTest
+        {
+            [WpfTheory]
+            [MemberData(nameof(SelectionOptions))]
+            public void SelectNextMatchForward(string selection)
+            {
+                Create("cat", "dog", "cat", "dog", "cat", "dog", "");
+                _globalSettings.Selection = selection;
+                _vimBuffer.ProcessNotation("/cat<CR>");
+                Assert.Equal(_textBuffer.GetPointInLine(2, 0), _textView.GetCaretPoint());
+                _vimBuffer.ProcessNotation("vgn");
+                var span1 = new SnapshotSpan(_textBuffer.GetPointInLine(2, 0), _textBuffer.GetPointInLine(2, 3));
+                Assert.Equal(span1, _textView.GetSelectionSpan());
+                _vimBuffer.ProcessNotation("gn");
+                var span2 = new SnapshotSpan(_textBuffer.GetPointInLine(2, 0), _textBuffer.GetPointInLine(4, 3));
+                Assert.Equal(span2, _textView.GetSelectionSpan());
+            }
+
+            [WpfTheory]
+            [MemberData(nameof(SelectionOptions))]
+            public void SelectNextMatchForwardWithCount(string selection)
+            {
+                Create("cat", "dog", "cat", "dog", "cat", "dog", "");
+                _globalSettings.Selection = selection;
+                _vimBuffer.ProcessNotation("/cat<CR>");
+                Assert.Equal(_textBuffer.GetPointInLine(2, 0), _textView.GetCaretPoint());
+                _vimBuffer.ProcessNotation("v2gn");
+                var span = new SnapshotSpan(_textBuffer.GetPointInLine(2, 0), _textBuffer.GetPointInLine(4, 3));
+                Assert.Equal(span, _textView.GetSelectionSpan());
+            }
+
+            [WpfFact]
+            public void SelectNextMatchBackwardInclusive()
+            {
+                Create("cat", "dog", "cat", "dog", "cat", "dog", "");
+                _globalSettings.Selection = "inclusive";
+                _vimBuffer.ProcessNotation("/cat<CR>n");
+                Assert.Equal(_textBuffer.GetPointInLine(4, 0), _textView.GetCaretPoint());
+                _vimBuffer.ProcessNotation("vgN");
+                var span1 = new SnapshotSpan(_textBuffer.GetPointInLine(2, 0), _textBuffer.GetPointInLine(4, 1));
+                Assert.Equal(span1, _textView.GetSelectionSpan());
+                _vimBuffer.ProcessNotation("gN");
+                var span2 = new SnapshotSpan(_textBuffer.GetPointInLine(0, 0), _textBuffer.GetPointInLine(4, 1));
+                Assert.Equal(span2, _textView.GetSelectionSpan());
+            }
+
+            [WpfFact]
+            public void SelectNextMatchBackwardExclusive()
+            {
+                Create("cat", "dog", "cat", "dog", "cat", "dog", "");
+                _globalSettings.Selection = "exclusive";
+                _vimBuffer.ProcessNotation("/cat<CR>nl");
+                Assert.Equal(_textBuffer.GetPointInLine(4, 1), _textView.GetCaretPoint());
+                _vimBuffer.ProcessNotation("vgN");
+                var span1 = new SnapshotSpan(_textBuffer.GetPointInLine(2, 0), _textBuffer.GetPointInLine(4, 1));
+                Assert.Equal(span1, _textView.GetSelectionSpan());
+                _vimBuffer.ProcessNotation("gN");
+                var span2 = new SnapshotSpan(_textBuffer.GetPointInLine(0, 0), _textBuffer.GetPointInLine(4, 1));
+                Assert.Equal(span2, _textView.GetSelectionSpan());
+            }
+
+            [WpfFact]
+            public void SelectNextMatchBackwardInclusiveWithCount()
+            {
+                Create("cat", "dog", "cat", "dog", "cat", "dog", "");
+                _globalSettings.Selection = "inclusive";
+                _vimBuffer.ProcessNotation("/cat<CR>n");
+                Assert.Equal(_textBuffer.GetPointInLine(4, 0), _textView.GetCaretPoint());
+                _vimBuffer.ProcessNotation("v2gN");
+                var span = new SnapshotSpan(_textBuffer.GetPointInLine(0, 0), _textBuffer.GetPointInLine(4, 1));
+                Assert.Equal(span, _textView.GetSelectionSpan());
+            }
+
+            [WpfFact]
+            public void SelectNextMatchBackwardExclusiveWithCount()
+            {
+                Create("cat", "dog", "cat", "dog", "cat", "dog", "");
+                _globalSettings.Selection = "exclusive";
+                _vimBuffer.ProcessNotation("/cat<CR>nl");
+                Assert.Equal(_textBuffer.GetPointInLine(4, 1), _textView.GetCaretPoint());
+                _vimBuffer.ProcessNotation("v2gN");
+                var span = new SnapshotSpan(_textBuffer.GetPointInLine(0, 0), _textBuffer.GetPointInLine(4, 1));
+                Assert.Equal(span, _textView.GetSelectionSpan());
+            }
+        }
+
         public abstract class YankSelectionTest : VisualModeIntegrationTest
         {
             private void AssertRegister(params string[] lines)

--- a/Test/VimCoreTest/VisualModeTest.cs
+++ b/Test/VimCoreTest/VisualModeTest.cs
@@ -292,6 +292,24 @@ namespace Vim.UnitTest
         }
 
         [WpfFact]
+        public void Bind_ExtendSelectionToNextMatch_Forward()
+        {
+            Create("");
+            _commandUtil.SetupCommandVisual(VisualCommand.NewExtendSelectionToNextMatch(SearchPath.Forward));
+            _mode.Process("gn");
+            _commandUtil.Verify();
+        }
+
+        [WpfFact]
+        public void Bind_ExtendSelectionToNextMatch_Backward()
+        {
+            Create("");
+            _commandUtil.SetupCommandVisual(VisualCommand.NewExtendSelectionToNextMatch(SearchPath.Backward));
+            _mode.Process("gN");
+            _commandUtil.Verify();
+        }
+
+        [WpfFact]
         public void Bind_PutOverSelection_ViaP()
         {
             Create("");


### PR DESCRIPTION
#### Changes

- Add the capability for the search service to include the start point in the search
- Add the `gn` and `gN` family of key bindings
- Implement 'next match' motion for operators in normal mode
- Implement 'select next match' operation from normal mode
- Implement 'extend selection to next match' from visual mode

#### Issues

- Fixes #1449