### PR TITLE
Surrogate Pair Progress

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1372,9 +1372,9 @@ type internal CommandUtil
 
     /// Switch to insert mode after the caret
     member x.InsertAfterCaret count =
-        match SnapshotPointUtil.TryGetNextCharacterSpanOnLine x.CaretPoint 1 with
-        | Some nextPoint ->
-            TextViewUtil.MoveCaretToPoint _textView nextPoint
+        let caretColumn = SnapshotColumn(x.CaretPoint)
+        match caretColumn.TryAddInLine(1, includeLineBreak = true) with
+        | Some nextColumn -> TextViewUtil.MoveCaretToPoint _textView nextColumn.StartPoint
         | None -> ()
 
         CommandResult.Completed (ModeSwitch.SwitchModeWithArgument (ModeKind.Insert, ModeArgument.InsertWithCount count))

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -106,10 +106,6 @@ type internal CommonOperations
 
         RegisterValue(stringData, operationKind)
 
-    /// Get the spaces for the given character
-    member x.GetSpacesForCharAtPoint point = 
-        SnapshotPointUtil.GetCharacterWidth point _localSettings.TabStop
-
     /// Get the count of spaces to get to the specified absolute column offset.  This will count
     /// tabs as counting for 'tabstop' spaces
     member x.GetSpacesToColumn line column = 

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -975,7 +975,7 @@ type internal CommonOperations
 
         match _vimTextBuffer.UseVirtualSpace, result.CaretColumn with
         | true, CaretColumn.InLastLine column ->
-            let columnNumber = SnapshotCharacterSpan(point).ColumnNumber
+            let columnNumber = SnapshotColumn(point).ColumnNumber
             let virtualSpaces = max 0 (column - columnNumber)
             point
             |> VirtualSnapshotPointUtil.OfPoint

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -1151,7 +1151,7 @@ type internal CommonOperations
     /// correct spaces / tab based on the 'expandtab' setting.  This has to consider the 
     /// difficulty of mixed spaces and tabs filling up the remaining tab boundary 
     member x.NormalizeBlanksAtColumn text (column: SnapshotColumn) = 
-        let spacesToColumn = SnapshotLineUtil.GetSpacesToColumn  column.Line column.ColumnNumber _localSettings.TabStop
+        let spacesToColumn = SnapshotLineUtil.GetSpacesToColumn column.Line column.ColumnNumber _localSettings.TabStop
         if spacesToColumn % _localSettings.TabStop = 0 then
             // If the column is on a 'tabstop' boundary then there is no difficulty here
             // with accounting for partial tabs.  Just normalize as we would for any other

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -1795,7 +1795,7 @@ type internal CommonOperations
                         lineNumber + offset
                         |> SnapshotUtil.GetLine originalSnapshot
                     let column = SnapshotCharacterSpan(line)
-                    let columnCount = column.ColumnCount
+                    let columnCount = SnapshotLineUtil.GetCharacterSpansCount SearchPath.Forward line
                     if columnCount < columnNumber then
                         let prefix = String.replicate (columnNumber - columnCount) " "
                         edit.Insert(line.End.Position, prefix + str) |> ignore

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -74,6 +74,8 @@ type internal CommonOperations
 
     member x.CaretPoint = TextViewUtil.GetCaretPoint _textView
 
+    member x.CaretColumn = SnapshotColumn(x.CaretPoint)
+
     member x.CaretVirtualPoint = TextViewUtil.GetCaretVirtualPoint _textView
 
     member x.CaretLine = TextViewUtil.GetCaretLine _textView
@@ -679,18 +681,18 @@ type internal CommonOperations
 
         /// Move the caret left.  Don't go past the start of the line 
         let moveLeft () = 
-            match SnapshotPointUtil.TryGetPreviousCharacterSpanOnLine x.CaretPoint 1 with
-            | Some point ->
-                x.MoveCaretToPoint point ViewFlags.Standard
+            match x.CaretColumn.TrySubtractInLine 1 with
+            | Some column ->
+                x.MoveCaretToPoint column.StartPoint ViewFlags.Standard
                 true
             | None ->
                 false
 
         /// Move the caret right.  Don't go off the end of the line
         let moveRight () =
-            match SnapshotPointUtil.TryGetNextCharacterSpanOnLine x.CaretPoint 1 with
-            | Some point ->
-                x.MoveCaretToPoint point ViewFlags.Standard
+            match x.CaretColumn.TryAddInLine(1, includeLineBreak = true) with
+            | Some column ->
+                x.MoveCaretToPoint column.StartPoint ViewFlags.Standard
                 true
             | None ->
                 false

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -1148,8 +1148,8 @@ type internal CommonOperations
     /// Given the specified blank 'text' at the specified column normalize it out to the
     /// correct spaces / tab based on the 'expandtab' setting.  This has to consider the 
     /// difficulty of mixed spaces and tabs filling up the remaining tab boundary 
-    member x.NormalizeBlanksAtColumn text (column: SnapshotColumn) = 
-        let spacesToColumn = SnapshotLineUtil.GetSpacesToColumn  column.Line column.Column _localSettings.TabStop
+    member x.NormalizeBlanksAtColumn text (column: SnapshotCharacterSpan) = 
+        let spacesToColumn = SnapshotLineUtil.GetSpacesToColumn  column.Line column.ColumnNumber _localSettings.TabStop
         if spacesToColumn % _localSettings.TabStop = 0 then
             // If the column is on a 'tabstop' boundary then there is no difficulty here
             // with accounting for partial tabs.  Just normalize as we would for any other

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -1148,7 +1148,7 @@ type internal CommonOperations
     /// Given the specified blank 'text' at the specified column normalize it out to the
     /// correct spaces / tab based on the 'expandtab' setting.  This has to consider the 
     /// difficulty of mixed spaces and tabs filling up the remaining tab boundary 
-    member x.NormalizeBlanksAtColumn text (column: SnapshotCharacterSpan) = 
+    member x.NormalizeBlanksAtColumn text (column: SnapshotColumn) = 
         let spacesToColumn = SnapshotLineUtil.GetSpacesToColumn  column.Line column.ColumnNumber _localSettings.TabStop
         if spacesToColumn % _localSettings.TabStop = 0 then
             // If the column is on a 'tabstop' boundary then there is no difficulty here
@@ -1777,7 +1777,7 @@ type internal CommonOperations
                 // Collection strings are inserted at the original character
                 // position down the set of lines creating whitespace as needed
                 // to match the indent
-                let column = SnapshotCharacterSpan(point)
+                let column = SnapshotColumn(point)
                 let lineNumber, columnNumber = column.LineNumber, column.ColumnNumber
     
                 // First break the strings into the collection to edit against
@@ -1794,7 +1794,7 @@ type internal CommonOperations
                     let line =
                         lineNumber + offset
                         |> SnapshotUtil.GetLine originalSnapshot
-                    let column = SnapshotCharacterSpan(line)
+                    let column = SnapshotColumn(line)
                     let columnCount = SnapshotLineUtil.GetCharacterSpansCount SearchPath.Forward line
                     if columnCount < columnNumber then
                         let prefix = String.replicate (columnNumber - columnCount) " "

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2475,7 +2475,7 @@ type StoredVisualSelection =
         let addOrEntireLine (point: SnapshotPoint) count = 
             let column = SnapshotColumn(point)
             match column.TryAddInLine(count, includeLineBreak = true) with
-            | Some column -> column.EndPoint
+            | Some column -> column.StartPoint
             | None -> 
                 match SnapshotPointUtil.TryAddOne column.Line.EndIncludingLineBreak with 
                 | Some p -> p

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2473,7 +2473,7 @@ type StoredVisualSelection =
         // Get the point which is 'count' columns forward from the passed in point (exclusive). If the point
         // extends past the line break the point past the line break will be returned if possible.
         let addOrEntireLine (point: SnapshotPoint) count = 
-            let column = SnapshotCharacterSpan(point)
+            let column = SnapshotColumn(point)
             match column.TryAddInLine(count, includeLineBreak = true) with
             | Some column -> column.EndPoint
             | None -> 
@@ -2488,7 +2488,7 @@ type StoredVisualSelection =
             let characterSpan = CharacterSpan(point, endPoint)
             VisualSelection.Character (characterSpan, SearchPath.Forward)
         | StoredVisualSelection.CharacterLine (lineCount, offset)  ->
-            let startColumn = SnapshotCharacterSpan(point)
+            let startColumn = SnapshotColumn(point)
             let range = SnapshotLineRangeUtil.CreateForLineAndMaxCount startColumn.Line (count * lineCount)
             let lastLine = range.LastLine
             let endPoint =

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -665,7 +665,7 @@ type SnapshotColumn =
     /// Whether the "character" at column is a linebreak
     member x.IsLineBreak = 
         x.CodePoint.StartPoint.Position = x.Line.End.Position &&
-        not x.IsEndPoint
+        not x.IsEndColumn
 
     /// The number of positions this occupies in the ITextSnapshot
     member x.Length = 
@@ -681,13 +681,13 @@ type SnapshotColumn =
 
     member x.EndPosition = x.EndPoint.Position
 
-    // CTODO: rename StartColumn
-    member x.IsStartPoint = x.CodePoint.IsStartPoint
+    /// Is this the first column in the buffer
+    member x.IsStartColumn = x.CodePoint.IsStartPoint
 
-    // CTODO: rename ENdColumn
-    member x.IsEndPoint = EditorCoreUtil.IsEndPoint x.StartPoint
+    /// Is this the end column in the buffer
+    member x.IsEndColumn = EditorCoreUtil.IsEndPoint x.StartPoint
 
-    member x.IsLineBreakOrEnd = x.IsLineBreak || x.IsEndPoint
+    member x.IsLineBreakOrEnd = x.IsLineBreak || x.IsEndColumn
 
     member x.IsCharacter (c: char) = x.CodePoint.IsCharacter c
 
@@ -755,7 +755,7 @@ type SnapshotColumn =
         let mutable isGood = true
         if count >= 0 then
             while count > 0 && isGood do
-                if current.IsEndPoint then
+                if current.IsEndColumn then
                     isGood <- false
                 else
                     current <- current.Add 1
@@ -765,7 +765,7 @@ type SnapshotColumn =
                         isGood <- false
         else
             while count < 0 && isGood do
-                if current.IsStartPoint then
+                if current.IsStartColumn then
                     isGood <- false
                 else
                     count <- count + 1
@@ -817,14 +817,14 @@ type SnapshotColumn =
             column <- column.Add 1
             count <- count - 1
             if 
-                column.IsEndPoint || 
+                column.IsEndColumn || 
                 column.LineNumber <> line.LineNumber ||
                 (column.IsLineBreak && not includeLineBreak)
             then
                 isGood <- false
 
         // Account for the case when columNumber is 0 and we're on an empty line
-        if (column.IsLineBreak || column.IsEndPoint) && not includeLineBreak then None
+        if (column.IsLineBreak || column.IsEndColumn) && not includeLineBreak then None
         elif isGood then Some column
         else None
 
@@ -846,7 +846,7 @@ type SnapshotColumn =
         | SearchPath.Forward -> 
             seq {
                 let mutable current = searchColumn
-                while not current.IsEndPoint do
+                while not current.IsEndColumn do
                     if not current.IsLineBreak || includeLineBreaks then
                         yield current
                     current <- current.Add 1
@@ -857,12 +857,12 @@ type SnapshotColumn =
                 let mutable current = searchColumn
                 while not isDone do
                     if 
-                        not current.IsEndPoint && 
+                        not current.IsEndColumn && 
                         (not current.IsLineBreak || includeLineBreaks)
                     then
                         yield current
 
-                    if current.IsStartPoint then
+                    if current.IsStartColumn then
                         isDone <- true
                     else
                         current <- current.Subtract 1
@@ -873,7 +873,7 @@ type SnapshotColumn =
         let includeLineBreaks = defaultArg includeLineBreaks false
         let all = seq {
             let mutable current = SnapshotColumn(searchLine)
-            while not current.IsEndPoint && current.LineNumber = searchLine.LineNumber do 
+            while not current.IsEndColumn && current.LineNumber = searchLine.LineNumber do 
                 if not current.IsLineBreak || includeLineBreaks then
                     yield current
                 current <- current.Add 1

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -469,7 +469,6 @@ type SnapshotCodePoint =
         if x.IsEndPoint then false
         else x.Length = 1 && func (x.StartPoint.GetChar())
 
-    // CTODO: consider whether or not to move this out to a helper type
     member x.IsBlank = x.IsCharacter CharUtil.IsBlank
 
     member x.IsWhiteSpace = x.IsCharacter CharUtil.IsWhiteSpace

--- a/Src/VimCore/FSharpExtensions.fs
+++ b/Src/VimCore/FSharpExtensions.fs
@@ -7,22 +7,28 @@ open Microsoft.VisualStudio.Utilities
 open Vim
 
 [<Extension>]
-module public OptionExtensions =
+type public OptionExtensions =
 
     [<Extension>]
-    let IsSome opt = Option.isSome opt
+    static member IsSome(opt): bool = Option.isSome opt
 
     [<Extension>]
-    let IsNone opt = Option.isNone opt
+    static member IsSome(opt, func): bool =
+        match opt with
+        | Some value -> func value
+        | None -> false
 
     [<Extension>]
-    let Is (opt:'a option, value) =
+    static member IsNone(opt) = Option.isNone opt
+
+    [<Extension>]
+    static member Is (opt:'a option, value) =
         match opt with 
         | Some(toTest) -> toTest = value
         | None         -> false
 
     [<Extension>]
-    let SomeOrDefault opt defaultValue = 
+    static member SomeOrDefault opt defaultValue = 
         match opt with 
         | Some(value) -> value
         | None -> defaultValue

--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -639,68 +639,8 @@ module internal CharUtil =
         else
             char ((int lowerBound) + number) 
 
-    /// Determines whether the given character occupies space on screen when displayed.
-    /// For instance, combining diacritics occupy the space of the previous character,
-    /// while control characters are simply not displayed.
-    let IsNonSpacingCharacter c =
-        // based on http://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
-        // TODO: this should be checked for consistency with
-        //       Visual studio handling of each character.
-
-        match System.Char.GetUnicodeCategory(c) with
-        //Visual studio does not render control characters
-        | System.Globalization.UnicodeCategory.Control
-        | System.Globalization.UnicodeCategory.NonSpacingMark
-        | System.Globalization.UnicodeCategory.Format
-        | System.Globalization.UnicodeCategory.EnclosingMark ->
-            /// Contrarily to http://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
-            /// the Soft hyphen (\u00ad) is invisible in VS.
-            true
-        | _ -> (c = '\u200b') || ('\u1160' <= c && c <= '\u11ff')
-
-    /// Determines if the given character occupies a single or two cells on screen.
-    let IsWideCharacter c =
-        // based on http://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
-        // TODO: this should be checked for consistency with
-        //       Visual studio handling of each character.
-        (c >= '\u1100' &&
-            (
-                // Hangul Jamo init. consonants
-                c <= '\u115f' || c = '\u2329' || c = '\u232a' ||
-                // CJK ... Yi
-                (c >= '\u2e80' && c <= '\ua4cf' && c <> '\u303f') ||
-                // Hangul Syllables */
-                (c >= '\uac00' && c <= '\ud7a3') ||
-                // CJK Compatibility Ideographs
-                (c >= '\uf900' && c <= '\ufaff') ||
-                // Vertical forms
-                (c >= '\ufe10' && c <= '\ufe19') ||
-                // CJK Compatibility Forms
-                (c >= '\ufe30' && c <= '\ufe6f') ||
-                // Fullwidth Forms
-                (c >= '\uff00' && c <= '\uff60') ||
-                (c >= '\uffe0' && c <= '\uffe6')));
-
-                // The following can only be detected with pairs of characters
-                //   (surrogate characters)
-                // Supplementary ideographic plane
-                //(ucs >= 0x20000 && ucs <= 0x2fffd) ||
-                // Tertiary ideographic plane
-                //(ucs >= 0x30000 && ucs <= 0x3fffd)));
-
-    /// Determines the character width when displayed, computed according to the various local settings.
-    let GetCharacterWidth c tabStop =
-        // TODO: for surrogate pairs, we need to be able to match characters specified as strings.
-        // E.g. if System.Char.IsHighSurrogate(c) then
-        //    let fullchar = point.Snapshot.GetSpan(point.Position, 1).GetText()
-        //    CommontUtil.GetSurrogatePairWidth fullchar
-
-        match c with
-        | '\u0000' -> 1
-        | '\t' -> tabStop
-        | _ when IsNonSpacingCharacter c -> 0
-        | _ when IsWideCharacter c -> 2
-        | _ -> 1
+    // CTODO: delete this
+    let GetCharacterWidth (c: char) (tabstop: int) = 0
 
     let GetDigitValue c = 
         match c with

--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -639,9 +639,6 @@ module internal CharUtil =
         else
             char ((int lowerBound) + number) 
 
-    // CTODO: delete this
-    let GetCharacterWidth (c: char) (tabstop: int) = 0
-
     let GetDigitValue c = 
         match c with
         | '0' -> Some 0

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -494,11 +494,11 @@ type internal InsertUtil
 
                     let existingRange = Span.FromBounds(insertColumn.Point.Position, x.CaretPoint.Position)
 
-                    // CTODO: the explicit SnapshotCharacterSpan shouldn't be needed here when we are done.
+                    // CTODO: the explicit SnapshotColumn shouldn't be needed here when we are done.
                     let text = 
                         let existingText = x.CurrentSnapshot.GetText(existingRange)
                         let indentText = StringUtil.RepeatChar addedSpaces ' ' 
-                        _operations.NormalizeBlanksAtColumn (existingText + indentText) (SnapshotCharacterSpan(insertColumn.Point))
+                        _operations.NormalizeBlanksAtColumn (existingText + indentText) (SnapshotColumn(insertColumn.Point))
 
                     let caretPosition = insertColumn.Point.Position + text.Length
                     _textBuffer.Replace(existingRange, text) |> ignore

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -50,7 +50,7 @@ type internal InsertUtil
     member x.CaretVirtualPoint = TextViewUtil.GetCaretVirtualPoint _textView
 
     /// The column of the caret
-    member x.CaretColumn = SnapshotColumnLegacy(x.CaretPoint)
+    member x.CaretColumn = SnapshotColumn(x.CaretPoint)
 
     /// The ITextSnapshotLine for the caret
     member x.CaretLine = TextViewUtil.GetCaretLine _textView
@@ -390,16 +390,16 @@ type internal InsertUtil
         x.Insert s
 
     member x.InsertCharacterCore lineNumber isReplace =
-        match SnapshotUtil.TryGetPointInLine _textBuffer.CurrentSnapshot lineNumber x.CaretColumn.Column with
+        match SnapshotColumn.TryCreateForLineAndColumnNumber(x.CurrentSnapshot, lineNumber, x.CaretColumn.ColumnNumber) with
         | None -> 
             _operations.Beep()
             CommandResult.Error
-        | Some point -> 
-            let text = SnapshotPointUtil.GetChar point |> StringUtil.OfChar
+        | Some column -> 
+            let text = column.GetText()
             let position = x.CaretPoint.Position
             if isReplace then x.DeleteRight 1 |> ignore
             _textBuffer.Insert(position, text) |> ignore
-            TextViewUtil.MoveCaretToPosition _textView (position + 1)
+            TextViewUtil.MoveCaretToPosition _textView (position + column.Length)
             CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Insert the character immediately above the caret
@@ -488,19 +488,18 @@ type internal InsertUtil
                     // we've hit a tab boundary which is defined by 'tabstop'
                     let insertColumn = 
                         let mutable column = x.CaretColumn
-                        while column.Column > 0 && CharUtil.IsBlank (column.Point.Subtract(1).GetChar()) do
+                        while column.ColumnNumber > 0 && column.Subtract(1).CodePoint.IsBlank do
                             column <- column.Subtract(1)
                         column
 
-                    let existingRange = Span.FromBounds(insertColumn.Point.Position, x.CaretPoint.Position)
+                    let existingRange = Span.FromBounds(insertColumn.StartPoint.Position, x.CaretPoint.Position)
 
-                    // CTODO: the explicit SnapshotColumn shouldn't be needed here when we are done.
                     let text = 
                         let existingText = x.CurrentSnapshot.GetText(existingRange)
                         let indentText = StringUtil.RepeatChar addedSpaces ' ' 
-                        _operations.NormalizeBlanksAtColumn (existingText + indentText) (SnapshotColumn(insertColumn.Point))
+                        _operations.NormalizeBlanksAtColumn (existingText + indentText) insertColumn
 
-                    let caretPosition = insertColumn.Point.Position + text.Length
+                    let caretPosition = insertColumn.StartPoint.Position + text.Length
                     _textBuffer.Replace(existingRange, text) |> ignore
                     caretPosition
 
@@ -698,10 +697,10 @@ type internal InsertUtil
 
     /// Undo replace, or equivalently, backspace in replace mode
     member x.UndoReplace () =
-        if x.CaretColumn.Column > 0 then
+        if x.CaretColumn.ColumnNumber > 0 then
             let point = x.CaretPoint.Subtract(1)
             TextViewUtil.MoveCaretToPosition _textView point.Position
-            match x.TryGetRecordedCharacter x.CaretColumn.Column with
+            match x.TryGetRecordedCharacter x.CaretColumn.ColumnNumber with
             | None -> ()
             | Some character -> 
                 let span = SnapshotSpan(x.CaretPoint, 1)
@@ -830,7 +829,7 @@ type internal InsertUtil
     /// The point we should backspace to in order to delete a character.  This will never 
     /// be called when the caret is at the start of the line
     member x.BackspaceOverCharPoint() =
-        Contract.Assert (x.CaretColumn.Column > 0)
+        Contract.Assert (x.CaretColumn.ColumnNumber > 0)
         let prevPoint = x.CaretPoint.Subtract(1)
         if _localSettings.SoftTabStop <> 0 && SnapshotPointUtil.IsBlank prevPoint && _vimTextBuffer.IsSoftTabStopValidForBackspace then
             x.BackspaceOverIndent()
@@ -841,7 +840,7 @@ type internal InsertUtil
     /// 'softtabstop' is set and there is a blank before the caret
     member x.BackspaceOverIndent() = 
         Contract.Assert (_localSettings.SoftTabStop <> 0)
-        Contract.Assert (x.CaretColumn.Column > 0)
+        Contract.Assert (x.CaretColumn.ColumnNumber > 0)
         Contract.Assert (SnapshotPointUtil.IsBlank (x.CaretPoint.Subtract(1)))
 
         let prevPoint = x.CaretPoint.Subtract(1)
@@ -881,14 +880,14 @@ type internal InsertUtil
 
     /// The point we should backspace to in order to delete a word
     member x.BackspaceOverWordPoint() =
-        Contract.Assert (x.CaretColumn.Column > 0)
+        Contract.Assert (x.CaretColumn.ColumnNumber > 0)
 
         // Jump past any blanks before the caret
         let searchPoint = 
             let mutable current = x.CaretColumn.Subtract 1
-            while current.Column > 0 && SnapshotPointUtil.IsBlank current.Point do
+            while current.ColumnNumber > 0 && current.CodePoint.IsBlank do
                 current <- current.Subtract 1
-            current.Point
+            current.StartPoint
 
         let deletePoint =  
             match _wordUtil.GetFullWordSpan WordKind.NormalWord searchPoint with

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -50,7 +50,7 @@ type internal InsertUtil
     member x.CaretVirtualPoint = TextViewUtil.GetCaretVirtualPoint _textView
 
     /// The column of the caret
-    member x.CaretColumn = SnapshotColumn(x.CaretPoint)
+    member x.CaretColumn = SnapshotColumnLegacy(x.CaretPoint)
 
     /// The ITextSnapshotLine for the caret
     member x.CaretLine = TextViewUtil.GetCaretLine _textView
@@ -90,7 +90,7 @@ type internal InsertUtil
                 else
                     let snapshotColumn =
                         line.Start
-                        |> SnapshotColumnUtil.GetColumns SearchPath.Forward
+                        |> SnapshotColumnUtilLegacy.GetColumns SearchPath.Forward
                         |> Seq.skipWhile (fun snapshotColumn -> snapshotColumn.Column <> column)
                         |> Seq.tryHead
                     match snapshotColumn with

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -494,10 +494,11 @@ type internal InsertUtil
 
                     let existingRange = Span.FromBounds(insertColumn.Point.Position, x.CaretPoint.Position)
 
+                    // CTODO: the explicit SnapshotCharacterSpan shouldn't be needed here when we are done.
                     let text = 
                         let existingText = x.CurrentSnapshot.GetText(existingRange)
                         let indentText = StringUtil.RepeatChar addedSpaces ' ' 
-                        _operations.NormalizeBlanksAtColumn (existingText + indentText) insertColumn
+                        _operations.NormalizeBlanksAtColumn (existingText + indentText) (SnapshotCharacterSpan(insertColumn.Point))
 
                     let caretPosition = insertColumn.Point.Position + text.Length
                     _textBuffer.Replace(existingRange, text) |> ignore

--- a/Src/VimCore/MefInterfaces.fs
+++ b/Src/VimCore/MefInterfaces.fs
@@ -455,7 +455,7 @@ type ICommonOperations =
     abstract NormalizeBlanks: text: string -> string
 
     /// Normalize the spaces and tabs in the string at the given column in the buffer
-    abstract NormalizeBlanksAtColumn: text: string -> column: SnapshotCharacterSpan -> string
+    abstract NormalizeBlanksAtColumn: text: string -> column: SnapshotColumn -> string
 
     /// Normalize the set of blanks into spaces
     abstract NormalizeBlanksToSpaces: string -> string

--- a/Src/VimCore/MefInterfaces.fs
+++ b/Src/VimCore/MefInterfaces.fs
@@ -455,7 +455,7 @@ type ICommonOperations =
     abstract NormalizeBlanks: text: string -> string
 
     /// Normalize the spaces and tabs in the string at the given column in the buffer
-    abstract NormalizeBlanksAtColumn: text: string -> column: SnapshotColumn -> string
+    abstract NormalizeBlanksAtColumn: text: string -> column: SnapshotCharacterSpan -> string
 
     /// Normalize the set of blanks into spaces
     abstract NormalizeBlanksToSpaces: string -> string

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -1638,7 +1638,7 @@ type internal MotionUtil
         let sentenceKind = SentenceKind.NoTrailingCharacters
         let searchColumn = 
             let mutable column = x.CaretColumn
-            while _textObjectUtil.IsSentenceWhiteSpace sentenceKind column && not column.IsEndPoint do
+            while _textObjectUtil.IsSentenceWhiteSpace sentenceKind column && not column.IsEndColumn do
                 column <- column.Add 1
             column
 
@@ -1664,10 +1664,10 @@ type internal MotionUtil
                 // sentence
                 let whiteSpaceAfter =
                     let mutable column = SnapshotColumn(span.End)
-                    while not (_textObjectUtil.IsSentenceStart sentenceKind column) && not column.IsEndPoint do
+                    while not (_textObjectUtil.IsSentenceStart sentenceKind column) && not column.IsEndColumn do
                         column <- column.Add 1
 
-                    if column.IsEndPoint || span.End.Position = column.StartPoint.Position then
+                    if column.IsEndColumn || span.End.Position = column.StartPoint.Position then
                         None
                     else
                         Some column
@@ -1676,7 +1676,7 @@ type internal MotionUtil
                 let includePrecedingWhiteSpace () =
                     let mutable column = SnapshotColumn(span.Start)
                     let mutable before = 
-                        if column.IsStartPoint then column
+                        if column.IsStartColumn then column
                         else column.Subtract 1
                     while column.StartPoint.Position > 0 && _textObjectUtil.IsSentenceWhiteSpace sentenceKind before do
                         column <- before

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -992,6 +992,8 @@ type internal MotionUtil
     /// The virtual caret point in the ITextView
     member x.CaretVirtualPoint = TextViewUtil.GetCaretVirtualPoint _textView
 
+    member x.CaretColumn = SnapshotColumn(x.CaretPoint)
+
     /// Caret line in the ITextView
     member x.CaretLine = SnapshotPointUtil.GetContainingLine x.CaretPoint
 
@@ -2290,6 +2292,7 @@ type internal MotionUtil
     /// Get the motion which is 'count' characters to the left of the caret on
     /// the same line
     member x.CharLeftOnSameLine count = 
+<<<<<<< HEAD
         let endPoint = x.CaretVirtualPoint
         if _vimTextBuffer.UseVirtualSpace && endPoint.IsInVirtualSpace then
             if count < endPoint.VirtualSpaces then
@@ -2315,10 +2318,19 @@ type internal MotionUtil
                 |> OptionUtil.getOrDefault x.CaretLine.Start
             let span = SnapshotSpan(startPoint, x.CaretPoint)
             MotionResult.Create(span, MotionKind.CharacterWiseExclusive, isForward = false)
+=======
+        let startColumn = 
+            match x.CaretColumn.TrySubtractInLine count with
+            | Some column -> column
+            | None -> SnapshotColumn(x.CaretLine)
+        let span = SnapshotSpan(startColumn.StartPoint, x.CaretPoint)
+        MotionResult.Create(span, MotionKind.CharacterWiseExclusive, isForward = false)
+>>>>>>> More progress porting API
 
     /// Get the motion which is 'count' characters to the right of the caret 
     /// on the same line
     member x.CharRightOnSameLine count =
+<<<<<<< HEAD
         if _vimTextBuffer.UseVirtualSpace then
             x.CharRightVirtual count
         else
@@ -2332,6 +2344,19 @@ type internal MotionUtil
                     |> OptionUtil.getOrDefault x.CaretLine.End
             let span = SnapshotSpan(x.CaretPoint, endPoint)
             MotionResult.Create(span, MotionKind.CharacterWiseExclusive, isForward = true)
+=======
+        let endPoint = 
+            if SnapshotPointUtil.IsInsideLineBreak x.CaretPoint then 
+                x.CaretPoint
+            elif x.CaretPoint.Position + 1 = x.CaretLine.End.Position then
+                x.CaretLine.End
+            else
+                match x.CaretColumn.TryAddInLine(count, includeLineBreak = true) with
+                | Some column -> column.StartPoint
+                | None -> x.CaretLine.End
+        let span = SnapshotSpan(x.CaretPoint, endPoint)
+        MotionResult.Create(span, MotionKind.CharacterWiseExclusive, isForward = true)
+>>>>>>> More progress porting API
 
     /// Get the motion which is 'count' characters before the caret
     /// through the buffer taking into acount 'virtualedit'

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -861,7 +861,7 @@ type MatchingTokenUtil() =
             found
 
         let line, column = 
-            let data = SnapshotColumn(point)
+            let data = SnapshotColumnLegacy(point)
             let line = data.Line
 
             // The search should normalize caret's in the line break back to the last valid 
@@ -1635,7 +1635,7 @@ type internal MotionUtil
         // AllSentence we don't want this behavior and want to start with the following sentence.  
         let sentenceKind = SentenceKind.NoTrailingCharacters
         let searchPoint = 
-            let mutable column = SnapshotColumn(x.CaretPoint)
+            let mutable column = SnapshotColumnLegacy(x.CaretPoint)
             while _textObjectUtil.IsSentenceWhiteSpace sentenceKind column && not (SnapshotPointUtil.IsEndPoint column.Point) do
                 column <- column.Add 1
             column.Point
@@ -1661,7 +1661,7 @@ type internal MotionUtil
                 // The white space after the sentence is the gap between this sentence and the next
                 // sentence
                 let whiteSpaceAfter =
-                    let mutable column = SnapshotColumn(span.End)
+                    let mutable column = SnapshotColumnLegacy(span.End)
                     while not (_textObjectUtil.IsSentenceStart sentenceKind column) && not (SnapshotPointUtil.IsEndPoint column.Point) do
                         column <- column.Add 1
 
@@ -1672,7 +1672,7 @@ type internal MotionUtil
 
                 // Include the preceding white space in the Span
                 let includePrecedingWhiteSpace () =
-                    let mutable column = SnapshotColumn(span.Start)
+                    let mutable column = SnapshotColumnLegacy(span.Start)
                     let mutable before = 
                         if SnapshotPointUtil.IsStartPoint column.Point then column
                         else column.Subtract 1

--- a/Src/VimCore/README.md
+++ b/Src/VimCore/README.md
@@ -1,0 +1,20 @@
+﻿
+## Terminology 
+
+Describes meaning of terms used in the API and code base.
+
+### Locations in the buffer
+
+- Position: refers to the position notation in underlying editor. For example `SnapshotPoint` is
+a specific position in an `ITextSnapshot`. It may be in the middle of a line feed, code point,
+etc ...
+- Code point: refers to a Unicode code point value. In addition to valid code points it can refer
+to broken code points (high or low surrogate without the matching value).
+- Columns: vim based unit of measure. The granularity of a left or right motion in vim. A tab is 
+a single column, as is a astral code point.
+- Spaces: vim based unit of measure for columns. That is each column takes up a specific number of 
+spaces. This is used often when calculating indentation / columns between lines.
+    - Unicode control and non spacing values: 0 
+    - Tab: current value of `tabstop`
+    - Wide characters: 2
+    - Everything else: 1

--- a/Src/VimCore/README.md
+++ b/Src/VimCore/README.md
@@ -18,3 +18,7 @@ spaces. This is used often when calculating indentation / columns between lines.
     - Tab: current value of `tabstop`
     - Wide characters: 2
     - Everything else: 1
+
+### TODO:
+
+Wide characters: are they handled at SnapshotCodePoint or SnapshotCharacterSpan. 

--- a/Src/VimCore/README.md
+++ b/Src/VimCore/README.md
@@ -21,4 +21,4 @@ spaces. This is used often when calculating indentation / columns between lines.
 
 ### TODO:
 
-Wide characters: are they handled at SnapshotCodePoint or SnapshotCharacterSpan. 
+Wide characters: are they handled at SnapshotCodePoint or SnapshotColumn. 

--- a/Src/VimCore/Resources.fs
+++ b/Src/VimCore/Resources.fs
@@ -17,6 +17,7 @@ module internal Resources =
     let Common_GotoDefFailed word = sprintf "Could not navigate to definition of %s" word
     let Common_InvalidAddress = "Invalid addresss"
     let Common_InvalidLineNumber = "Invalid Line Number"
+    let Common_LocationOutsideBuffer = "The location specified is outside the buffer"
     let Common_MarkInvalid = "Argument must be a letter or forward / back quote"
     let Common_MarkNotSet = "Mark not set"
     let Common_NoFoldFound = "No fold found"

--- a/Src/VimCore/TextObjectUtil.fs
+++ b/Src/VimCore/TextObjectUtil.fs
@@ -150,7 +150,7 @@ type internal TextObjectUtil
             // If this point is the start of a sentence line then it's the end point of the
             // previous sentence span. 
             true
-        elif column.IsStartPoint then
+        elif column.IsStartColumn then
             // Start of buffer is not the end of a sentence
             false
         else
@@ -165,7 +165,7 @@ type internal TextObjectUtil
             //  
             //  b
             let line = columnBefore.Line
-            if (columnBefore.IsLineBreak || columnBefore.IsEndPoint) && x.IsSentenceLine line then
+            if (columnBefore.IsLineBreak || columnBefore.IsEndColumn) && x.IsSentenceLine line then
                 true
             else
                 x.IsSentenceEndSimple sentenceKind column
@@ -198,7 +198,7 @@ type internal TextObjectUtil
         | SentenceKind.NoTrailingCharacters -> ()
         | SentenceKind.Default ->
             while not pastStart && isCharInList SentenceTrailingChars current do
-                if current.IsStartPoint then 
+                if current.IsStartColumn then 
                     pastStart <- true
                 else
                     current <- current.Subtract 1
@@ -210,7 +210,7 @@ type internal TextObjectUtil
     member x.IsSentenceEndWhiteSpace (column: SnapshotColumn) =
         column.CodePoint.IsWhiteSpace ||
         column.IsLineBreak ||
-        column.IsEndPoint
+        column.IsEndColumn
 
     /// Is this point the star of a sentence.  Considers sentences, paragraphs and section
     /// boundaries
@@ -240,7 +240,7 @@ type internal TextObjectUtil
                 adjustedColumn <- adjustedColumn.Subtract 1
             adjustedColumn
 
-        if column.IsStartPoint then
+        if column.IsStartColumn then
             // The start of the ITextBuffer is the start of a sentence
             true
         elif adjustedColumn.IsStartOfLine && x.IsEmptyLineWithNoEmptyAbove adjustedColumn.Line then
@@ -253,7 +253,7 @@ type internal TextObjectUtil
         else
             // Move backwards while we are on white space
             let mutable current = column.Subtract 1
-            while x.IsSentenceEndWhiteSpace current && not current.IsStartPoint do
+            while x.IsSentenceEndWhiteSpace current && not current.IsStartColumn do
                 current <- current.Subtract 1
 
             if column.StartPosition = current.StartPosition then
@@ -270,7 +270,7 @@ type internal TextObjectUtil
             false
         else
             let mutable current = column 
-            while not (x.IsSentenceEnd sentenceKind current) && x.IsSentenceEndWhiteSpace current && not current.IsStartPoint do
+            while not (x.IsSentenceEnd sentenceKind current) && x.IsSentenceEndWhiteSpace current && not current.IsStartColumn do
                 current <- current.Subtract 1
 
             x.IsSentenceEnd sentenceKind current
@@ -443,7 +443,7 @@ type internal TextObjectUtil
 
         // Wrap the get full span method to deal with <end>.  
         let getSpanFromStartColumn (column: SnapshotColumn) = 
-            if column.IsEndPoint then
+            if column.IsEndColumn then
                 SnapshotSpan(column.StartPoint, 0)
             else
                 getSpanFromStartColumn column
@@ -463,13 +463,13 @@ type internal TextObjectUtil
             |> SeqUtil.headOrDefault (SnapshotColumn.GetEndColumn column.Snapshot)
 
         // Search includes the section which contains the start point so go ahead and get it
-        match path, column.IsStartPoint with
+        match path, column.IsStartColumn with
         | SearchPath.Forward, _ ->
 
             // Get the next object.  The provided point should either be <end> or point 
             // to the start of a section
             let getNext (column: SnapshotColumn) = 
-                if column.IsEndPoint then
+                if column.IsEndColumn then
                     None
                 else
                     let span = getSpanFromStartColumn column
@@ -500,7 +500,7 @@ type internal TextObjectUtil
             // Get the previous section.  The provided point should either be 0 or point
             // to the start of a section
             let getPrevious (column: SnapshotColumn) = 
-                if column.IsStartPoint then
+                if column.IsStartColumn then
                     None
                 else
                     let startColumn = getStartBackward (column.Subtract 1)

--- a/Src/VimCore/TextObjectUtil.fs
+++ b/Src/VimCore/TextObjectUtil.fs
@@ -93,7 +93,7 @@ type internal TextObjectUtil
 
     /// Is this point the start of a paragraph.  Considers both paragraph and section 
     /// start points
-    member x.IsParagraphStart (column: SnapshotColumnLegacy) =
+    member x.IsParagraphStart (column: SnapshotColumn) =
         if column.IsStartOfLine then
             let line = column.Line
             x.IsParagraphStartOnly line || x.IsSectionStart SectionKind.Default line
@@ -144,13 +144,13 @@ type internal TextObjectUtil
 
     /// Is this the end point of the span of an actual sentence.  Considers sentence, paragraph and 
     /// section semantics
-    member x.IsSentenceEnd sentenceKind (column: SnapshotColumnLegacy) = 
+    member x.IsSentenceEnd sentenceKind (column: SnapshotColumn) = 
         let line = column.Line
         if column.IsStartOfLine && x.IsSentenceLine line then
             // If this point is the start of a sentence line then it's the end point of the
             // previous sentence span. 
             true
-        elif column.Point.Position = 0 then
+        elif column.IsStartPoint then
             // Start of buffer is not the end of a sentence
             false
         else
@@ -165,57 +165,56 @@ type internal TextObjectUtil
             //  
             //  b
             let line = columnBefore.Line
-            if SnapshotLineUtil.IsLastPointIncludingLineBreak line columnBefore.Point && x.IsSentenceLine line then
+            if (columnBefore.IsLineBreak || columnBefore.IsEndPoint) && x.IsSentenceLine line then
                 true
             else
                 x.IsSentenceEndSimple sentenceKind column
 
     /// Checks for a simple end of a sentence.  Only checks for the characters case and
     /// will ignore items like sentence lines and new lines
-    member x.IsSentenceEndSimple sentenceKind (column: SnapshotColumnLegacy) = 
-        if not (x.IsSentenceEndWhiteSpace column.Point) then
+    member x.IsSentenceEndSimple sentenceKind (column: SnapshotColumn) = 
+        if not (x.IsSentenceEndWhiteSpace column) then
             // If the column doesn't begin in the white space that ends a sentence then
             // this can't possible be the end of a simple sentence
             false
         else
-            let point = column.Point.Subtract 1
-            x.IsSentenceLastSimple sentenceKind point
+            let previous = column.Subtract 1
+            x.IsSentenceLastSimple sentenceKind previous
 
     /// Checks for the last character of a simple sentence.  Only checks for the characters 
     /// case and will ignore items like sentence lines
-    member x.IsSentenceLastSimple sentenceKind (point: SnapshotPoint) = 
+    member x.IsSentenceLastSimple sentenceKind (column: SnapshotColumn) = 
         // Is the char for the provided point in the given list.  Make sure to 
         // account for the snapshot end point here as it makes the remaining 
         // logic easier 
-        let snapshot = point.Snapshot
-        let isCharInList list position = 
-            let point = SnapshotPoint(snapshot, position)
-            let c = point.GetChar()
-            ListUtil.contains c list 
+        let isCharInList list (column: SnapshotColumn) = 
+            List.exists (fun (c: char) -> column.IsCharacter(c)) list
 
-        let mutable position = point.Position
+        let mutable current = column
+        let mutable pastStart = false
 
         // First move past the trailing characters if supported by the kind
         match sentenceKind with
         | SentenceKind.NoTrailingCharacters -> ()
         | SentenceKind.Default ->
-            while position >= 0 && isCharInList SentenceTrailingChars position do
-                position <- position - 1
+            while not pastStart && isCharInList SentenceTrailingChars current do
+                if current.IsStartPoint then 
+                    pastStart <- true
+                else
+                    current <- current.Subtract 1
 
-        if position < 0 then 
-            false
-        else 
-            isCharInList SentenceEndChars position
+        if pastStart then false
+        else isCharInList SentenceEndChars current
 
     // Is this a valid white space item to end the sentence
-    member x.IsSentenceEndWhiteSpace point =
-        SnapshotPointUtil.IsWhiteSpace point || 
-        SnapshotPointUtil.IsInsideLineBreak point ||
-        SnapshotPointUtil.IsEndPoint point
+    member x.IsSentenceEndWhiteSpace (column: SnapshotColumn) =
+        column.CodePoint.IsWhiteSpace ||
+        column.IsLineBreak ||
+        column.IsEndPoint
 
     /// Is this point the star of a sentence.  Considers sentences, paragraphs and section
     /// boundaries
-    member x.IsSentenceStart sentenceKind (column: SnapshotColumnLegacy) = 
+    member x.IsSentenceStart sentenceKind (column: SnapshotColumn) = 
         if x.IsSentenceStartOnly sentenceKind column then
             true
         else
@@ -234,44 +233,44 @@ type internal TextObjectUtil
 
     /// Is the start of a sentence.  This doesn't consider section or paragraph boundaries
     /// but specifically items related to the start of a sentence
-    member x.IsSentenceStartOnly sentenceKind (column: SnapshotColumnLegacy) = 
-        let mutable adjustedColumn = column 
-        while adjustedColumn.Column > 0 && SnapshotPointUtil.IsBlank (adjustedColumn.Point.Subtract(1)) do
-            adjustedColumn <- adjustedColumn.Subtract 1
+    member x.IsSentenceStartOnly sentenceKind (column: SnapshotColumn) = 
+        let adjustedColumn = 
+            let mutable adjustedColumn = column 
+            while adjustedColumn.ColumnNumber > 0 && adjustedColumn.Subtract(1).CodePoint.IsBlank do
+                adjustedColumn <- adjustedColumn.Subtract 1
+            adjustedColumn
 
-        let point = column.Point
-        if SnapshotPointUtil.IsStartPoint point then
+        if column.IsStartPoint then
             // The start of the ITextBuffer is the start of a sentence
             true
         elif adjustedColumn.IsStartOfLine && x.IsEmptyLineWithNoEmptyAbove adjustedColumn.Line then
             true
-        elif x.IsSentenceEndWhiteSpace point then
+        elif x.IsSentenceEndWhiteSpace column then
             // Sentence white space isn't the start of a sentence
             false
         elif adjustedColumn.IsStartOfLine && x.IsLineAboveEmpty adjustedColumn.Line then
             true
         else
             // Move backwards while we are on white space
-            let mutable current = point.Subtract 1
-            while x.IsSentenceEndWhiteSpace current && current.Position > 0 do
+            let mutable current = column.Subtract 1
+            while x.IsSentenceEndWhiteSpace current && not current.IsStartPoint do
                 current <- current.Subtract 1
 
-            if point.Position = current.Position then
+            if column.StartPosition = current.StartPosition then
                 // If the character before isn't sentence white space then this can't be 
                 // a sentence so bail out 
                 false
             else
                 let current = current.Add 1
-                let column = SnapshotColumnLegacy(current)
-                x.IsSentenceEnd sentenceKind column
+                x.IsSentenceEnd sentenceKind current
 
     /// Is the SnapshotPoint in the white space between sentences
-    member x.IsSentenceWhiteSpace sentenceKind (column: SnapshotColumnLegacy) =
+    member x.IsSentenceWhiteSpace sentenceKind (column: SnapshotColumn) =
         if column.IsStartOfLine && x.IsEmptyLineWithNoEmptyAbove column.Line then
             false
         else
             let mutable current = column 
-            while not (x.IsSentenceEnd sentenceKind current) && x.IsSentenceEndWhiteSpace current.Point && current.Point.Position > 0 do
+            while not (x.IsSentenceEnd sentenceKind current) && x.IsSentenceEndWhiteSpace current && not current.IsStartPoint do
                 current <- current.Subtract 1
 
             x.IsSentenceEnd sentenceKind current
@@ -315,23 +314,20 @@ type internal TextObjectUtil
 
     /// Get the SnapshotSpan values for the paragraph object starting from the given SnapshotPoint
     /// in the specified direction.  
-    member x.GetParagraphs path point = 
+    member x.GetParagraphs path column = 
 
         // Get the full span of a paragraph given a start point
-        let getFullSpanFromStartColumn (column: SnapshotColumnLegacy) =
+        let getFullSpanFromStartColumn (column: SnapshotColumn) =
             Contract.Assert (x.IsParagraphStart column)
-            let point = column.Point
-            let snapshot = SnapshotPointUtil.GetSnapshot point
-            let endPoint =
-                point 
-                |> SnapshotPointUtil.AddOne
-                |> SnapshotColumnUtilLegacy.GetColumnsIncludingLineBreak SearchPath.Forward
+            let endColumn =
+                let seq = SnapshotColumn.GetColumns(column, SearchPath.Forward, includeLineBreaks = true)
+                seq
+                |> Seq.skip 1
                 |> Seq.skipWhile (fun c -> not (x.IsParagraphStart c))
-                |> Seq.map SnapshotColumnUtilLegacy.GetPoint
-                |> SeqUtil.headOrDefault (SnapshotUtil.GetEndPoint snapshot)
-            SnapshotSpan(point, endPoint)
+                |> SeqUtil.headOrDefault (SnapshotColumn.GetEndColumn column.Snapshot)
+            SnapshotSpan(column.StartPoint, endColumn.StartPoint)
 
-        x.GetTextObjectsCore point path x.IsParagraphStart getFullSpanFromStartColumn
+        x.GetTextObjectsCore column path x.IsParagraphStart getFullSpanFromStartColumn
 
     /// Get the SnapshotLineRange values for the section values starting from the given SnapshotPoint 
     /// in the specified direction.  Note: The full span of the section will be returned if the 
@@ -424,90 +420,78 @@ type internal TextObjectUtil
     /// Get the SnapshotSpan values for the sentence values starting from the given SnapshotPoint 
     /// in the specified direction.  Note: The full span of the section will be returned if the 
     /// provided SnapshotPoint is in the middle of it
-    member x.GetSentences sentenceKind path (point: SnapshotPoint) =
+    member x.GetSentences sentenceKind path (column: SnapshotColumn) =
 
         // Get the full span of a sentence given the particular start point
-        let getFullSpanFromStartColumn (column: SnapshotColumnLegacy) =
+        let getFullSpanFromStartColumn (column: SnapshotColumn) =
             Contract.Assert (x.IsSentenceStart sentenceKind column)
-
-            let point = column.Point
-            let snapshot = column.Snapshot
-
             // Move forward until we hit the end point and then move one past it so the end
             // point is included in the span
-            let endPoint = 
-                point
-                |> SnapshotPointUtil.AddOne
-                |> SnapshotColumnUtilLegacy.GetColumnsIncludingLineBreak SearchPath.Forward
+            let endColumn =
+                let seq = SnapshotColumn.GetColumns(column, SearchPath.Forward, includeLineBreaks = true)
+                seq
+                |> Seq.skip 1
                 |> Seq.skipWhile (fun c -> not (x.IsSentenceEnd sentenceKind c))
-                |> Seq.map (fun c -> c.Point)
-                |> SeqUtil.headOrDefault (SnapshotUtil.GetEndPoint snapshot)
-            SnapshotSpan(point, endPoint)
+                |> SeqUtil.headOrDefault (SnapshotColumn.GetEndColumn column.Snapshot)
+            SnapshotSpan(column.StartPoint, endColumn.StartPoint)
 
-        x.GetTextObjectsCore point path (x.IsSentenceStart sentenceKind) getFullSpanFromStartColumn
+        x.GetTextObjectsCore column path (x.IsSentenceStart sentenceKind) getFullSpanFromStartColumn
 
     /// Get the text objects core from the given point in the given direction
-    member x.GetTextObjectsCore (point: SnapshotPoint) path (isStartColumn: SnapshotColumnLegacy -> bool) (getSpanFromStartColumn: SnapshotColumnLegacy -> SnapshotSpan) = 
-
-        let column = SnapshotColumnUtilLegacy.CreateFromPoint point
-        let snapshot = SnapshotPointUtil.GetSnapshot point
+    member x.GetTextObjectsCore (column: SnapshotColumn) path (isStartColumn: SnapshotColumn -> bool) (getSpanFromStartColumn: SnapshotColumn -> SnapshotSpan) = 
         let isNotStartColumn column = not (isStartColumn column)
 
         // Wrap the get full span method to deal with <end>.  
-        let getSpanFromStartColumn (column: SnapshotColumnLegacy) = 
-            if SnapshotPointUtil.IsEndPoint column.Point then
-                SnapshotSpan(column.Point, 0)
+        let getSpanFromStartColumn (column: SnapshotColumn) = 
+            if column.IsEndPoint then
+                SnapshotSpan(column.StartPoint, 0)
             else
                 getSpanFromStartColumn column
 
         // Get the section start going backwards from the given point.
-        let getStartBackward point = 
-            point 
-            |> SnapshotColumnUtilLegacy.GetColumnsIncludingLineBreak SearchPath.Backward
+        let getStartBackward column = 
+            let seq = SnapshotColumn.GetColumns(column, SearchPath.Backward, includeLineBreaks = true)
+            seq
             |> Seq.skipWhile isNotStartColumn
-            |> Seq.map SnapshotColumnUtilLegacy.GetPoint
-            |> SeqUtil.headOrDefault (SnapshotPoint(snapshot, 0))
+            |> SeqUtil.headOrDefault (SnapshotColumn.GetStartColumn column.Snapshot)
 
         // Get the section start going forward from the given point 
-        let getStartForward point = 
-            point
-            |> SnapshotColumnUtilLegacy.GetColumnsIncludingLineBreak SearchPath.Forward
+        let getStartForward column = 
+            let seq = SnapshotColumn.GetColumns(column, SearchPath.Forward, includeLineBreaks = true)
+            seq
             |> Seq.skipWhile isNotStartColumn
-            |> Seq.map SnapshotColumnUtilLegacy.GetPoint
-            |> SeqUtil.headOrDefault (SnapshotUtil.GetEndPoint snapshot)
+            |> SeqUtil.headOrDefault (SnapshotColumn.GetEndColumn column.Snapshot)
 
         // Search includes the section which contains the start point so go ahead and get it
-        match path, SnapshotPointUtil.IsStartPoint point with 
+        match path, column.IsStartPoint with
         | SearchPath.Forward, _ ->
 
             // Get the next object.  The provided point should either be <end> or point 
             // to the start of a section
-            let getNext point = 
-                if SnapshotPointUtil.IsEndPoint point then
+            let getNext (column: SnapshotColumn) = 
+                if column.IsEndPoint then
                     None
                 else
-                    let column = SnapshotColumnLegacy(point)
                     let span = getSpanFromStartColumn column
-                    let startPoint = getStartForward span.End
+                    let startPoint = getStartForward (SnapshotColumn(span.End))
                     Some (span, startPoint)
 
             // Get the point to start the sequence from.  Need to be very careful though 
             // because it's possible for the first SnapshotSpan being completely before the 
             // provided SnapshotPoint.  This can happen for text objects which have white 
             // space chunks and the provided point 
-            let startPoint = 
-                let startPoint = getStartBackward point
-                let startColumn = SnapshotColumnLegacy(startPoint)
+            let startColumn = 
+                let startColumn = getStartBackward column
                 let span = getSpanFromStartColumn startColumn
-                if point.Position >= span.End.Position then
-                    let forwardPoint = getStartForward span.End
-                    if forwardPoint.Position > point.Position then
-                        startPoint
+                if column.StartPosition >= span.End.Position then
+                    let forwardColumn = getStartForward (SnapshotColumn(span.End))
+                    if forwardColumn.StartPosition > column.StartPosition then
+                        startColumn
                     else
-                        forwardPoint
+                        forwardColumn
                 else
-                    startPoint
-            Seq.unfold getNext startPoint
+                    startColumn
+            Seq.unfold getNext startColumn
         | SearchPath.Backward, true ->
             // Handle the special case here
             Seq.empty
@@ -515,13 +499,12 @@ type internal TextObjectUtil
 
             // Get the previous section.  The provided point should either be 0 or point
             // to the start of a section
-            let getPrevious point = 
-                if SnapshotPointUtil.IsStartPoint point then
+            let getPrevious (column: SnapshotColumn) = 
+                if column.IsStartPoint then
                     None
                 else
-                    let startPoint = point |> SnapshotPointUtil.SubtractOne |> getStartBackward
-                    let startColumn = SnapshotColumnLegacy(startPoint)
+                    let startColumn = getStartBackward (column.Subtract 1)
                     let span = getSpanFromStartColumn startColumn
-                    Some (span, startPoint)
+                    Some (span, startColumn)
 
-            Seq.unfold getPrevious point
+            Seq.unfold getPrevious column

--- a/Src/VimCore/TextObjectUtil.fsi
+++ b/Src/VimCore/TextObjectUtil.fsi
@@ -65,7 +65,7 @@ type internal TextObjectUtil =
     member GetSentences: sentenceKind: SentenceKind -> path: SearchPath -> point: SnapshotPoint -> SnapshotSpan seq
 
     /// Is the SnapshotPoint the start of a sentence 
-    member IsSentenceStart: sentenceKind: SentenceKind -> column: SnapshotColumn -> bool
+    member IsSentenceStart: sentenceKind: SentenceKind -> column: SnapshotColumnLegacy -> bool
 
     /// Is the SnapshotPoint in the white space between sentences
-    member IsSentenceWhiteSpace: sentenceKind: SentenceKind -> column: SnapshotColumn -> bool
+    member IsSentenceWhiteSpace: sentenceKind: SentenceKind -> column: SnapshotColumnLegacy -> bool

--- a/Src/VimCore/TextObjectUtil.fsi
+++ b/Src/VimCore/TextObjectUtil.fsi
@@ -47,7 +47,7 @@ type internal TextObjectUtil =
 
     /// Get the SnapshotSpan values for the paragraph object starting from the given SnapshotPoint
     /// in the specified direction.  
-    member GetParagraphs: path: SearchPath -> point: SnapshotPoint -> SnapshotSpan seq
+    member GetParagraphs: path: SearchPath -> column: SnapshotColumn -> SnapshotSpan seq
 
     /// Get the SnapshotLineRange values for the section values starting from the given SnapshotPoint 
     /// in the specified direction.  Note: The full span of the section will be returned if the 
@@ -62,10 +62,10 @@ type internal TextObjectUtil =
     /// Get the SnapshotSpan values for the sentence values starting from the given SnapshotPoint 
     /// in the specified direction.  Note: The full span of the section will be returned if the 
     /// provided SnapshotPoint is in the middle of it
-    member GetSentences: sentenceKind: SentenceKind -> path: SearchPath -> point: SnapshotPoint -> SnapshotSpan seq
+    member GetSentences: sentenceKind: SentenceKind -> path: SearchPath -> column: SnapshotColumn -> SnapshotSpan seq
 
     /// Is the SnapshotPoint the start of a sentence 
-    member IsSentenceStart: sentenceKind: SentenceKind -> column: SnapshotColumnLegacy -> bool
+    member IsSentenceStart: sentenceKind: SentenceKind -> column: SnapshotColumn -> bool
 
     /// Is the SnapshotPoint in the white space between sentences
-    member IsSentenceWhiteSpace: sentenceKind: SentenceKind -> column: SnapshotColumnLegacy -> bool
+    member IsSentenceWhiteSpace: sentenceKind: SentenceKind -> column: SnapshotColumn -> bool

--- a/Src/VimCore/VimCore.fsproj
+++ b/Src/VimCore/VimCore.fsproj
@@ -9,6 +9,7 @@
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="README.md" />
     <Compile Include="Resources.fs" />
     <Compile Include="Constants.fs" />
     <Compile Include="FSharpUtil.fs" />
@@ -122,6 +123,7 @@
     <Compile Include="FSharpExtensions.fs" />
     <Compile Include="AssemblyInfo.fs" />
   </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <!-- Using element form vs. attributes to work around NuGet restore bug
          https://github.com/NuGet/Home/issues/6367 

--- a/Src/VimEditorHost/EditorHost.cs
+++ b/Src/VimEditorHost/EditorHost.cs
@@ -59,6 +59,14 @@ namespace Vim.EditorHost
         }
 
         /// <summary>
+        /// Create an ITextBuffer instance with the given content
+        /// </summary>
+        public ITextBuffer CreateTextBufferRaw(string content, IContentType contentType = null)
+        {
+            return TextBufferFactoryService.CreateTextBufferRaw(content, contentType);
+        }
+
+        /// <summary>
         /// Create an ITextBuffer instance with the given lines
         /// </summary>
         public ITextBuffer CreateTextBuffer(params string[] lines)

--- a/Src/VimEditorHost/Extensions.cs
+++ b/Src/VimEditorHost/Extensions.cs
@@ -18,6 +18,23 @@ namespace Vim.EditorHost
         #region ITextBufferFactoryService
 
         /// <summary>
+        /// Create an ITextBuffer with the specified content
+        /// </summary>
+        public static ITextBuffer CreateTextBufferRaw(this ITextBufferFactoryService textBufferFactoryService, string content, IContentType contentType = null)
+        {
+            var textBuffer = contentType != null
+                ? textBufferFactoryService.CreateTextBuffer(contentType)
+                : textBufferFactoryService.CreateTextBuffer();
+
+            if (!string.IsNullOrEmpty(content))
+            {
+                textBuffer.Replace(new Span(0, 0), content);
+            }
+
+            return textBuffer;
+        }
+
+        /// <summary>
         /// Create an ITextBuffer with the specified lines
         /// </summary>
         public static ITextBuffer CreateTextBuffer(this ITextBufferFactoryService textBufferFactoryService, params string[] lines)

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -917,17 +917,23 @@ namespace Vim.UnitTest
             return GetLine(snapshot, snapshot.LineCount - 1);
         }
 
-        public static SnapshotColumn GetColumn(this ITextSnapshot snapshot, int position)
+        public static SnapshotCharacterSpan GetColumn(this ITextSnapshot snapshot, int position)
         {
             var point = new SnapshotPoint(snapshot, position);
-            return new SnapshotColumn(point);
+            return new SnapshotCharacterSpan(point);
         }
 
         #endregion
 
         #region ITextBuffer
 
-        public static SnapshotColumn GetColumn(this ITextBuffer textBuffer, int position)
+        public static SnapshotColumnLegacy GetColumnLegacy(this ITextBuffer textBuffer, int position)
+        {
+            var column = GetColumn(textBuffer, position);
+            return new SnapshotColumnLegacy(column.StartPoint);
+        }
+
+        public static SnapshotCharacterSpan GetColumn(this ITextBuffer textBuffer, int position)
         {
             return GetColumn(textBuffer.CurrentSnapshot, position);
         }
@@ -1643,9 +1649,9 @@ namespace Vim.UnitTest
             return view.Caret.Position.VirtualBufferPosition;
         }
 
-        public static SnapshotColumn GetCaretColumn(this ITextView textView)
+        public static SnapshotColumnLegacy GetCaretColumn(this ITextView textView)
         {
-            return new SnapshotColumn(textView.GetCaretPoint());
+            return new SnapshotColumnLegacy(textView.GetCaretPoint());
         }
 
         public static SnapshotSpan GetSelectionSpan(this ITextView textView)
@@ -1713,9 +1719,9 @@ namespace Vim.UnitTest
             return true;
         }
 
-        public static SnapshotColumn GetColumn(this SnapshotPoint point)
+        public static SnapshotColumnLegacy GetColumn(this SnapshotPoint point)
         {
-            return new SnapshotColumn(point);
+            return new SnapshotColumnLegacy(point);
         }
 
         /// <summary>

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -917,10 +917,10 @@ namespace Vim.UnitTest
             return GetLine(snapshot, snapshot.LineCount - 1);
         }
 
-        public static SnapshotCharacterSpan GetColumn(this ITextSnapshot snapshot, int position)
+        public static SnapshotColumn GetColumn(this ITextSnapshot snapshot, int position)
         {
             var point = new SnapshotPoint(snapshot, position);
-            return new SnapshotCharacterSpan(point);
+            return new SnapshotColumn(point);
         }
 
         #endregion
@@ -933,7 +933,7 @@ namespace Vim.UnitTest
             return new SnapshotColumnLegacy(column.StartPoint);
         }
 
-        public static SnapshotCharacterSpan GetColumn(this ITextBuffer textBuffer, int position)
+        public static SnapshotColumn GetColumn(this ITextBuffer textBuffer, int position)
         {
             return GetColumn(textBuffer.CurrentSnapshot, position);
         }

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -917,9 +917,21 @@ namespace Vim.UnitTest
             return GetLine(snapshot, snapshot.LineCount - 1);
         }
 
-        public static SnapshotColumn GetColumn(this ITextSnapshot snapshot, int position)
+        public static SnapshotColumn GetColumnFromPosition(this ITextSnapshot snapshot, int position)
         {
             var point = new SnapshotPoint(snapshot, position);
+            return new SnapshotColumn(point);
+        }
+
+        public static SnapshotColumn GetEndColumn(this ITextSnapshot snapshot)
+        {
+            var point = new SnapshotPoint(snapshot, snapshot.Length);
+            return new SnapshotColumn(point);
+        }
+
+        public static SnapshotColumn GetStartColumn(this ITextSnapshot snapshot)
+        {
+            var point = new SnapshotPoint(snapshot, 0);
             return new SnapshotColumn(point);
         }
 
@@ -929,13 +941,13 @@ namespace Vim.UnitTest
 
         public static SnapshotColumnLegacy GetColumnLegacy(this ITextBuffer textBuffer, int position)
         {
-            var column = GetColumn(textBuffer, position);
+            var column = GetColumnFromPosition(textBuffer, position);
             return new SnapshotColumnLegacy(column.StartPoint);
         }
 
-        public static SnapshotColumn GetColumn(this ITextBuffer textBuffer, int position)
+        public static SnapshotColumn GetColumnFromPosition(this ITextBuffer textBuffer, int position)
         {
-            return GetColumn(textBuffer.CurrentSnapshot, position);
+            return GetColumnFromPosition(textBuffer.CurrentSnapshot, position);
         }
 
         public static SnapshotPoint GetStartPoint(this ITextBuffer textBuffer)
@@ -1719,9 +1731,14 @@ namespace Vim.UnitTest
             return true;
         }
 
-        public static SnapshotColumnLegacy GetColumn(this SnapshotPoint point)
+        public static SnapshotColumnLegacy GetColumnLegacy(this SnapshotPoint point)
         {
             return new SnapshotColumnLegacy(point);
+        }
+
+        public static SnapshotColumn GetColumn(this SnapshotPoint point)
+        {
+            return new SnapshotColumn(point);
         }
 
         /// <summary>

--- a/Src/VimTestUtils/VimTestBase.cs
+++ b/Src/VimTestUtils/VimTestBase.cs
@@ -382,6 +382,11 @@ namespace Vim.UnitTest
             return builder.ToString();
         }
 
+        public ITextBuffer CreateTextBufferRaw(string content)
+        {
+            return _vimEditorHost.CreateTextBufferRaw(content);
+        }
+
         public ITextBuffer CreateTextBuffer(params string[] lines)
         {
             return _vimEditorHost.CreateTextBuffer(lines);

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -1706,12 +1706,12 @@ namespace Vim.UnitTest
 
                 Assert.Equal("dug", _textView.GetLine(1).GetText());
 
-                Assert.Equal(0, _textView.Caret.Position.BufferPosition.GetColumn().Column);
+                Assert.Equal(0, _textView.Caret.Position.BufferPosition.GetColumnLegacy().Column);
                 Assert.Equal(0, _textView.GetCaretLine().LineNumber);
 
                 _vimBuffer.ProcessNotation("`.");
 
-                Assert.Equal(1, _textView.Caret.Position.BufferPosition.GetColumn().Column);
+                Assert.Equal(1, _textView.Caret.Position.BufferPosition.GetColumnLegacy().Column);
                 Assert.Equal(1, _textView.GetCaretLine().LineNumber);
             }
 

--- a/Test/VimCoreTest/CommonOperationsIntegrationTest.cs
+++ b/Test/VimCoreTest/CommonOperationsIntegrationTest.cs
@@ -300,14 +300,14 @@ namespace Vim.UnitTest
                 [WpfFact]
                 public void Simple()
                 {
-                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 8), _textBuffer.GetColumn(0));
+                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 8), _textBuffer.GetColumnFromPosition(0));
                     Assert.Equal("\t\t", text);
                 }
 
                 [WpfFact]
                 public void ExtraSpacesAtEnd()
                 {
-                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 6), _textBuffer.GetColumn(0));
+                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 6), _textBuffer.GetColumnFromPosition(0));
                     Assert.Equal("\t  ", text);
                 }
 
@@ -315,7 +315,7 @@ namespace Vim.UnitTest
                 public void NonTabBoundary()
                 {
                     _textBuffer.SetText("a");
-                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 8), _textBuffer.GetColumn(1));
+                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 8), _textBuffer.GetColumnFromPosition(1));
                     Assert.Equal("\t\t ", text);
                 }
 
@@ -323,7 +323,7 @@ namespace Vim.UnitTest
                 public void NonTabBoundaryExactTabPlusTab()
                 {
                     _textBuffer.SetText("a");
-                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 7), _textBuffer.GetColumn(1));
+                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 7), _textBuffer.GetColumnFromPosition(1));
                     Assert.Equal("\t\t", text);
                 }
 
@@ -331,14 +331,14 @@ namespace Vim.UnitTest
                 public void NonTabBoundaryExactTab()
                 {
                     _textBuffer.SetText("a");
-                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 3), _textBuffer.GetColumn(1));
+                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 3), _textBuffer.GetColumnFromPosition(1));
                     Assert.Equal("\t", text);
                 }
 
                 [WpfFact]
                 public void NotEnoughSpaces()
                 {
-                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 3), _textBuffer.GetColumn(0));
+                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 3), _textBuffer.GetColumnFromPosition(0));
                     Assert.Equal("   ", text);
                 }
 
@@ -346,7 +346,7 @@ namespace Vim.UnitTest
                 public void NonTabBoundaryWithTabs()
                 {
                     _textBuffer.SetText("a");
-                    var text = _commonOperations.NormalizeBlanksAtColumn("\t\t", _textBuffer.GetColumn(1));
+                    var text = _commonOperations.NormalizeBlanksAtColumn("\t\t", _textBuffer.GetColumnFromPosition(1));
                     Assert.Equal("\t\t", text);
                 }
             }
@@ -364,7 +364,7 @@ namespace Vim.UnitTest
                 public void ExactToTabBoundary()
                 {
                     _textBuffer.SetText("a");
-                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 3), _textBuffer.GetColumn(1));
+                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 3), _textBuffer.GetColumnFromPosition(1));
                     Assert.Equal(new string(' ', 3), text);
                 }
 
@@ -372,7 +372,7 @@ namespace Vim.UnitTest
                 public void OneOverTabBoundary()
                 {
                     _textBuffer.SetText("a");
-                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 4), _textBuffer.GetColumn(1));
+                    var text = _commonOperations.NormalizeBlanksAtColumn(new string(' ', 4), _textBuffer.GetColumnFromPosition(1));
                     Assert.Equal(new string(' ', 4), text);
                 }
             }

--- a/Test/VimCoreTest/CommonOperationsTest.cs
+++ b/Test/VimCoreTest/CommonOperationsTest.cs
@@ -1155,7 +1155,7 @@ namespace Vim.UnitTest
             {
                 Create("hello world");
                 _operations.NavigateToPoint(new VirtualSnapshotPoint(_textBuffer.GetPoint(3)));
-                Assert.Equal(3, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(3, _textView.GetCaretPoint().GetColumnLegacy().Column);
             }
 
             /// <summary>

--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -75,6 +75,20 @@ namespace Vim.UnitTest
                 _vimBuffer.ProcessNotation("<C-y>");
                 Assert.Equal(1, VimHost.BeepCount);
             }
+
+            [WpfFact]
+            public void UnicodeCharacter()
+            {
+                const string alien = "\U0001F47D"; // 👽
+                Create($"{alien}{alien}cat", "");
+                _textView.MoveCaretToLine(1);
+                _vimBuffer.ProcessNotation("<C-y>");
+                Assert.Equal($"{alien}", _textBuffer.GetLineText(1));
+                Assert.Equal(_textBuffer.GetPointInLine(line: 1, column: 2), _textView.GetCaretPoint());
+                _vimBuffer.ProcessNotation("<C-y>");
+                Assert.Equal($"{alien}{alien}", _textBuffer.GetLineText(1));
+                Assert.Equal(_textBuffer.GetPointInLine(line: 1, column: 4), _textView.GetCaretPoint());
+            }
         }
 
         public sealed class InsertCharacterBelowTest : InsertModeIntegrationTest

--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -603,12 +603,12 @@ namespace Vim.UnitTest
 
                 Assert.Equal("dog bird", _textView.GetLine(1).GetText());
 
-                Assert.Equal(0, _textView.Caret.Position.BufferPosition.GetColumn().Column);
+                Assert.Equal(0, _textView.Caret.Position.BufferPosition.GetColumnLegacy().Column);
                 Assert.Equal(0, _textView.GetCaretLine().LineNumber);
 
                 _vimBuffer.ProcessNotation("`.");
 
-                Assert.Equal(7, _textView.Caret.Position.BufferPosition.GetColumn().Column);
+                Assert.Equal(7, _textView.Caret.Position.BufferPosition.GetColumnLegacy().Column);
                 Assert.Equal(1, _textView.GetCaretLine().LineNumber);
             }
 
@@ -1833,7 +1833,7 @@ namespace Vim.UnitTest
                 _textView.MoveCaretToLine(1);
                 _vimBuffer.Process("3.");
                 Assert.Equal("hhh", _textView.GetLine(1).GetText());
-                Assert.Equal(2, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(2, _textView.GetCaretPoint().GetColumnLegacy().Column);
             }
 
             /// <summary>
@@ -1851,7 +1851,7 @@ namespace Vim.UnitTest
                 _textView.MoveCaretToLine(1);
                 _vimBuffer.Process("3.");
                 Assert.Equal("hhha", _textView.GetLine(1).GetText());
-                Assert.Equal(2, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(2, _textView.GetCaretPoint().GetColumnLegacy().Column);
             }
 
             /// <summary>

--- a/Test/VimCoreTest/InsertUtilTest.cs
+++ b/Test/VimCoreTest/InsertUtilTest.cs
@@ -387,7 +387,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineLeft();
 
                 Assert.Equal("    ", _textView.GetLine(0).GetText());
-                Assert.Equal(4, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(4, _insertUtilRaw.CaretColumn.ColumnNumber);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
@@ -407,7 +407,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineLeft();
 
                 Assert.Equal("  foo", _textView.GetLine(0).GetText());
-                Assert.Equal(2, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(2, _insertUtilRaw.CaretColumn.ColumnNumber);
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
             }
 
@@ -427,7 +427,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineRight();
 
                 Assert.Equal("            ", _textView.GetLine(0).GetText());
-                Assert.Equal(12, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(12, _insertUtilRaw.CaretColumn.ColumnNumber);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
@@ -451,7 +451,7 @@ namespace Vim.UnitTest
                 var text = _textView.GetLine(0).GetText();
                 Assert.Equal(indent.Length, text.Length);
                 Assert.Equal(indent, text);
-                Assert.Equal(8, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(8, _insertUtilRaw.CaretColumn.ColumnNumber);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
@@ -472,7 +472,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineRight();
 
                 Assert.Equal("\t    ", _textView.GetLine(0).GetText());
-                Assert.Equal(5, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(5, _insertUtilRaw.CaretColumn.ColumnNumber);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
@@ -489,7 +489,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineRight();
 
                 Assert.Equal("    ", _textView.GetLine(0).GetText());
-                Assert.Equal(4, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(4, _insertUtilRaw.CaretColumn.ColumnNumber);
             }
 
             /// <summary>
@@ -505,7 +505,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineRight();
 
                 Assert.Equal("    abc", _textView.GetLine(0).GetText());
-                Assert.Equal(4, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(4, _insertUtilRaw.CaretColumn.ColumnNumber);
             }
         }
 
@@ -532,7 +532,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineLeft();
 
                 Assert.Equal("    ", _textView.GetLine(0).GetText());
-                Assert.Equal(4, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(4, _insertUtilRaw.CaretColumn.ColumnNumber);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
@@ -552,7 +552,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineLeft();
 
                 Assert.Equal("  foo", _textView.GetLine(0).GetText());
-                Assert.Equal(2, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(2, _insertUtilRaw.CaretColumn.ColumnNumber);
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
             }
 
@@ -572,7 +572,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineRight();
 
                 Assert.Equal("            ", _textView.GetLine(0).GetText());
-                Assert.Equal(12, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(12, _insertUtilRaw.CaretColumn.ColumnNumber);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
@@ -593,7 +593,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineRight();
 
                 Assert.Equal("            ", _textView.GetLine(0).GetText());
-                Assert.Equal(12, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(12, _insertUtilRaw.CaretColumn.ColumnNumber);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
@@ -614,7 +614,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineRight();
 
                 Assert.Equal("\t    ", _textView.GetLine(0).GetText());
-                Assert.Equal(5, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(5, _insertUtilRaw.CaretColumn.ColumnNumber);
                 Assert.False(_textView.Caret.InVirtualSpace);
                 // probably redundant, but we just want to be sure...
                 Assert.Equal(0, _textView.Caret.Position.VirtualSpaces);
@@ -631,7 +631,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineRight();
 
                 Assert.Equal("    ", _textView.GetLine(0).GetText());
-                Assert.Equal(4, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(4, _insertUtilRaw.CaretColumn.ColumnNumber);
             }
 
             /// <summary>
@@ -647,7 +647,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.ShiftLineRight();
 
                 Assert.Equal("    abc", _textView.GetLine(0).GetText());
-                Assert.Equal(4, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(4, _insertUtilRaw.CaretColumn.ColumnNumber);
             }
         }
 
@@ -661,7 +661,7 @@ namespace Vim.UnitTest
 
                 _insertUtilRaw.MoveCaretByWord(Direction.Left);
 
-                Assert.Equal(5, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(5, _insertUtilRaw.CaretColumn.ColumnNumber);
             }
 
             [WpfFact]
@@ -673,7 +673,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.MoveCaretByWord(Direction.Left);
                 _insertUtilRaw.MoveCaretByWord(Direction.Left);
 
-                Assert.Equal(0, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(0, _insertUtilRaw.CaretColumn.ColumnNumber);
             }
 
             [WpfFact]
@@ -684,7 +684,7 @@ namespace Vim.UnitTest
 
                 _insertUtilRaw.MoveCaretByWord(Direction.Right);
 
-                Assert.Equal(10, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(10, _insertUtilRaw.CaretColumn.ColumnNumber);
             }
 
             [WpfFact]
@@ -696,7 +696,7 @@ namespace Vim.UnitTest
                 _insertUtilRaw.MoveCaretByWord(Direction.Right);
                 _insertUtilRaw.MoveCaretByWord(Direction.Right);
 
-                Assert.Equal(14, _insertUtilRaw.CaretColumn.Column);
+                Assert.Equal(14, _insertUtilRaw.CaretColumn.ColumnNumber);
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/MotionUtilTest.cs
+++ b/Test/VimCoreTest/MotionUtilTest.cs
@@ -3390,7 +3390,7 @@ more";
             public void GetSentences1()
             {
                 Create("a. b.");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[] { "a.", "b." },
                     ret.Select(x => x.GetText()).ToList());
@@ -3400,7 +3400,7 @@ more";
             public void GetSentences2()
             {
                 Create("a! b.");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[] { "a!", "b." },
                     ret.Select(x => x.GetText()).ToList());
@@ -3410,7 +3410,7 @@ more";
             public void GetSentences3()
             {
                 Create("a? b.");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[] { "a?", "b." },
                     ret.Select(x => x.GetText()).ToList());
@@ -3420,7 +3420,7 @@ more";
             public void GetSentences4()
             {
                 Create("a? b.");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetEndPoint());
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetEndColumn());
                 Assert.Equal(
                     new string[] { },
                     ret.Select(x => x.GetText()).ToList());
@@ -3433,7 +3433,7 @@ more";
             public void GetSentences_BackwardFromEndOfBuffer()
             {
                 Create("a? b.");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Backward, _snapshot.GetEndPoint());
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Backward, _snapshot.GetEndColumn());
                 Assert.Equal(
                     new[] { "b.", "a?" },
                     ret.Select(x => x.GetText()).ToList());
@@ -3447,7 +3447,7 @@ more";
             public void GetSentences_BackwardFromSingleWhitespace()
             {
                 Create("a? b.");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Backward, _snapshot.GetPoint(2));
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Backward, _snapshot.GetColumnFromPosition(2));
                 Assert.Equal(
                     new[] { "a?" },
                     ret.Select(x => x.GetText()).ToList());
@@ -3460,7 +3460,7 @@ more";
             public void GetSentences_ManyTrailingChars()
             {
                 Create("a?)]' b.");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[] { "a?)]'", "b." },
                     ret.Select(x => x.GetText()).ToList());
@@ -3473,7 +3473,7 @@ more";
             public void GetSentences_BackwardWithCharBetween()
             {
                 Create("a?) b.");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Backward, _snapshot.GetEndPoint());
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Backward, _snapshot.GetEndColumn());
                 Assert.Equal(
                     new[] { "b.", "a?)" },
                     ret.Select(x => x.GetText()).ToList());
@@ -3486,7 +3486,7 @@ more";
             public void GetSentences_NeedSpaceAfterEndCharacter()
             {
                 Create("a!b. c");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[] { "a!b.", "c" },
                     ret.Select(x => x.GetText()).ToList());
@@ -3500,7 +3500,7 @@ more";
             public void GetSentences_IncompleteBoundary()
             {
                 Create("a!b. c");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Backward, _snapshot.GetEndPoint());
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Backward, _snapshot.GetEndColumn());
                 Assert.Equal(
                     new[] { "c", "a!b." },
                     ret.Select(x => x.GetText()).ToList());
@@ -3515,7 +3515,7 @@ more";
             public void GetSentences_ForwardBlankLinesAreBoundaries()
             {
                 Create("a", "", "", "b");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[]
                 {
@@ -3533,7 +3533,7 @@ more";
             public void GetSentences_FromMiddleOfWord()
             {
                 Create("dog", "cat", "bear");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetEndPoint().Subtract(1));
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _snapshot.GetEndColumn().Subtract(1));
                 Assert.Equal(
                     new[] { "dog" + Environment.NewLine + "cat" + Environment.NewLine + "bear" },
                     ret.Select(x => x.GetText()).ToList());
@@ -3547,7 +3547,7 @@ more";
             public void GetSentences_BackwardFromStartOfSentence()
             {
                 Create("dog. cat");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Backward, _textBuffer.GetPoint(4));
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Backward, _textBuffer.GetColumnFromPosition(4));
                 Assert.Equal(
                     new[] { "dog." },
                     ret.Select(x => x.GetText()).ToList());
@@ -3560,7 +3560,7 @@ more";
             public void GetSentences_BlankLinesAreSentences()
             {
                 Create("dog.  ", "", "cat.");
-                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _textBuffer.GetPoint(0));
+                var ret = _motionUtil.GetSentences(SentenceKind.Default, SearchPath.Forward, _textBuffer.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[] { "dog.", Environment.NewLine, "cat." },
                     ret.Select(x => x.GetText()).ToList());
@@ -3570,7 +3570,7 @@ more";
             public void GetParagraphs_SingleBreak()
             {
                 Create("a", "b", "", "c");
-                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[]
                 {
@@ -3588,7 +3588,7 @@ more";
             public void GetParagraphs_ConsequtiveBreaks()
             {
                 Create("a", "b", "", "", "c");
-                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[]
                 {
@@ -3605,7 +3605,7 @@ more";
             public void GetParagraphs_FormFeedShouldBeBoundary()
             {
                 Create("a", "b", "\f", "", "c");
-                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[]
                 {
@@ -3624,7 +3624,7 @@ more";
             public void GetParagraphs_FormFeedIsNotConsequtive()
             {
                 Create("a", "b", "\f", "", "c");
-                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[]
                 {
@@ -3643,7 +3643,7 @@ more";
             {
                 Create("a", ".hh", "bear");
                 _globalSettings.Paragraphs = "hh";
-                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[]
                 {
@@ -3661,7 +3661,7 @@ more";
             {
                 Create("a", ".j", "bear");
                 _globalSettings.Paragraphs = "hhj ";
-                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetPoint(0));
+                var ret = _motionUtil.GetParagraphs(SearchPath.Forward, _snapshot.GetColumnFromPosition(0));
                 Assert.Equal(
                     new[]
                 {

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -150,7 +150,7 @@ namespace Vim.UnitTest
             {
                 Create("  dog");
                 _vimBuffer.Process("_");
-                Assert.Equal(2, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(2, _textView.GetCaretPoint().GetColumnLegacy().Column);
             }
 
             /// <summary>
@@ -4724,7 +4724,7 @@ namespace Vim.UnitTest
             {
                 Create("cat", "tree", "horse", "racoon");
                 _vimBuffer.ProcessNotation("$");
-                Assert.Equal(2, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(2, _textView.GetCaretPoint().GetColumnLegacy().Column);
                 _vimBuffer.ProcessNotation("j");
                 Assert.Equal(3, _textView.GetCaretPoint().GetColumn().Column);
                 _vimBuffer.ProcessNotation("j");
@@ -4739,7 +4739,7 @@ namespace Vim.UnitTest
                 Create("racoon", "horse", "tree", "cat");
                 _textView.MoveCaretToLine(3);
                 _vimBuffer.ProcessNotation("$");
-                Assert.Equal(2, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(2, _textView.GetCaretPoint().GetColumnLegacy().Column);
                 _vimBuffer.ProcessNotation("k");
                 Assert.Equal(3, _textView.GetCaretPoint().GetColumn().Column);
                 _vimBuffer.ProcessNotation("k");
@@ -4760,9 +4760,9 @@ namespace Vim.UnitTest
                 _globalSettings.VirtualEdit = "onemore";
                 Assert.True(_globalSettings.IsVirtualEditOneMore);
                 _vimBuffer.ProcessNotation("$");
-                Assert.Equal(2, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(2, _textView.GetCaretPoint().GetColumnLegacy().Column);
                 _vimBuffer.ProcessNotation("j");
-                Assert.Equal(3, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(3, _textView.GetCaretPoint().GetColumnLegacy().Column);
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -4726,11 +4726,11 @@ namespace Vim.UnitTest
                 _vimBuffer.ProcessNotation("$");
                 Assert.Equal(2, _textView.GetCaretPoint().GetColumnLegacy().Column);
                 _vimBuffer.ProcessNotation("j");
-                Assert.Equal(3, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(3, _textView.GetCaretPoint().GetColumn().ColumnNumber);
                 _vimBuffer.ProcessNotation("j");
-                Assert.Equal(4, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(4, _textView.GetCaretPoint().GetColumn().ColumnNumber);
                 _vimBuffer.ProcessNotation("j");
-                Assert.Equal(5, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(5, _textView.GetCaretPoint().GetColumn().ColumnNumber);
             }
 
             [WpfFact]
@@ -4741,11 +4741,11 @@ namespace Vim.UnitTest
                 _vimBuffer.ProcessNotation("$");
                 Assert.Equal(2, _textView.GetCaretPoint().GetColumnLegacy().Column);
                 _vimBuffer.ProcessNotation("k");
-                Assert.Equal(3, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(3, _textView.GetCaretPoint().GetColumn().ColumnNumber);
                 _vimBuffer.ProcessNotation("k");
-                Assert.Equal(4, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(4, _textView.GetCaretPoint().GetColumn().ColumnNumber);
                 _vimBuffer.ProcessNotation("k");
-                Assert.Equal(5, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(5, _textView.GetCaretPoint().GetColumn().ColumnNumber);
             }
 
             /// <summary>

--- a/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
+++ b/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
@@ -1,0 +1,119 @@
+﻿using Microsoft.VisualStudio.Text;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using Vim.EditorHost;
+
+namespace Vim.UnitTest
+{
+    public abstract class SnapshotCharacterSpanTest : VimTestBase
+    {
+        private ITextBuffer _textBuffer;
+
+        private void Create(params string[] lines)
+        {
+            _textBuffer = CreateTextBuffer(lines);
+        }
+
+        public sealed class AddSubtractTest : SnapshotCharacterSpanTest
+        {
+            [WpfFact]
+            public void AddSameLine()
+            {
+                Create("cat", "dog", "fish");
+                var original = new SnapshotCharacterSpan(_textBuffer.GetPoint(0));
+                var column = original.Add(1);
+                Assert.Equal(1, column.ColumnNumber);
+                Assert.Equal(0, column.LineNumber);
+            }
+
+            [WpfFact]
+            public void AddNextLine()
+            {
+                Create("cat", "dog", "fish");
+                var original = new SnapshotCharacterSpan(_textBuffer.GetPoint(0));
+                var column = original.Add(4);
+                Assert.Equal(0, column.ColumnNumber);
+                Assert.Equal(1, column.LineNumber);
+            }
+
+            [WpfFact]
+            public void AddBeforeLine()
+            {
+                Create("cat", "dog", "fish");
+                var original = new SnapshotCharacterSpan(_textBuffer.GetLine(1).Start);
+                var column = original.Add(-2);
+                Assert.Equal(2, column.ColumnNumber);
+                Assert.Equal(0, column.LineNumber);
+            }
+
+            [WpfFact]
+            public void SubtractSameLine()
+            {
+                Create("cat", "dog", "fish");
+                var original = new SnapshotCharacterSpan(_textBuffer.GetPoint(1));
+                var column = original.Subtract(1);
+                Assert.Equal(0, column.ColumnNumber);
+                Assert.Equal(0, column.LineNumber);
+            }
+
+            [WpfFact]
+            public void SubtractBeforeLine()
+            {
+                Create("cat", "dog", "fish");
+                var original = new SnapshotCharacterSpan(_textBuffer.GetLine(1).Start);
+                var column = original.Subtract(2);
+                Assert.Equal(2, column.ColumnNumber);
+                Assert.Equal(0, column.LineNumber);
+            }
+        }
+
+        public sealed class Ctor : SnapshotCharacterSpanTest
+        {
+            [WpfFact]
+            public void PointSimple()
+            {
+                Create("cat", "dog");
+                var point = _textBuffer.GetPoint(1);
+                var column = new SnapshotCharacterSpan(point);
+                Assert.Equal(0, column.LineNumber);
+                Assert.Equal(1, column.ColumnNumber);
+                Assert.False(column.IsLineBreak);
+            }
+
+            [WpfFact]
+            public void PointInsideLineBreak()
+            {
+                Create("cat", "dog");
+                var point = _textBuffer.GetPoint(_textBuffer.GetLine(0).End);
+                var column = new SnapshotCharacterSpan(point);
+                Assert.Equal(0, column.LineNumber);
+                Assert.Equal(3, column.ColumnNumber);
+                Assert.True(column.IsLineBreak);
+                Assert.Equal("cat", column.Line.GetText());
+            }
+        }
+
+        public sealed class SurrogatePairs : SnapshotCharacterSpanTest
+        {
+            [WpfFact]
+            public void SurrogatePair()
+            {
+                // Extraterrestrial alien emoji from issue #1786.
+                Create("'\U0001F47D'", "");
+                Assert.Equal(6, _textBuffer.GetLine(0).ExtentIncludingLineBreak.GetText().Length);
+                var column = new SnapshotCharacterSpan(_textBuffer.GetLine(0).Start);
+                Assert.Equal(4, column.ColumnCountIncludingLineBreak);
+                Assert.Equal(1, column.Width);
+                column = new SnapshotCharacterSpan(column, 1);
+                Assert.Equal(2, column.Width);
+                column = new SnapshotCharacterSpan(column, 2);
+                Assert.Equal(1, column.Width);
+                column = new SnapshotCharacterSpan(column, 3);
+                Assert.Equal(Environment.NewLine.Length, column.Width);
+            }
+        }
+    }
+}

--- a/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
+++ b/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
@@ -17,6 +17,11 @@ namespace Vim.UnitTest
             _textBuffer = CreateTextBuffer(lines);
         }
 
+        private void CreateRaw(string content)
+        {
+            _textBuffer = CreateTextBufferRaw(content);
+        }
+
         public sealed class AddSubtractTest : SnapshotCharacterSpanTest
         {
             [WpfFact]
@@ -29,10 +34,12 @@ namespace Vim.UnitTest
                 Assert.Equal(0, column.LineNumber);
             }
 
-            [WpfFact]
-            public void AddNextLine()
+            [WpfTheory]
+            [InlineData("\n")]
+            [InlineData("\r\n")]
+            public void AddNextLine(string lineBreakText)
             {
-                Create("cat", "dog", "fish");
+                CreateRaw("cat" + lineBreakText + "dog" + lineBreakText + "fish");
                 var original = new SnapshotCharacterSpan(_textBuffer.GetPoint(0));
                 var column = original.Add(4);
                 Assert.Equal(0, column.ColumnNumber);
@@ -59,10 +66,12 @@ namespace Vim.UnitTest
                 Assert.Equal(0, column.LineNumber);
             }
 
-            [WpfFact]
-            public void SubtractBeforeLine()
+            [WpfTheory]
+            [InlineData("\n")]
+            [InlineData("\r\n")]
+            public void SubtractBeforeLine(string lineBreakText)
             {
-                Create("cat", "dog", "fish");
+                CreateRaw("cat" +lineBreakText + "dog" + lineBreakText + "fish");
                 var original = new SnapshotCharacterSpan(_textBuffer.GetLine(1).Start);
                 var column = original.Subtract(2);
                 Assert.Equal(2, column.ColumnNumber);
@@ -93,6 +102,15 @@ namespace Vim.UnitTest
                 Assert.Equal(3, column.ColumnNumber);
                 Assert.True(column.IsLineBreak);
                 Assert.Equal("cat", column.Line.GetText());
+            }
+
+            [WpfFact]
+            public void EndPoint()
+            {
+                Create("cat");
+                var point = _textBuffer.GetEndPoint();
+                var characterSpan = new SnapshotCharacterSpan(point);
+                Assert.True(characterSpan.Point.Position == _textBuffer.CurrentSnapshot.Length);
             }
         }
 

--- a/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
+++ b/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
@@ -8,11 +8,10 @@ using Vim.EditorHost;
 
 namespace Vim.UnitTest
 {
-    // TOOD: need to test specifying a point that is the second character of a line break
-    // TODO: Consider removing position Apis and replace with start and end 
-    // TODO: rename width to length
-    // TODO: test add past end
-    // TODO: test subtract before start
+    // CTODO: need to test specifying a point that is the second character of a line break
+    // CTODO: Consider removing position Apis and replace with start and end 
+    // CTODO: test add past end
+    // CTODO: test subtract before start
     public abstract class SnapshotCharacterSpanTest : VimTestBase
     {
         private ITextBuffer _textBuffer;
@@ -115,13 +114,13 @@ namespace Vim.UnitTest
                 var i = letters.Length - 2;
                 var point = new SnapshotCharacterSpan(_textBuffer.GetEndPoint());
                 point = point.Subtract(2);
-                while (point.Point.Position != 0)
+                while (!point.IsStartPoint)
                 {
                     Assert.True(point.IsLineBreak);
                     point = point.Subtract(1);
                     Assert.Equal(letters[i], point.GetText());
 
-                    if (point.Point.Position != 0)
+                    if (!point.IsStartPoint)
                     {
                         point = point.Subtract(1);
                         i--;
@@ -161,7 +160,7 @@ namespace Vim.UnitTest
                 Create("cat");
                 var point = _textBuffer.GetEndPoint();
                 var characterSpan = new SnapshotCharacterSpan(point);
-                Assert.True(characterSpan.Point.Position == _textBuffer.CurrentSnapshot.Length);
+                Assert.True(characterSpan.StartPoint.Position == _textBuffer.CurrentSnapshot.Length);
             }
         }
     }

--- a/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
+++ b/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
@@ -13,7 +13,7 @@ namespace Vim.UnitTest
     // CTODO: Consider removing position Apis and replace with start and end 
     // CTODO: test add past end
     // CTODO: test subtract before start
-    public abstract class SnapshotCharacterSpanTest : VimTestBase
+    public abstract class SnapshotColumnTest : VimTestBase
     {
         private ITextBuffer _textBuffer;
 
@@ -27,7 +27,7 @@ namespace Vim.UnitTest
             _textBuffer = CreateTextBufferRaw(content);
         }
 
-        public sealed class AddSubtractTest : SnapshotCharacterSpanTest
+        public sealed class AddSubtractTest : SnapshotColumnTest
         {
             [WpfFact]
             public void AddSameLine()
@@ -150,7 +150,7 @@ namespace Vim.UnitTest
             }
         }
 
-        public sealed class TryAddInSameLineTest : SnapshotCharacterSpanTest
+        public sealed class TryAddInSameLineTest : SnapshotColumnTest
         {
             [WpfFact]
             public void ToLineBreak()
@@ -183,7 +183,7 @@ namespace Vim.UnitTest
             }
         }
 
-        public sealed class Ctor : SnapshotCharacterSpanTest
+        public sealed class Ctor : SnapshotColumnTest
         {
             [WpfFact]
             public void PointSimple()
@@ -217,7 +217,7 @@ namespace Vim.UnitTest
                 Assert.True(characterSpan.StartPoint.Position == _textBuffer.CurrentSnapshot.Length);
             }
         }
-        public sealed class MiscTest : SnapshotCharacterSpanTest
+        public sealed class MiscTest : SnapshotColumnTest
         {
             [WpfFact]
             public void EndPoint()

--- a/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
+++ b/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
@@ -217,6 +217,36 @@ namespace Vim.UnitTest
                 Assert.True(characterSpan.StartPoint.Position == _textBuffer.CurrentSnapshot.Length);
             }
         }
+
+        public sealed class TryCreateTests : SnapshotColumnTest
+        {
+            [WpfFact]
+            public void TryCreateLineNegative()
+            {
+                Create("cat");
+                var column = SnapshotColumn.TryCreateForLineAndColumnNumber(_textBuffer.CurrentSnapshot, -1, -1, FSharpOption.False);
+                Assert.True(column.IsNone());
+            }
+
+            [WpfFact]
+            public void TryCreateColumnSimple()
+            {
+                Create("cat");
+                var column = SnapshotColumn.TryCreateForLineAndColumnNumber(_textBuffer.CurrentSnapshot, lineNumber: 0, columnNumber: 1, includeLineBreak: FSharpOption.False);
+                Assert.True(column.IsSome(x => x.IsCharacter('a')));
+            }
+
+            [WpfFact]
+            public void EmptyLineIsLineBreak()
+            {
+                Create("", "dog");
+                var column = SnapshotColumn.TryCreateForLineAndColumnNumber(_textBuffer.CurrentSnapshot, lineNumber: 0, columnNumber: 0, includeLineBreak: FSharpOption.False);
+                Assert.True(column.IsNone());
+                column = SnapshotColumn.TryCreateForLineAndColumnNumber(_textBuffer.CurrentSnapshot, lineNumber: 0, columnNumber: 0, includeLineBreak: FSharpOption.True);
+                Assert.True(column.IsSome(x => x.IsLineBreak));
+            }
+        }
+
         public sealed class MiscTest : SnapshotColumnTest
         {
             [WpfFact]

--- a/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
+++ b/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
@@ -115,13 +115,13 @@ namespace Vim.UnitTest
                 var i = letters.Length - 2;
                 var point = new SnapshotColumn(_textBuffer.GetEndPoint());
                 point = point.Subtract(2);
-                while (!point.IsStartPoint)
+                while (!point.IsStartColumn)
                 {
                     Assert.True(point.IsLineBreak);
                     point = point.Subtract(1);
                     Assert.Equal(letters[i], point.GetText());
 
-                    if (!point.IsStartPoint)
+                    if (!point.IsStartColumn)
                     {
                         point = point.Subtract(1);
                         i--;
@@ -176,10 +176,10 @@ namespace Vim.UnitTest
                 Create("cat", "dog");
                 var column = new SnapshotColumn(_textBuffer.GetPointInLine(line: 1, column: 2));
                 var next = column.TryAddInLine(1, includeLineBreak: FSharpOption.True);
-                Assert.True(next.IsSome(x => x.IsEndPoint));
+                Assert.True(next.IsSome(x => x.IsEndColumn));
 
                 next = column.TryAddInLine(1, includeLineBreak: FSharpOption.False);
-                Assert.True(next.IsSome(x => x.IsEndPoint));
+                Assert.True(next.IsSome(x => x.IsEndColumn));
             }
         }
 
@@ -282,7 +282,7 @@ namespace Vim.UnitTest
                 Create("cat");
                 var point = _textBuffer.GetEndPoint();
                 var column = new SnapshotColumn(point);
-                Assert.True(column.IsEndPoint);
+                Assert.True(column.IsEndColumn);
                 Assert.False(column.IsLineBreak);
             }
         }

--- a/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
+++ b/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
@@ -32,7 +32,7 @@ namespace Vim.UnitTest
             public void AddSameLine()
             {
                 Create("cat", "dog", "fish");
-                var original = new SnapshotCharacterSpan(_textBuffer.GetPoint(0));
+                var original = new SnapshotColumn(_textBuffer.GetPoint(0));
                 var column = original.Add(1);
                 Assert.Equal(1, column.ColumnNumber);
                 Assert.Equal(0, column.LineNumber);
@@ -44,7 +44,7 @@ namespace Vim.UnitTest
             public void AddNextLine(string lineBreakText)
             {
                 CreateRaw("cat" + lineBreakText + "dog" + lineBreakText + "fish");
-                var original = new SnapshotCharacterSpan(_textBuffer.GetPoint(0));
+                var original = new SnapshotColumn(_textBuffer.GetPoint(0));
                 var column = original.Add(4);
                 Assert.Equal(0, column.ColumnNumber);
                 Assert.Equal(1, column.LineNumber);
@@ -58,7 +58,7 @@ namespace Vim.UnitTest
                 var letters = CharUtil.LettersLower.Select(x => x.ToString()).ToArray();
                 var content = string.Join(lineBreakText, letters);
                 CreateRaw(content);
-                var point = new SnapshotCharacterSpan(_textBuffer.GetPoint(0));
+                var point = new SnapshotColumn(_textBuffer.GetPoint(0));
                 for (var i = 0; i < letters.Length; i++)
                 {
                     Assert.Equal(letters[i], point.GetText());
@@ -75,7 +75,7 @@ namespace Vim.UnitTest
             public void AddBeforeLine()
             {
                 Create("cat", "dog", "fish");
-                var original = new SnapshotCharacterSpan(_textBuffer.GetLine(1).Start);
+                var original = new SnapshotColumn(_textBuffer.GetLine(1).Start);
                 var column = original.Add(-2);
                 Assert.Equal(2, column.ColumnNumber);
                 Assert.Equal(0, column.LineNumber);
@@ -85,7 +85,7 @@ namespace Vim.UnitTest
             public void SubtractSameLine()
             {
                 Create("cat", "dog", "fish");
-                var original = new SnapshotCharacterSpan(_textBuffer.GetPoint(1));
+                var original = new SnapshotColumn(_textBuffer.GetPoint(1));
                 var column = original.Subtract(1);
                 Assert.Equal(0, column.ColumnNumber);
                 Assert.Equal(0, column.LineNumber);
@@ -97,7 +97,7 @@ namespace Vim.UnitTest
             public void SubtractBeforeLine(string lineBreakText)
             {
                 CreateRaw("cat" +lineBreakText + "dog" + lineBreakText + "fish");
-                var original = new SnapshotCharacterSpan(_textBuffer.GetLine(1).Start);
+                var original = new SnapshotColumn(_textBuffer.GetLine(1).Start);
                 var column = original.Subtract(2);
                 Assert.Equal(2, column.ColumnNumber);
                 Assert.Equal(0, column.LineNumber);
@@ -112,7 +112,7 @@ namespace Vim.UnitTest
                 var content = string.Join(lineBreakText, letters);
                 CreateRaw(content);
                 var i = letters.Length - 2;
-                var point = new SnapshotCharacterSpan(_textBuffer.GetEndPoint());
+                var point = new SnapshotColumn(_textBuffer.GetEndPoint());
                 point = point.Subtract(2);
                 while (!point.IsStartPoint)
                 {
@@ -136,7 +136,7 @@ namespace Vim.UnitTest
             {
                 Create("cat", "dog");
                 var point = _textBuffer.GetPoint(1);
-                var column = new SnapshotCharacterSpan(point);
+                var column = new SnapshotColumn(point);
                 Assert.Equal(0, column.LineNumber);
                 Assert.Equal(1, column.ColumnNumber);
                 Assert.False(column.IsLineBreak);
@@ -147,7 +147,7 @@ namespace Vim.UnitTest
             {
                 Create("cat", "dog");
                 var point = _textBuffer.GetPoint(_textBuffer.GetLine(0).End);
-                var column = new SnapshotCharacterSpan(point);
+                var column = new SnapshotColumn(point);
                 Assert.Equal(0, column.LineNumber);
                 Assert.Equal(3, column.ColumnNumber);
                 Assert.True(column.IsLineBreak);
@@ -159,7 +159,7 @@ namespace Vim.UnitTest
             {
                 Create("cat");
                 var point = _textBuffer.GetEndPoint();
-                var characterSpan = new SnapshotCharacterSpan(point);
+                var characterSpan = new SnapshotColumn(point);
                 Assert.True(characterSpan.StartPoint.Position == _textBuffer.CurrentSnapshot.Length);
             }
         }

--- a/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
+++ b/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
@@ -9,10 +9,6 @@ using Vim.Extensions;
 
 namespace Vim.UnitTest
 {
-    // CTODO: need to test specifying a point that is the second character of a line break
-    // CTODO: Consider removing position Apis and replace with start and end 
-    // CTODO: test add past end
-    // CTODO: test subtract before start
     public abstract class SnapshotColumnTest : VimTestBase
     {
         private ITextBuffer _textBuffer;

--- a/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
+++ b/Test/VimCoreTest/SnapshotCharacterSpanTest.cs
@@ -213,8 +213,35 @@ namespace Vim.UnitTest
             {
                 Create("cat");
                 var point = _textBuffer.GetEndPoint();
-                var characterSpan = new SnapshotColumn(point);
-                Assert.True(characterSpan.StartPoint.Position == _textBuffer.CurrentSnapshot.Length);
+                var column = new SnapshotColumn(point);
+                Assert.True(column.StartPoint.Position == _textBuffer.CurrentSnapshot.Length);
+            }
+
+            [WpfFact]
+            public void EndPointOnEmptyLine()
+            {
+                Create("cat", "");
+                var point = _textBuffer.GetEndPoint();
+                var column = new SnapshotColumn(point);
+                Assert.True(column.StartPoint.Position == _textBuffer.CurrentSnapshot.Length);
+            }
+
+            [WpfFact]
+            public void EmptyLineAtEnd()
+            {
+                Create("cat", "");
+                var point = _textBuffer.GetPointInLine(line: 1, column: 0);
+                var column = new SnapshotColumn(point);
+                Assert.True(column.StartPoint.Position == _textBuffer.CurrentSnapshot.Length);
+            }
+
+            [WpfFact]
+            public void SecondPositionOfLineBreak()
+            {
+                Create("cat", "dog");
+                var point = _textBuffer.GetPoint(4);
+                var column = new SnapshotColumn(point);
+                Assert.True(column.StartPoint.Position == 3);
             }
         }
 

--- a/Test/VimCoreTest/SnapshotCodePointTest.cs
+++ b/Test/VimCoreTest/SnapshotCodePointTest.cs
@@ -29,7 +29,7 @@ namespace Vim.UnitTest
 
             if (position != null)
             {
-                Assert.Equal(position.Value, point.Point.Position);
+                Assert.Equal(position.Value, point.StartPoint.Position);
             }
         }
 

--- a/Test/VimCoreTest/SnapshotCodePointTest.cs
+++ b/Test/VimCoreTest/SnapshotCodePointTest.cs
@@ -152,5 +152,28 @@ namespace Vim.UnitTest
                 Assert.Equal(0, point2.Line.LineNumber);
             }
         }
+
+        public sealed class IsCharacterTests : SnapshotCodePointTest
+        {
+            [WpfFact]
+            public void Simple()
+            {
+                var textBuffer = CreateTextBuffer("cat");
+                var point = new SnapshotCodePoint(textBuffer.GetStartPoint());
+                Assert.True(point.IsCharacter('c'));
+                Assert.False(point.IsCharacter('\t'));
+            }
+
+            /// <summary>
+            /// Don't throw when asking this at the end point. 
+            /// </summary>
+            [WpfFact]
+            public void EndPoint()
+            {
+                var textBuffer = CreateTextBuffer("cat");
+                var point = new SnapshotCodePoint(textBuffer.GetEndPoint());
+                Assert.False(point.IsCharacter('c'));
+            }
+        }
     }
 }

--- a/Test/VimCoreTest/SnapshotCodePointTest.cs
+++ b/Test/VimCoreTest/SnapshotCodePointTest.cs
@@ -175,5 +175,19 @@ namespace Vim.UnitTest
                 Assert.False(point.IsCharacter('c'));
             }
         }
+
+        public sealed class MiscTest : SnapshotCodePointTest
+        {
+            [WpfFact]
+            public void EndPoint()
+            {
+                var textBuffer = CreateTextBuffer("cat");
+                var point = new SnapshotCodePoint(textBuffer.GetEndPoint());
+                Assert.Equal(textBuffer.GetEndPoint(), point.StartPoint);
+                Assert.Equal(textBuffer.GetEndPoint(), point.EndPoint);
+                Assert.True(point.IsEndPoint);
+            }
+
+        }
     }
 }

--- a/Test/VimCoreTest/SnapshotColumnTest.cs
+++ b/Test/VimCoreTest/SnapshotColumnTest.cs
@@ -95,25 +95,5 @@ namespace Vim.UnitTest
                 Assert.Equal("cat", column.Line.GetText());
             }
         }
-
-        public sealed class SurrogatePairs : SnapshotColumnTest
-        {
-            [WpfFact]
-            public void SurrogatePair()
-            {
-                // Extraterrestrial alien emoji from issue #1786.
-                Create("'\U0001F47D'", "");
-                Assert.Equal(6, _textBuffer.GetLine(0).ExtentIncludingLineBreak.GetText().Length);
-                var column = new SnapshotCharacterSpan(_textBuffer.GetLine(0).Start);
-                Assert.Equal(4, column.ColumnCountIncludingLineBreak);
-                Assert.Equal(1, column.Width);
-                column = new SnapshotCharacterSpan(column, 1);
-                Assert.Equal(2, column.Width);
-                column = new SnapshotCharacterSpan(column, 2);
-                Assert.Equal(1, column.Width);
-                column = new SnapshotCharacterSpan(column, 3);
-                Assert.Equal(Environment.NewLine.Length, column.Width);
-            }
-        }
     }
 }

--- a/Test/VimCoreTest/SnapshotColumnTest.cs
+++ b/Test/VimCoreTest/SnapshotColumnTest.cs
@@ -8,7 +8,7 @@ using Vim.EditorHost;
 
 namespace Vim.UnitTest
 {
-    public abstract class SnapshotColumnTest : VimTestBase
+    public abstract class SnapshotColumnLegacyTest : VimTestBase
     {
         private ITextBuffer _textBuffer;
 
@@ -17,7 +17,7 @@ namespace Vim.UnitTest
             _textBuffer = CreateTextBuffer(lines);
         }
 
-        public sealed class AddSubtractTest : SnapshotColumnTest
+        public sealed class AddSubtractTest : SnapshotColumnLegacyTest
         {
             [WpfFact]
             public void AddSameLine()
@@ -70,7 +70,7 @@ namespace Vim.UnitTest
             }
         }
 
-        public sealed class Ctor : SnapshotColumnTest
+        public sealed class Ctor : SnapshotColumnLegacyTest
         {
             [WpfFact]
             public void PointSimple()

--- a/Test/VimCoreTest/SnapshotColumnTest.cs
+++ b/Test/VimCoreTest/SnapshotColumnTest.cs
@@ -23,7 +23,7 @@ namespace Vim.UnitTest
             public void AddSameLine()
             {
                 Create("cat", "dog", "fish");
-                var original = new SnapshotColumn(_textBuffer.GetPoint(0));
+                var original = new SnapshotColumnLegacy(_textBuffer.GetPoint(0));
                 var column = original.Add(1);
                 Assert.Equal(1, column.Column);
                 Assert.Equal(0, column.LineNumber);
@@ -33,7 +33,7 @@ namespace Vim.UnitTest
             public void AddNextLine()
             {
                 Create("cat", "dog", "fish");
-                var original = new SnapshotColumn(_textBuffer.GetPoint(0));
+                var original = new SnapshotColumnLegacy(_textBuffer.GetPoint(0));
                 var column = original.Add(5);
                 Assert.Equal(0, column.Column);
                 Assert.Equal(1, column.LineNumber);
@@ -43,7 +43,7 @@ namespace Vim.UnitTest
             public void AddBeforeLine()
             {
                 Create("cat", "dog", "fish");
-                var original = new SnapshotColumn(_textBuffer.GetLine(1).Start);
+                var original = new SnapshotColumnLegacy(_textBuffer.GetLine(1).Start);
                 var column = original.Add(-3);
                 Assert.Equal(2, column.Column);
                 Assert.Equal(0, column.LineNumber);
@@ -53,7 +53,7 @@ namespace Vim.UnitTest
             public void SubtractSameLine()
             {
                 Create("cat", "dog", "fish");
-                var original = new SnapshotColumn(_textBuffer.GetPoint(1));
+                var original = new SnapshotColumnLegacy(_textBuffer.GetPoint(1));
                 var column = original.Subtract(1);
                 Assert.Equal(0, column.Column);
                 Assert.Equal(0, column.LineNumber);
@@ -63,7 +63,7 @@ namespace Vim.UnitTest
             public void SubtractBeforeLine()
             {
                 Create("cat", "dog", "fish");
-                var original = new SnapshotColumn(_textBuffer.GetLine(1).Start);
+                var original = new SnapshotColumnLegacy(_textBuffer.GetLine(1).Start);
                 var column = original.Subtract(3);
                 Assert.Equal(2, column.Column);
                 Assert.Equal(0, column.LineNumber);
@@ -77,7 +77,7 @@ namespace Vim.UnitTest
             {
                 Create("cat", "dog");
                 var point = _textBuffer.GetPoint(1);
-                var column = new SnapshotColumn(point);
+                var column = new SnapshotColumnLegacy(point);
                 Assert.Equal(0, column.LineNumber);
                 Assert.Equal(1, column.Column);
                 Assert.False(column.IsInsideLineBreak);
@@ -88,7 +88,7 @@ namespace Vim.UnitTest
             {
                 Create("cat", "dog");
                 var point = _textBuffer.GetPoint(_textBuffer.GetLine(0).End);
-                var column = new SnapshotColumn(point);
+                var column = new SnapshotColumnLegacy(point);
                 Assert.Equal(0, column.LineNumber);
                 Assert.Equal(3, column.Column);
                 Assert.True(column.IsInsideLineBreak);

--- a/Test/VimCoreTest/TextObjectUtilTest.cs
+++ b/Test/VimCoreTest/TextObjectUtilTest.cs
@@ -33,7 +33,7 @@ namespace Vim.UnitTest
             public void SingleSpace()
             {
                 Create("a!b. c");
-                Assert.True(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumn(4)));
+                Assert.True(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumnLegacy(4)));
             }
 
             /// <summary>
@@ -43,7 +43,7 @@ namespace Vim.UnitTest
             public void ManyTrailingCharacters()
             {
                 Create("a?)]' b.");
-                Assert.True(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumn(5)));
+                Assert.True(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumnLegacy(5)));
             }
 
             /// <summary>
@@ -53,7 +53,7 @@ namespace Vim.UnitTest
             public void StartOfBuffer()
             {
                 Create("dog. cat");
-                Assert.False(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumn(0)));
+                Assert.False(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumnLegacy(0)));
             }
 
             /// <summary>

--- a/Test/VimCoreTest/TextObjectUtilTest.cs
+++ b/Test/VimCoreTest/TextObjectUtilTest.cs
@@ -33,7 +33,7 @@ namespace Vim.UnitTest
             public void SingleSpace()
             {
                 Create("a!b. c");
-                Assert.True(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumnLegacy(4)));
+                Assert.True(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumnFromPosition(4)));
             }
 
             /// <summary>
@@ -43,7 +43,7 @@ namespace Vim.UnitTest
             public void ManyTrailingCharacters()
             {
                 Create("a?)]' b.");
-                Assert.True(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumnLegacy(5)));
+                Assert.True(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumnFromPosition(5)));
             }
 
             /// <summary>
@@ -53,7 +53,7 @@ namespace Vim.UnitTest
             public void StartOfBuffer()
             {
                 Create("dog. cat");
-                Assert.False(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumnLegacy(0)));
+                Assert.False(_textObjectUtil.IsSentenceEnd(SentenceKind.Default, _textBuffer.GetColumnFromPosition(0)));
             }
 
             /// <summary>

--- a/Test/VimCoreTest/VimBufferTest.cs
+++ b/Test/VimCoreTest/VimBufferTest.cs
@@ -548,7 +548,7 @@ namespace Vim.UnitTest
             protected void AssertPosition(int lineNumber, int column, FSharpOption<VirtualSnapshotPoint> option)
             {
                 Assert.True(option.IsSome());
-                var line = VirtualSnapshotPointUtil.GetPoint(option.Value).GetColumn();
+                var line = VirtualSnapshotPointUtil.GetPoint(option.Value).GetColumnLegacy();
                 Assert.Equal(lineNumber, line.LineNumber);
                 Assert.Equal(column, line.Column);
             }

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -1927,7 +1927,7 @@ namespace Vim.UnitTest
                 Create("cat dog");
                 _vimBuffer.ProcessNotation("vllU");
                 Assert.Equal("CAT dog", _textBuffer.GetLine(0).GetText());
-                Assert.Equal(0, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(0, _textView.GetCaretPoint().GetColumnLegacy().Column);
             }
 
             [WpfFact]
@@ -1936,7 +1936,7 @@ namespace Vim.UnitTest
                 Create("CAT dog");
                 _vimBuffer.ProcessNotation("vllu");
                 Assert.Equal("cat dog", _textBuffer.GetLine(0).GetText());
-                Assert.Equal(0, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(0, _textView.GetCaretPoint().GetColumnLegacy().Column);
             }
 
             [WpfFact]
@@ -1945,7 +1945,7 @@ namespace Vim.UnitTest
                 Create("cat dog");
                 _vimBuffer.ProcessNotation("vllg?");
                 Assert.Equal("png dog", _textBuffer.GetLine(0).GetText());
-                Assert.Equal(0, _textView.GetCaretPoint().GetColumn().Column);
+                Assert.Equal(0, _textView.GetCaretPoint().GetColumnLegacy().Column);
             }
         }
 


### PR DESCRIPTION
This is building off of @ricksladkey surrogate pair work. This PR doesn't complete the work, quite a bit left. But it makes substantial progress in cleaning up our surrogate pair handling in the code base. This PR essentially does the following:

- Add documentation on what our API terminology means for position, column and spaces
- Renames the old `SnapshotColumn` type to `SnapshotColumnLegacy`. It was fundamentally flawed for surrogate pairs. A future PR (almost done) will completely delete this type. 
- Renames `SnapshotCharacterSpan` to `SnapshotColumn` and expands the API to handle many cases I found. 
- Replaces `SnaphotColumnLegacy` with `SnapshotColumn` in many of the critical places in the code base.

There is still quite a bit of work left here but this pushes us must further to surrogate pair correctness. 


#2275