### PR TITLE
Add subtract

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -211,8 +211,11 @@ type internal CommandUtil
                 | NumberValue.Binary number ->
                     let prefix = numberText.Substring(0, 2)
                     let width = numberText.Length - 2
-                    let newNumber = int64(number + uint64(count))
-                    let formattedNumber = System.Convert.ToString(newNumber, 2)
+                    let newNumber = number + uint64(count)
+
+                    // There are no overloads for unsigned integer types and
+                    // binary convert is always unsigned anyway.
+                    let formattedNumber = System.Convert.ToString(int64(newNumber), 2)
                     prefix + formattedNumber.PadLeft(width, '0')
 
             Some (span, text)

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -187,14 +187,15 @@ type internal CommandUtil
                     c |> CharUtil.AlphaAdd count |> StringUtil.OfChar
 
                 | NumberValue.Decimal number ->
-                    let width =
-                        if numberText.StartsWith("-")
-                        then numberText.Length - 1
-                        else numberText.Length
-                    sprintf "%0*d" width (number + int64(count))
+                    let newNumber = number + int64(count)
+                    let oldSignWidth = if numberText.StartsWith("-") then 1 else 0
+                    let newSignWidth = if newNumber < 0L then 1 else 0
+                    let width = numberText.Length + newSignWidth - oldSignWidth
+                    sprintf "%0*d" width newNumber
 
                 | NumberValue.Octal number ->
-                    sprintf "0%0*o" (numberText.Length - 1) (number + uint64(count))
+                    let newNumber = number + uint64(count)
+                    sprintf "0%0*o" (numberText.Length - 1) newNumber
 
                 | NumberValue.Hex number ->
                     let prefix = numberText.Substring(0, 2)
@@ -1215,7 +1216,7 @@ type internal CommandUtil
 
         // Get the point for an octal number.
         let getOctal () =
-            getNumber NumberValue.Octal @"\b0[0-7]*\b" (fun text ->
+            getNumber NumberValue.Octal @"\b0[0-7]+\b" (fun text ->
                 try
                     true, System.Convert.ToUInt64(text, 8)
                 with

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -188,9 +188,13 @@ type internal CommandUtil
 
                 | NumberValue.Decimal number ->
                     let newNumber = number + int64(count)
-                    let oldSignWidth = if numberText.StartsWith("-") then 1 else 0
-                    let newSignWidth = if newNumber < 0L then 1 else 0
-                    let width = numberText.Length + newSignWidth - oldSignWidth
+                    let width =
+                        if numberText.StartsWith("-0") || numberText.StartsWith("0") then
+                            let oldSignWidth = if numberText.StartsWith("-") then 1 else 0
+                            let newSignWidth = if newNumber < 0L then 1 else 0
+                            numberText.Length + newSignWidth - oldSignWidth
+                        else
+                            1
                     sprintf "%0*d" width newNumber
 
                 | NumberValue.Octal number ->

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -128,10 +128,54 @@ type internal CommandUtil
 
     /// Add count values to the specific word
     member x.AddToWord count =
+        match x.AddToWordAtPoint x.CaretPoint count with
+        | Some (span, text) ->
 
-        match x.GetNumberValueAtCaret() with
+            // Need a transaction here in order to properly position the caret.
+            // After the add the caret needs to be positioned on the last
+            // character in the number.
+            x.EditWithUndoTransaction "Add to word" (fun () ->
+
+                _textBuffer.Replace(span.Span, text) |> ignore
+
+                let position = span.Start.Position + text.Length - 1
+                TextViewUtil.MoveCaretToPosition _textView position)
+
         | None ->
             _commonOperations.Beep()
+
+        CommandResult.Completed ModeSwitch.NoSwitch
+
+    /// Add count to the word in each line of the selection, optionally progressively
+    member x.AddToSelection (visualSpan: VisualSpan) count isProgressive =
+        let startPoint = visualSpan.Start
+
+        // Use a transaction to guarantee caret position.  Caret should be at
+        // the start during undo and redo so move it before the edit
+        TextViewUtil.MoveCaretToPoint _textView startPoint
+        x.EditWithUndoTransaction "Add to selection" (fun () ->
+            use edit = _textBuffer.CreateEdit()
+            visualSpan.PerLineSpans |> Seq.iteri (fun index span ->
+                let countForIndex =
+                    if isProgressive then
+                        count * (index + 1)
+                    else
+                        count
+                match x.AddToWordAtPoint span.Start countForIndex with
+                | Some (span, text) ->
+                    edit.Replace(span.Span, text) |> ignore
+                | None ->
+                    ())
+
+            let position = x.ApplyEditAndMapPosition edit startPoint.Position
+            TextViewUtil.MoveCaretToPosition _textView position)
+
+        CommandResult.Completed ModeSwitch.SwitchPreviousMode
+
+    /// Add count values to the specific word
+    member x.AddToWordAtPoint point count: (SnapshotSpan * string) option =
+
+        match x.GetNumberValueAtPoint point with
         | Some (numberValue, span) ->
 
             // Calculate the new value of the number.
@@ -171,17 +215,9 @@ type internal CommandUtil
                     let formattedNumber = System.Convert.ToString(newNumber, 2)
                     prefix + formattedNumber.PadLeft(width, '0')
 
-            // Need a transaction here in order to properly position the caret.
-            // After the add the caret needs to be positioned on the last
-            // character in the number.
-            x.EditWithUndoTransaction "Add" (fun () ->
+            Some (span, text)
 
-                _textBuffer.Replace(span.Span, text) |> ignore
-
-                let position = span.Start.Position + text.Length - 1
-                TextViewUtil.MoveCaretToPosition _textView position)
-
-        CommandResult.Completed ModeSwitch.NoSwitch
+        | None -> None
 
     /// Apply the ITextEdit and returned the mapped position value from the resulting
     /// ITextSnapshot into the current ITextSnapshot.
@@ -1128,27 +1164,31 @@ type internal CommandUtil
     /// Get the appropriate register for the CommandData
     member x.GetRegister name = _commonOperations.GetRegister name
 
-    /// Get the number value at the caret.  This is used for the CTRL-A and CTRL-X
-    /// command so it will look forward on the current line for the first word
-    ///
-    /// TODO: Need to integrate the parsing functions here with that of the tokenizer
-    /// which also parses out the same set of numbers
     member x.GetNumberValueAtCaret(): (NumberValue * SnapshotSpan) option =
-        let caretLine = x.CaretLine
-        let startPosition = caretLine.Start.Position
-        let index = x.CaretPoint.Position - startPosition
+        x.GetNumberValueAtPoint x.CaretPoint
+
+    /// Get the number value at the specified point.  This is used for the
+    /// CTRL-A and CTRL-X command so it will look forward on the current line
+    /// for the first word
+    ///
+    /// TODO: Need to integrate the parsing functions here with that of the
+    /// tokenizer which also parses out the same set of numbers
+    member x.GetNumberValueAtPoint point: (NumberValue * SnapshotSpan) option =
+        let line = SnapshotPointUtil.GetContainingLine point
+        let startPosition = line.Start.Position
+        let index = point.Position - startPosition
 
         // Get the match from the line with the given regex for the first
-        // number that contains the caret or is after the caret.
+        // number that contains the point or begins after the point.
         let getNumber numberValue numberPattern parseFunc =
-            caretLine
+            line
             |> SnapshotLineUtil.GetText
             |> (fun text -> RegularExpressions.Regex.Matches(text, numberPattern))
             |> Seq.cast<RegularExpressions.Match>
             |> Seq.tryFind (fun m ->
                 index >= m.Index && index < m.Index + m.Length || index < m.Index)
             |> Option.map (fun m ->
-                let span = SnapshotSpan(x.CurrentSnapshot, startPosition + m.Index, m.Length)
+                let span = SnapshotSpan(point.Snapshot, startPosition + m.Index, m.Length)
                 let succeeded, number = parseFunc m.Value
                 if succeeded then
                     Some (numberValue number, span)
@@ -1209,7 +1249,7 @@ type internal CommandUtil
 
                 // Now check for alpha by going forward to the first alpha
                 // character.
-                SnapshotSpan(x.CaretPoint, caretLine.EndIncludingLineBreak)
+                SnapshotSpan(point, line.EndIncludingLineBreak)
                 |> SnapshotSpanUtil.GetPoints SearchPath.Forward
                 |> Seq.skipWhile (fun point ->
                     point
@@ -2738,6 +2778,7 @@ type internal CommandUtil
         let registerName = data.RegisterName
         let count = data.CountOrDefault
         match command with
+        | VisualCommand.AddToSelection isProgressive -> x.AddToSelection visualSpan count isProgressive
         | VisualCommand.ChangeCase kind -> x.ChangeCaseVisual kind visualSpan
         | VisualCommand.ChangeSelection -> x.ChangeSelection registerName visualSpan
         | VisualCommand.CloseAllFoldsInSelection -> x.CloseAllFoldsInSelection visualSpan
@@ -2762,6 +2803,7 @@ type internal CommandUtil
         | VisualCommand.ReplaceSelection keyInput -> x.ReplaceSelection keyInput visualSpan
         | VisualCommand.ShiftLinesLeft -> x.ShiftLinesLeftVisual count visualSpan
         | VisualCommand.ShiftLinesRight -> x.ShiftLinesRightVisual count visualSpan
+        | VisualCommand.SubtractFromSelection isProgressive -> x.SubtractFromSelection visualSpan count isProgressive
         | VisualCommand.SwitchModeInsert atEndOfLine -> x.SwitchModeInsert visualSpan atEndOfLine
         | VisualCommand.SwitchModePrevious -> x.SwitchPreviousMode()
         | VisualCommand.SwitchModeVisual visualKind -> x.SwitchModeVisual visualKind
@@ -3331,6 +3373,10 @@ type internal CommandUtil
     /// Subtract 'count' values from the word under the caret
     member x.SubtractFromWord count =
         x.AddToWord -count
+
+    /// Subtract count from the word in each line of the selection, optionally progressively
+    member x.SubtractFromSelection visualSpan count isProgressive =
+        x.AddToSelection visualSpan -count isProgressive
 
     /// Switch to the given mode
     member x.SwitchMode modeKind modeArgument =

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1893,25 +1893,25 @@ type VisualSpan =
         match x with 
         | VisualSpan.Character characterSpan ->
             seq {
-                let first, middle, last =
+                let leadingEdge, middle, trailingEdge =
                     SnapshotSpanUtil.GetLinesAndEdges characterSpan.Span
-                match first with
+                match leadingEdge with
                 | Some span -> yield span
                 | None -> ()
                 match middle with
                 | Some lineRange ->
                     let spans =
                         lineRange.Lines
-                        |> Seq.map SnapshotLineUtil.GetExtent
+                        |> Seq.map SnapshotLineUtil.GetExtentIncludingLineBreak
                     yield! spans
                 | None -> ()
-                match last with
+                match trailingEdge with
                 | Some span -> yield span
                 | None -> ()
             }
         | VisualSpan.Line lineRange ->
             lineRange.Lines
-            |> Seq.map SnapshotLineUtil.GetExtent
+            |> Seq.map SnapshotLineUtil.GetExtentIncludingLineBreak
         | VisualSpan.Block blockSpan ->
             blockSpan.BlockSpans
             :> SnapshotSpan seq

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3256,7 +3256,7 @@ type VisualCommand =
     /// Shift the selected lines to the right
     | ShiftLinesRight
 
-    /// Subtract count to the word in each line of the selection, optionally progressively
+    /// Subtract count from the word in each line of the selection, optionally progressively
     | SubtractFromSelection of bool
 
     /// Switch the mode to insert and possibly a block insert. The bool specifies whether

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1889,8 +1889,8 @@ type VisualSpan =
         | VisualSpan.Block blockSpan -> blockSpan.BlockSpans :> SnapshotSpan seq
 
     /// Return the per line spans which make up this VisualSpan instance
-    member x.PerLineSpans = 
-        match x with 
+    member x.PerLineSpans =
+        match x with
         | VisualSpan.Character characterSpan ->
             seq {
                 let leadingEdge, middle, trailingEdge =

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -98,6 +98,10 @@ type internal VisualMode
                 yield ("gq", CommandFlags.Repeatable, VisualCommand.FormatTextLines false)
                 yield ("gw", CommandFlags.Repeatable, VisualCommand.FormatTextLines true)
                 yield ("!", CommandFlags.Repeatable, VisualCommand.FilterLines)
+                yield ("<C-a>", CommandFlags.Repeatable, VisualCommand.AddToSelection false)
+                yield ("<C-x>", CommandFlags.Repeatable, VisualCommand.SubtractFromSelection false)
+                yield ("g<C-a>", CommandFlags.Repeatable, VisualCommand.AddToSelection true)
+                yield ("g<C-x>", CommandFlags.Repeatable, VisualCommand.SubtractFromSelection true)
             } |> Seq.map (fun (str, flags, command) -> 
                 let keyInputSet = KeyNotationUtil.StringToKeyInputSet str
                 CommandBinding.VisualBinding (keyInputSet, flags, command))

--- a/Src/VimCore/VimSettings.fs
+++ b/Src/VimCore/VimSettings.fs
@@ -505,7 +505,7 @@ type internal LocalSettings
             (AutoIndentName, "ai", SettingValue.Toggle false, SettingOptions.None)
             (ExpandTabName, "et", SettingValue.Toggle false, SettingOptions.None)
             (NumberName, "nu", SettingValue.Toggle false, SettingOptions.None)
-            (NumberFormatsName, "nf", SettingValue.String "octal,hex", SettingOptions.None)
+            (NumberFormatsName, "nf", SettingValue.String "bin,octal,hex", SettingOptions.None)
             (SoftTabStopName, "sts", SettingValue.Number 0, SettingOptions.None)
             (ShiftWidthName, "sw", SettingValue.Number 8, SettingOptions.None)
             (TabStopName, "ts", SettingValue.Number 8, SettingOptions.None)
@@ -544,6 +544,8 @@ type internal LocalSettings
         | NumberFormat.Decimal ->
             // This is always supported independent of the option value
             true
+        | NumberFormat.Binary ->
+            isSupported "bin"
         | NumberFormat.Octal ->
             isSupported "octal"
         | NumberFormat.Hex ->

--- a/Src/VimCore/VimSettingsInterface.fs
+++ b/Src/VimCore/VimSettingsInterface.fs
@@ -93,6 +93,7 @@ type NumberFormat =
     | Decimal
     | Hex
     | Octal
+    | Binary
 
 /// The options which can be set in the 'clipboard' setting
 [<RequireQualifiedAccess>]

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -7040,6 +7040,112 @@ namespace Vim.UnitTest
                 _vimBuffer.ProcessNotation("<C-a>");
                 Assert.Equal("0x1b", _textBuffer.GetLine(0).GetText());
             }
+
+            [WpfFact]
+            public void HexWithLettersFromEnd()
+            {
+                // Reported in issue #1765.
+                Create("0x00ff", "");
+                _textView.MoveCaretToLine(0, 5);
+                _vimBuffer.ProcessNotation("<C-a>");
+                Assert.Equal("0x0100", _textBuffer.GetLine(0).GetText());
+            }
+
+            [WpfFact]
+            public void HexMatchesPrefix()
+            {
+                Create("0X00ff", "");
+                _vimBuffer.ProcessNotation("<C-a>");
+                Assert.Equal("0X0100", _textBuffer.GetLine(0).GetText());
+            }
+
+            [WpfFact]
+            public void HexMatchesLowercase()
+            {
+                Create("0x00fe", "");
+                _vimBuffer.ProcessNotation("<C-a>");
+                Assert.Equal("0x00ff", _textBuffer.GetLine(0).GetText());
+            }
+
+            [WpfFact]
+            public void HexMatchesUppercase()
+            {
+                Create("0x00FE", "");
+                _vimBuffer.ProcessNotation("<C-a>");
+                Assert.Equal("0x00FF", _textBuffer.GetLine(0).GetText());
+            }
+
+            [WpfFact]
+            public void Octal()
+            {
+                Create("0007", "");
+                _localSettings.NumberFormats = "octal";
+                _vimBuffer.ProcessNotation("<C-a>");
+                Assert.Equal("0010", _textBuffer.GetLine(0).GetText());
+            }
+
+            [WpfFact]
+            public void LoneZeroIsNotOctal()
+            {
+                Create("0", "");
+                _localSettings.NumberFormats = "octal";
+                _vimBuffer.ProcessNotation("10<C-a>");
+                Assert.Equal("10", _textBuffer.GetLine(0).GetText());
+            }
+
+            [WpfFact]
+            public void DecimalWithLeadingZeroes()
+            {
+                Create("0007", "");
+                _localSettings.NumberFormats = "";
+                _vimBuffer.ProcessNotation("<C-a>");
+                Assert.Equal("0008", _textBuffer.GetLine(0).GetText());
+            }
+
+            [WpfFact]
+            public void NegativeDecimalWithLeadingZeroes()
+            {
+                Create("-0007", "");
+                _localSettings.NumberFormats = "";
+                _vimBuffer.ProcessNotation("<C-a>");
+                Assert.Equal("-0006", _textBuffer.GetLine(0).GetText());
+            }
+
+            [WpfFact]
+            public void DecimalBecomingPositive()
+            {
+                Create("-0001", "");
+                _localSettings.NumberFormats = "";
+                _vimBuffer.ProcessNotation("<C-a>");
+                Assert.Equal("0000", _textBuffer.GetLine(0).GetText());
+            }
+
+            [WpfFact]
+            public void DecimalBecomingNegative()
+            {
+                Create("0000", "");
+                _localSettings.NumberFormats = "";
+                _vimBuffer.ProcessNotation("<C-x>");
+                Assert.Equal("-0001", _textBuffer.GetLine(0).GetText());
+            }
+
+            [WpfFact]
+            public void Binary()
+            {
+                Create("0b001", "");
+                _localSettings.NumberFormats = "bin";
+                _vimBuffer.ProcessNotation("<C-a>");
+                Assert.Equal("0b010", _textBuffer.GetLine(0).GetText());
+            }
+
+            [WpfFact]
+            public void Alpha()
+            {
+                Create("cog", "");
+                _localSettings.NumberFormats = "alpha";
+                _vimBuffer.ProcessNotation("<C-a>");
+                Assert.Equal("dog", _textBuffer.GetLine(0).GetText());
+            }
         }
 
         public sealed class NumberedRegisterTest : NormalModeIntegrationTest

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -304,6 +304,35 @@ namespace Vim.UnitTest
             }
         }
 
+        public sealed class AddSubtractTest : VisualModeIntegrationTest
+        {
+            [WpfTheory]
+            [InlineData("v")]
+            [InlineData("V")]
+            [InlineData("<C-v>")]
+            public void Basic(string visualKey)
+            {
+                Create("1", "2", "3", "");
+                _vimBuffer.ProcessNotation(visualKey);
+                _vimBuffer.ProcessNotation("2j$");
+                _vimBuffer.ProcessNotation("<C-a>");
+                Assert.Equal(new[] { "2", "3", "4", "" }, _textBuffer.GetLines());
+            }
+
+            [WpfTheory]
+            [InlineData("v")]
+            [InlineData("V")]
+            [InlineData("<C-v>")]
+            public void Progressive(string visualKey)
+            {
+                Create("1", "2", "3", "");
+                _vimBuffer.ProcessNotation(visualKey);
+                _vimBuffer.ProcessNotation("2j$");
+                _vimBuffer.ProcessNotation("g<C-a>");
+                Assert.Equal(new[] { "2", "4", "6", "" }, _textBuffer.GetLines());
+            }
+        }
+
         public abstract class VisualShiftTest : VisualModeIntegrationTest
         {
             protected abstract string Select { get; }


### PR DESCRIPTION
#### Changes

- Fix numerous minor problems with 'add/subtract to/from word' (with tests)
- Add support for binary and octal number formats
- Add `<C-a>`, `<C-x>`, `g<C-a>` and `g<C-x>` keybindings to visual mode
- Implement 'add/subtract in selection', including progressive addition/subtraction

#### Issues

- Fixes #876
- Fixes #1765
- Fixes #1986 