### PR TITLE
Support shift count for ':<' and ':>'

### DIFF
--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -690,10 +690,10 @@ and [<RequireQualifiedAccess>] LineCommand =
     | ShellCommand of LineRangeSpecifier * string
 
     /// Process the '<' shift left command
-    | ShiftLeft of LineRangeSpecifier
+    | ShiftLeft of LineRangeSpecifier * int
 
     /// Process the '>' shift right command
-    | ShiftRight of LineRangeSpecifier
+    | ShiftRight of LineRangeSpecifier * int
 
     /// Sort the specified LineRange.  The options are as follows:
     /// - The LineRange to change (defaults to entire buffer)

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1570,14 +1570,14 @@ type VimInterpreter
         inner 0 false
 
     /// Shift the given line range to the left
-    member x.RunShiftLeft lineRange = 
+    member x.RunShiftLeft lineRange count =
         x.RunWithLineRangeOrDefault lineRange DefaultLineRange.CurrentLine (fun lineRange ->
-            _commonOperations.ShiftLineRangeLeft lineRange 1)
+            _commonOperations.ShiftLineRangeLeft lineRange count)
 
     /// Shift the given line range to the right
-    member x.RunShiftRight lineRange = 
+    member x.RunShiftRight lineRange count =
         x.RunWithLineRangeOrDefault lineRange DefaultLineRange.CurrentLine (fun lineRange ->
-            _commonOperations.ShiftLineRangeRight lineRange 1)
+            _commonOperations.ShiftLineRangeRight lineRange count)
 
     /// Run the :sort command
     member x.RunSort lineRange reverseOrder flags pattern =
@@ -1838,8 +1838,8 @@ type VimInterpreter
         | LineCommand.Search (lineRange, path, pattern) -> x.RunSearch lineRange path pattern
         | LineCommand.Set argumentList -> x.RunSet argumentList
         | LineCommand.ShellCommand (lineRange, command) -> x.RunShellCommand lineRange command
-        | LineCommand.ShiftLeft lineRange -> x.RunShiftLeft lineRange
-        | LineCommand.ShiftRight lineRange -> x.RunShiftRight lineRange
+        | LineCommand.ShiftLeft (lineRange, count) -> x.RunShiftLeft lineRange count
+        | LineCommand.ShiftRight (lineRange, count) -> x.RunShiftRight lineRange count
         | LineCommand.Sort (lineRange, hasBang, flags, pattern) -> x.RunSort lineRange hasBang flags pattern
         | LineCommand.Source (hasBang, filePath) -> x.RunSource hasBang filePath
         | LineCommand.Substitute (lineRange, pattern, replace, flags) -> x.RunSubstitute lineRange pattern replace flags

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -840,8 +840,8 @@ type Parser
             | LineCommand.Search (_, path, pattern) -> LineCommand.Search (lineRange, path, pattern)
             | LineCommand.Set _ -> noRangeCommand
             | LineCommand.ShellCommand _ -> noRangeCommand
-            | LineCommand.ShiftLeft _ -> LineCommand.ShiftLeft lineRange
-            | LineCommand.ShiftRight _ -> LineCommand.ShiftRight lineRange
+            | LineCommand.ShiftLeft (_, count) -> LineCommand.ShiftLeft (lineRange, count)
+            | LineCommand.ShiftRight (_, count) -> LineCommand.ShiftRight (lineRange, count)
             | LineCommand.Sort (_, hasBang, flags, pattern) -> LineCommand.Sort (lineRange, hasBang, flags, pattern)
             | LineCommand.Source _ -> noRangeCommand
             | LineCommand.Substitute (_, pattern, replace, flags) -> LineCommand.Substitute (lineRange, pattern, replace, flags)
@@ -1557,15 +1557,23 @@ type Parser
 
     /// Parse out the shift left pattern
     member x.ParseShiftLeft lineRange = 
+        let mutable count = 1
+        while _tokenizer.CurrentChar = '<' do
+            _tokenizer.MoveNextChar()
+            count <- count + 1
         x.SkipBlanks()
         let lineRange = x.ParseLineRangeSpecifierEndCount lineRange
-        LineCommand.ShiftLeft (lineRange)
+        LineCommand.ShiftLeft (lineRange, count)
 
     /// Parse out the shift right pattern
     member x.ParseShiftRight lineRange = 
+        let mutable count = 1
+        while _tokenizer.CurrentChar = '>' do
+            _tokenizer.MoveNextChar()
+            count <- count + 1
         x.SkipBlanks()
         let lineRange = x.ParseLineRangeSpecifierEndCount lineRange
-        LineCommand.ShiftRight (lineRange)
+        LineCommand.ShiftRight (lineRange, count)
 
     /// Parse out the shell command
     member x.ParseShellCommand lineRange =

--- a/Test/VimCoreTest/ParserTest.cs
+++ b/Test/VimCoreTest/ParserTest.cs
@@ -674,7 +674,7 @@ let x = 42
                 var command = ParseLineCommand(range + ">");
                 Assert.True(command.IsShiftRight);
                 var shift = (LineCommand.ShiftRight)command;
-                return shift.Item;
+                return shift.Item1;
             }
 
             [Fact]
@@ -1651,7 +1651,8 @@ let x = 42
                 var command = ParseLineCommand("'a,'b>");
                 Assert.True(command.IsShiftRight);
                 var shift = (LineCommand.ShiftRight)command;
-                Assert.True(shift.Item.IsRange);
+                Assert.True(shift.Item1.IsRange);
+                Assert.Equal(1, shift.Item2);
             }
 
             [Fact]
@@ -1660,7 +1661,36 @@ let x = 42
                 var command = ParseLineCommand("'a,'b >");
                 Assert.True(command.IsShiftRight);
                 var shift = (LineCommand.ShiftRight)command;
-                Assert.True(shift.Item.IsRange);
+                Assert.True(shift.Item1.IsRange);
+                Assert.Equal(1, shift.Item2);
+            }
+
+            [Fact]
+            public void ShiftDoubleLeft()
+            {
+                var command = ParseLineCommand("<<");
+                Assert.Equal(2, ((LineCommand.ShiftLeft)command).Item2);
+            }
+
+            [Fact]
+            public void ShiftDoubleRight()
+            {
+                var command = ParseLineCommand(">>");
+                Assert.Equal(2, ((LineCommand.ShiftRight)command).Item2);
+            }
+
+            [Fact]
+            public void ShiftTripleLeft()
+            {
+                var command = ParseLineCommand("<<<");
+                Assert.Equal(3, ((LineCommand.ShiftLeft)command).Item2);
+            }
+
+            [Fact]
+            public void ShiftTripleRight()
+            {
+                var command = ParseLineCommand(">>>");
+                Assert.Equal(3, ((LineCommand.ShiftRight)command).Item2);
             }
         }
 


### PR DESCRIPTION
Fixes #872