### PR TITLE
Fix sources of excess allocations

### DIFF
--- a/Src/VimCore/CommandRunner.fs
+++ b/Src/VimCore/CommandRunner.fs
@@ -319,7 +319,7 @@ type internal CommandRunner
                     BindResult.Error
 
         // Lets get it started
-        inner (KeyInputSet.OneKeyInput keyInput) KeyInputSet.Empty keyInput
+        inner (KeyInputSet(keyInput)) KeyInputSet.Empty keyInput
 
     /// Should the Escape key cancel the current command
     member x.ShouldEscapeCancelCurrentCommand () = 

--- a/Src/VimCore/CommandRunner.fs
+++ b/Src/VimCore/CommandRunner.fs
@@ -393,6 +393,7 @@ type internal CommandRunner
 
     interface ICommandRunner with
         member x.Commands = _commandMap |> Seq.map (fun pair -> pair.Value)
+        member x.CommandCount = _commandMap.Count
         member x.IsHandlingEscape =
             match _data.CommandFlags with
             | None -> false

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1308,110 +1308,96 @@ type VisualKind =
 /// values which make up a command name.  
 ///
 /// The intent of this type is that two values are equal if the sequence of 
-/// KeyInputs are Equal.  So a OneKeyInput can be equal to a ManyKeyInputs if the
-/// have the same values
+/// KeyInputs are Equal.  
 ///
 /// It is not possible to simple store this as a string as it is possible, and 
 /// in fact likely due to certain virtual key codes which are unable to be mapped,
 /// for KeyInput values will map to a single char.  Hence to maintain proper semantics
 /// we have to use KeyInput values directly.
-[<RequireQualifiedAccess>]
-[<CustomEquality>]
-[<CustomComparison>]
 [<DebuggerDisplay("{ToString(),nq}")>]
-type KeyInputSet =
-    | Empty
-    | OneKeyInput of KeyInput
-    | TwoKeyInputs of KeyInput * KeyInput
-    | ManyKeyInputs of KeyInput list
-    with 
+type KeyInputSet
+    (
+        _keyInputs: KeyInput list
+    ) =
+
+    let _length = _keyInputs.Length 
+
+    static let s_empty = KeyInputSet([])
+
+    new (keyInput: KeyInput) = 
+        KeyInputSet([keyInput])
+
+    new (keyInput1: KeyInput, keyInput2: KeyInput) = 
+        let list = keyInput1 :: [keyInput2]
+        KeyInputSet(list)
+
+    /// Get the list of KeyInput which represent this KeyInputSet
+    member x.KeyInputs = _keyInputs
+
+    /// Length of the contained KeyInput's
+    member x.Length = _length
 
     /// Returns the first KeyInput if present
     member x.FirstKeyInput = 
-        match x with 
-        | Empty -> None
-        | OneKeyInput(ki) -> Some ki
-        | TwoKeyInputs(ki,_) -> Some ki
-        | ManyKeyInputs(list) -> ListUtil.tryHeadOnly list
+        match x.KeyInputs with
+        | head :: _ -> Some head
+        | [] -> None
 
     /// Returns the rest of the KeyInput values after the first
     member x.Rest = 
-        match x with
-        | Empty -> List.empty
-        | OneKeyInput _ -> List.empty
-        | TwoKeyInputs (_, keyInput2) -> [ keyInput2 ]
-        | ManyKeyInputs list -> List.tail list
-
-    /// Get the list of KeyInput which represent this KeyInputSet
-    member x.KeyInputs =
-        match x with 
-        | Empty -> List.empty
-        | OneKeyInput(ki) -> [ki]
-        | TwoKeyInputs(k1,k2) -> [k1;k2]
-        | ManyKeyInputs(list) -> list
+        match x.KeyInputs with 
+        | [] -> List.Empty
+        | _ :: tail -> tail
 
     /// A string representation of the name.  It is unreliable to use this for anything
     /// other than display as two distinct KeyInput values can map to a single char
     member x.Name = x.KeyInputs |> Seq.map (fun ki -> ki.Char) |> StringUtil.OfCharSeq
 
-    /// Length of the contained KeyInput's
-    member x.Length =
-        match x with
-        | Empty -> 0
-        | OneKeyInput _ -> 1
-        | TwoKeyInputs _ -> 2
-        | ManyKeyInputs list -> list.Length
-
     /// Add a KeyInput to the end of this KeyInputSet and return the 
     /// resulting value
-    member x.Add ki =
-        match x with 
-        | Empty -> OneKeyInput ki
-        | OneKeyInput previous -> TwoKeyInputs(previous,ki)
-        | TwoKeyInputs (p1, p2) -> ManyKeyInputs [p1;p2;ki]
-        | ManyKeyInputs list -> ManyKeyInputs (list @ [ki])
+    member x.Add keyInput =
+        let list = x.KeyInputs @ [keyInput] 
+        KeyInputSet(list)
 
     /// Does the name start with the given KeyInputSet
-    member x.StartsWith (targetName: KeyInputSet) = 
-        match targetName,x with
-        | Empty, _ -> true
-        | OneKeyInput leftKi, OneKeyInput rightKi ->  leftKi = rightKi
-        | OneKeyInput leftKi, TwoKeyInputs (rightKi, _) -> leftKi = rightKi
-        | _ -> 
-            let left = targetName.KeyInputs 
-            let right = x.KeyInputs
-            if left.Length <= right.Length then
-                SeqUtil.contentsEqual (left |> Seq.ofList) (right |> Seq.ofList |> Seq.take left.Length)
-            else false
+    member x.StartsWith (keyInputSet: KeyInputSet) = 
+        let left = keyInputSet.KeyInputs 
+        let right = x.KeyInputs
+        if left.Length <= right.Length then
+            SeqUtil.contentsEqual (left |> Seq.ofList) (right |> Seq.ofList |> Seq.take left.Length)
+        else false
+
+    static member Empty = s_empty
 
     member x.CompareTo (other: KeyInputSet) = 
-        let rec inner (left:KeyInput list) (right:KeyInput list) =
-            if left.IsEmpty && right.IsEmpty then 0
-            elif left.IsEmpty then -1
-            elif right.IsEmpty then 1
-            elif left.Head < right.Head then -1
-            elif left.Head > right.Head then 1
-            else inner (List.tail left) (List.tail right)
-        inner x.KeyInputs other.KeyInputs
+        if x.Length <> other.Length then
+            x.Length - other.Length 
+        else
+            let mutable left = x.KeyInputs
+            let mutable right = other.KeyInputs
+            let mutable value = 0
+            while not left.IsEmpty do
+                value <- left.Head.CompareTo right.Head
+                if value <> 0 then
+                    left <- []
+                else
+                    left <- left.Tail
+                    right <- right.Tail
+            value
 
     override x.GetHashCode() = 
-        match x with
-        | Empty -> 1
-        | OneKeyInput ki -> ki.GetHashCode()
-        | TwoKeyInputs (k1, k2) -> k1.GetHashCode() ^^^ k2.GetHashCode()
-        | ManyKeyInputs list -> 
-            list 
-            |> Seq.ofList
-            |> Seq.map (fun ki -> ki.GetHashCode())
-            |> Seq.sum
+        let mutable hashCode = 1
+        let mutable current = x.KeyInputs
+        while not current.IsEmpty do
+            hashCode <- 
+                if hashCode = 1 then current.Head.GetHashCode()
+                else hashCode ^^^ current.Head.GetHashCode()
+            current <- current.Tail
+        hashCode
 
     override x.Equals(yobj) =
         match yobj with
-        | :? KeyInputSet as y -> 
-            match x,y with
-            | OneKeyInput(left),OneKeyInput(right) -> left = right
-            | TwoKeyInputs(l1,l2),TwoKeyInputs(r1,r2) -> l1 = r1 && l2 = r2
-            | _ -> ListUtil.contentsEqual x.KeyInputs y.KeyInputs
+        | :? KeyInputSet as y -> (x.CompareTo y) = 0
         | _ -> false
 
     static member op_Equality(this,other) = System.Collections.Generic.EqualityComparer<KeyInputSet>.Default.Equals(this,other)
@@ -1433,29 +1419,26 @@ type KeyInputSet =
 
 module KeyInputSetUtil =
 
+    let Empty = KeyInputSet([])
+
     let OfSeq sequence = 
-        match Seq.length sequence with
-        | 0 -> KeyInputSet.Empty
-        | 1 -> KeyInputSet.OneKeyInput (Seq.item 0 sequence)
-        | 2 -> KeyInputSet.TwoKeyInputs ((Seq.item 0 sequence),(Seq.item 1 sequence))
-        | _ -> sequence |> List.ofSeq |> KeyInputSet.ManyKeyInputs 
+        let list = List.ofSeq sequence
+        KeyInputSet(list)
 
-    let OfList list = 
-        match list with
-        | [] -> KeyInputSet.Empty
-        | [ki] -> KeyInputSet.OneKeyInput ki
-        | _ -> 
-            match list.Length with
-            | 2 -> KeyInputSet.TwoKeyInputs ((List.item 0 list),(List.item 1 list))
-            | _ -> KeyInputSet.ManyKeyInputs list
+    let OfList (list: KeyInput list) = 
+        KeyInputSet(list)
 
-    let OfChar c = c |> KeyInputUtil.CharToKeyInput |> KeyInputSet.OneKeyInput
+    let OfChar c = 
+        let keyInput = KeyInputUtil.CharToKeyInput c
+        KeyInputSet([keyInput])
 
     let OfCharArray ([<System.ParamArray>] arr) = 
-        arr
-        |> Seq.ofArray
-        |> Seq.map KeyInputUtil.CharToKeyInput
-        |> OfSeq
+        let list = 
+            arr
+            |> Seq.ofArray
+            |> Seq.map KeyInputUtil.CharToKeyInput
+            |> List.ofSeq
+        KeyInputSet(list)
 
     let OfString (str:string) = str |> Seq.map KeyInputUtil.CharToKeyInput |> OfSeq
 
@@ -1464,6 +1447,9 @@ module KeyInputSetUtil =
         |> Seq.ofArray 
         |> Seq.map KeyInputUtil.VimKeyToKeyInput
         |> OfSeq
+
+    let Single (keyInput: KeyInput) =
+        KeyInputSet(keyInput)
 
     let Combine (left: KeyInputSet) (right: KeyInputSet) =
         let all = left.KeyInputs @ right.KeyInputs

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3781,8 +3781,11 @@ type IMotionCapture =
 /// Responsible for managing a set of Commands and running them
 type ICommandRunner =
 
-    /// Set of Commands currently supported
+    /// Set of Commands currently supported.
     abstract Commands: CommandBinding seq
+
+    /// Count of commands currently supported.
+    abstract CommandCount: int
 
     /// In certain circumstances a specific type of key remapping needs to occur for input.  This 
     /// option will have the appropriate value in those circumstances.  For example while processing

--- a/Src/VimCore/DisabledMode.fs
+++ b/Src/VimCore/DisabledMode.fs
@@ -24,7 +24,7 @@ type internal DisabledMode(_vimBufferData: IVimBufferData) =
         member x.VimTextBuffer = _vimBufferData.VimTextBuffer
         member x.HelpMessage = x.HelpString
         member x.ModeKind = ModeKind.Disabled        
-        member x.CommandNames = Seq.singleton _globalSettings.DisableAllCommand |> Seq.map KeyInputSet.OneKeyInput
+        member x.CommandNames = Seq.singleton (KeyInputSet(_globalSettings.DisableAllCommand))
         member x.CanProcess ki = ki = _globalSettings.DisableAllCommand
         member x.Process keyInput = x.Process keyInput
         member x.OnEnter _  = ()

--- a/Src/VimCore/KeyInput.fsi
+++ b/Src/VimCore/KeyInput.fsi
@@ -34,6 +34,9 @@ type KeyInput =
     /// Is this a mouse key
     member IsMouseKey: bool
 
+    /// Compare to another KeyInput value
+    member CompareTo: other: KeyInput -> int
+
     /// The empty KeyInput.  Used in places where a KeyInput is required but no 
     /// good mapping exists
     static member DefaultValue: KeyInput

--- a/Src/VimCore/KeyMap.fs
+++ b/Src/VimCore/KeyMap.fs
@@ -38,7 +38,7 @@ type Mapper
                 match lhs.FirstKeyInput, keyMapping.Right.FirstKeyInput with
                 | Some leftKey, Some rightKey ->
                     if leftKey = rightKey then
-                        let mappedSet = KeyInputSet.OneKeyInput leftKey
+                        let mappedSet = KeyInputSet(leftKey)
                         let remainingSet = keyMapping.Right.KeyInputs |> List.tail |> KeyInputSetUtil.OfList
                         mappedSet, remainingSet
                     else
@@ -112,7 +112,7 @@ type Mapper
                 isDone := true
             elif not _isZeroMappingEnabled && Mapper.IsFirstKeyInputZero lhs then
                 // 0 mapping is disabled and we have a 0 input so we are done
-                let mappedKeyInputSet = KeyInputUtil.CharToKeyInput '0' |> KeyInputSet.OneKeyInput
+                let mappedKeyInputSet = KeyInputUtil.CharToKeyInput '0' |> KeyInputSetUtil.Single
                 let remainingKeyInputSet = lhs.Rest |> KeyInputSetUtil.OfList
                 successfulMap mappedKeyInputSet remainingKeyInputSet
             else
@@ -149,7 +149,7 @@ type Mapper
                 else
                     // First character can't be mapped but the rest is still eligible for 
                     // mapping after that character is complete 
-                    let mapped = KeyInputSet.OneKeyInput lhs.FirstKeyInput.Value
+                    let mapped = KeyInputSet(lhs.FirstKeyInput.Value)
                     let remaining = lhs.Rest |> KeyInputSetUtil.OfList
                     result := KeyMappingResult.PartiallyMapped (mapped, remaining)
                     isDone := true

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -167,7 +167,7 @@ type internal CommandMode
         member x.Command 
             with get() = x.Command
             and set value = x.ChangeCommand value
-        member x.CommandNames = HistoryUtil.CommandNames |> Seq.map KeyInputSet.OneKeyInput
+        member x.CommandNames = HistoryUtil.CommandNames |> Seq.map KeyInputSetUtil.Single
         member x.InPasteWait = x.InPasteWait
         member x.ModeKind = ModeKind.Command
         member x.CanProcess keyInput = not keyInput.IsMouseKey

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -299,7 +299,7 @@ type internal InsertMode
 
     member x.CommandNames =
         x.EnsureCommandsBuilt()
-        _commandMap |> Seq.map (fun p -> p.Key) |> Seq.map KeyInputSet.OneKeyInput
+        _commandMap |> Seq.map (fun p -> p.Key) |> Seq.map KeyInputSetUtil.Single
 
     member x.BuildCommands () =
 
@@ -374,7 +374,7 @@ type internal InsertMode
             InsertCommandDataArray
             |> Seq.append applicableNoSelectionCommands
             |> Seq.map (fun (keyInput, insertCommand, commandFlags) ->
-                let keyInputSet = KeyInputSet.OneKeyInput keyInput
+                let keyInputSet = KeyInputSet(keyInput)
                 let rawInsertCommand = RawInsertCommand.InsertCommand (keyInputSet, insertCommand, commandFlags)
                 (keyInput, rawInsertCommand))
 
@@ -480,7 +480,7 @@ type internal InsertMode
                             let text = StringUtil.OfChar c
                             InsertCommand.Insert text
                     let commandFlags = CommandFlags.Repeatable ||| CommandFlags.InsertEdit
-                    let keyInputSet = KeyInputSet.OneKeyInput keyInput
+                    let keyInputSet = KeyInputSet(keyInput)
                     RawInsertCommand.InsertCommand (keyInputSet, command, commandFlags) |> Some
 
                 if keyInput.KeyModifiers <> VimKeyModifiers.None && not (CharUtil.IsLetterOrDigit c) then
@@ -827,7 +827,7 @@ type internal InsertMode
                     let newLine = _operations.GetNewLineText x.CaretPoint
                     EditUtil.NormalizeNewLines text newLine
 
-                let keyInputSet = KeyInputSet.OneKeyInput keyInput
+                let keyInputSet = KeyInputSet(keyInput)
                 let insertCommand = if isOverwrite then InsertCommand.Overwrite text else InsertCommand.Insert text
                 x.RunInsertCommand insertCommand keyInputSet CommandFlags.InsertEdit
 

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -216,7 +216,7 @@ type internal NormalMode
     member x.TextView = _vimBufferData.TextView
     member x.TextBuffer = _vimTextBuffer.TextBuffer
     member x.CaretPoint = this.TextView.Caret.Position.BufferPosition
-    member x.IsCommandRunnerPopulated = _runner.Commands |> SeqUtil.isNotEmpty
+    member x.IsCommandRunnerPopulated = _runner.CommandCount > 0
     member x.KeyRemapMode = 
         if _runner.IsWaitingForMoreInput then
             _runner.KeyRemapMode

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -314,7 +314,7 @@ type internal NormalMode
 
     /// Get the information on how to handle the tilde command based on the current setting for 'tildeop'
     member x.GetTildeCommand() =
-        let name = KeyInputUtil.CharToKeyInput '~' |> KeyInputSet.OneKeyInput
+        let name = KeyInputUtil.CharToKeyInput '~' |> KeyInputSetUtil.Single
         let flags = CommandFlags.Repeatable
         let command = 
             if _globalSettings.TildeOp then
@@ -347,8 +347,8 @@ type internal NormalMode
         _data <- EmptyData
 
     member x.CanProcess (keyInput: KeyInput) =
-        let doesCommandStartWith keyInput =
-            let name = KeyInputSet.OneKeyInput keyInput
+        let doesCommandStartWith (keyInput: KeyInput) =
+            let name = KeyInputSet(keyInput)
             _runner.Commands 
             |> Seq.filter (fun command -> command.KeyInputSet.StartsWith name)
             |> SeqUtil.isNotEmpty

--- a/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
+++ b/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
@@ -185,7 +185,7 @@ type internal SubstituteConfirmMode
 
     interface ISubstituteConfirmMode with
         member x.CanProcess keyInput = x.CanProcess keyInput
-        member x.CommandNames = _commandMap |> Seq.map (fun pair -> KeyInputSet.OneKeyInput pair.Key)
+        member x.CommandNames = _commandMap |> Seq.map (fun pair -> KeyInputSet(pair.Key))
         member x.CurrentMatch = x.CurrentMatch
         member x.CurrentSubstitute = x.CurrentSubstitute
         member x.ModeKind = ModeKind.SubstituteConfirm

--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -409,11 +409,11 @@ type internal VimBuffer
 
     /// Get the correct mapping of the given KeyInput value in the current state of the 
     /// IVimBuffer.  This will consider any buffered KeyInput values 
-    member x.GetKeyInputMapping keyInput =
+    member x.GetKeyInputMapping (keyInput: KeyInput) =
 
         let keyInputSet = 
             match _bufferedKeyInput with
-            | None -> KeyInputSet.OneKeyInput keyInput
+            | None -> KeyInputSet(keyInput)
             | Some bufferedKeyInputSet -> bufferedKeyInputSet.Add keyInput
 
         x.GetKeyMappingCore keyInputSet x.KeyRemapMode
@@ -572,7 +572,7 @@ type internal VimBuffer
             | KeyRemapMode.None -> 
                 // There is no mode for the current key stroke but may be for the subsequent
                 // ones in the set.  Process the first one only here 
-                remainingSet.Value.FirstKeyInput.Value |> KeyInputSet.OneKeyInput |> processSet
+                remainingSet.Value.FirstKeyInput.Value |> KeyInputSetUtil.Single |> processSet
                 remainingSet := remainingSet.Value.Rest |> KeyInputSetUtil.OfList
             | _ -> 
                 let keyMappingResult = x.GetKeyMappingCore remainingSet.Value x.KeyRemapMode
@@ -636,7 +636,7 @@ type internal VimBuffer
                 // this KeyInput needs more input then it will be re-buffered
                 let keyInputSet = 
                     match _bufferedKeyInput with
-                    | None -> KeyInputSet.OneKeyInput keyInput
+                    | None -> KeyInputSet(keyInput)
                     | Some bufferedKeyInputSet -> bufferedKeyInputSet.Add keyInput
                 _bufferedKeyInput <- None
 

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -653,7 +653,7 @@ namespace Vim.UnitTest
 
         public static IEnumerable<KeyInput> GetKeyMapping(this IKeyMap keyMap, KeyInput ki, KeyRemapMode mode)
         {
-            return GetKeyMapping(keyMap, KeyInputSet.NewOneKeyInput(ki), mode);
+            return GetKeyMapping(keyMap, new KeyInputSet(ki), mode);
         }
 
         public static IEnumerable<KeyInput> GetKeyMapping(this IKeyMap keyMap, KeyInputSet kiSet, KeyRemapMode mode)
@@ -663,7 +663,7 @@ namespace Vim.UnitTest
 
         public static KeyMappingResult GetKeyMappingResult(this IKeyMap keyMap, KeyInput ki, KeyRemapMode mode)
         {
-            return GetKeyMappingResult(keyMap, KeyInputSet.NewOneKeyInput(ki), mode);
+            return GetKeyMappingResult(keyMap, new KeyInputSet(ki), mode);
         }
 
         public static KeyMappingResult GetKeyMappingResult(this IKeyMap keyMap, KeyInputSet set, KeyRemapMode mode)

--- a/Src/VimTestUtils/VimUtil.cs
+++ b/Src/VimTestUtils/VimUtil.cs
@@ -82,7 +82,7 @@ namespace Vim.UnitTest
         {
             var fsharpFunc = func.ToFSharpFunc();
             var list = name.Select(KeyInputUtil.CharToKeyInput).ToFSharpList();
-            var commandName = KeyInputSet.NewManyKeyInputs(list);
+            var commandName = new KeyInputSet(list);
             var command = NormalCommand.NewPing(new PingData(fsharpFunc));
             return CommandBinding.NewNormalBinding(commandName, CommandFlags.None, command);
         }

--- a/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
+++ b/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
@@ -57,7 +57,7 @@ namespace Vim.VisualStudio.Implementation.Misc
             if (result.IsMapped)
             {
                 var set = ((KeyMappingResult.Mapped)result).Item;
-                if (!set.IsOneKeyInput)
+                if (set.Length != 1)
                 {
                     mapped = null;
                     return false;

--- a/Test/VimCoreTest/CommandNameTest.cs
+++ b/Test/VimCoreTest/CommandNameTest.cs
@@ -8,23 +8,24 @@ namespace Vim.UnitTest
     {
         private KeyInputSet CreateOne(char c)
         {
-            return KeyInputSet.NewOneKeyInput(KeyInputUtil.CharToKeyInput(c));
+            return new KeyInputSet(KeyInputUtil.CharToKeyInput(c));
         }
 
         private KeyInputSet CreateTwo(char c1, char c2)
         {
-            return KeyInputSet.NewTwoKeyInputs(KeyInputUtil.CharToKeyInput(c1), KeyInputUtil.CharToKeyInput(c2));
+            var keyInputSet = new KeyInputSet(KeyInputUtil.CharToKeyInput(c1));
+            return keyInputSet.Add(KeyInputUtil.CharToKeyInput(c2));
         }
 
         private KeyInputSet CreateMany(params char[] all)
         {
-            return KeyInputSet.NewManyKeyInputs(all.Select(KeyInputUtil.CharToKeyInput).ToFSharpList());
+            return new KeyInputSet(all.Select(KeyInputUtil.CharToKeyInput).ToFSharpList());
         }
 
         [Fact]
         public void Add1()
         {
-            var name1 = KeyInputSet.NewOneKeyInput(KeyInputUtil.CharToKeyInput('c'));
+            var name1 = new KeyInputSet(KeyInputUtil.CharToKeyInput('c'));
             var name2 = name1.Add(KeyInputUtil.CharToKeyInput('a'));
             Assert.Equal("ca", name2.Name);
         }
@@ -32,7 +33,7 @@ namespace Vim.UnitTest
         [Fact]
         public void Name1()
         {
-            var name1 = KeyInputSet.NewOneKeyInput(KeyInputUtil.CharToKeyInput('c'));
+            var name1 = new KeyInputSet(KeyInputUtil.CharToKeyInput('c'));
             Assert.Equal("c", name1.Name);
         }
 
@@ -48,7 +49,7 @@ namespace Vim.UnitTest
                 EqualityUnit.Create(CreateOne('a')).WithNotEqualValues(CreateOne('b')),
                 EqualityUnit.Create(CreateOne('a')).WithEqualValues(CreateMany('a')),
                 EqualityUnit.Create(CreateOne('D')).WithEqualValues(KeyNotationUtil.StringToKeyInputSet("D")),
-                EqualityUnit.Create(KeyInputSet.NewOneKeyInput(KeyInputUtil.CharToKeyInput('D'))).WithEqualValues(KeyNotationUtil.StringToKeyInputSet("D")));
+                EqualityUnit.Create(new KeyInputSet(KeyInputUtil.CharToKeyInput('D'))).WithEqualValues(KeyNotationUtil.StringToKeyInputSet("D")));
         }
     }
 }

--- a/Test/VimCoreTest/InsertModeTest.cs
+++ b/Test/VimCoreTest/InsertModeTest.cs
@@ -403,7 +403,7 @@ namespace Vim.UnitTest
             public void Control_OpenBracket1()
             {
                 var ki = KeyInputUtil.CharWithControlToKeyInput('[');
-                var name = KeyInputSet.NewOneKeyInput(ki);
+                var name = new KeyInputSet(ki);
                 Assert.Contains(name, _mode.CommandNames);
             }
 

--- a/Test/VimCoreTest/KeyInputSetTest.cs
+++ b/Test/VimCoreTest/KeyInputSetTest.cs
@@ -9,8 +9,8 @@ namespace Vim.UnitTest
         [Fact]
         public void Compare_AlternateKeyInputShouldBeEqual()
         {
-            var left = KeyInputSet.NewOneKeyInput(KeyInputUtil.EnterKey);
-            var right = KeyInputSet.NewOneKeyInput(KeyInputUtil.CharWithControlToKeyInput('m'));
+            var left = new KeyInputSet(KeyInputUtil.EnterKey);
+            var right = new KeyInputSet(KeyInputUtil.CharWithControlToKeyInput('m'));
             Assert.True(0 == left.CompareTo(right));
             Assert.True(0 == right.CompareTo(left));
         }
@@ -18,8 +18,8 @@ namespace Vim.UnitTest
         [Fact]
         public void Compare_AlternateKeyInputShouldBeEqualInMap()
         {
-            var left = KeyInputSet.NewOneKeyInput(KeyInputUtil.EnterKey);
-            var right = KeyInputSet.NewOneKeyInput(KeyInputUtil.CharWithControlToKeyInput('m'));
+            var left = new KeyInputSet(KeyInputUtil.EnterKey);
+            var right = new KeyInputSet(KeyInputUtil.CharWithControlToKeyInput('m'));
             var map = MapModule.Empty<KeyInputSet, bool>().Add(left, true);
             var result = MapModule.TryFind(right, map);
             Assert.True(result.IsSome());

--- a/Test/VimCoreTest/KeyMapTest.cs
+++ b/Test/VimCoreTest/KeyMapTest.cs
@@ -376,7 +376,7 @@ namespace Vim.UnitTest
             {
                 Map("<D-k>", "gk");
                 var ki = new KeyInput(VimKey.RawCharacter, VimKeyModifiers.Command, FSharpOption.Create('k'));
-                var kiSet = KeyInputSet.NewOneKeyInput(ki);
+                var kiSet = new KeyInputSet(ki);
                 AssertPartialMapping(kiSet, "g", "k");
             }
 
@@ -703,7 +703,7 @@ namespace Vim.UnitTest
                 _map.MapWithNoRemap("aa", "b", KeyRemapMode.Normal);
 
                 var input = "aa".Select(KeyInputUtil.CharToKeyInput).ToFSharpList();
-                var res = _map.GetKeyMapping(KeyInputSet.NewManyKeyInputs(input), KeyRemapMode.Normal);
+                var res = _map.GetKeyMapping(new KeyInputSet(input), KeyRemapMode.Normal);
                 Assert.Equal('b', res.AsMapped().Item.KeyInputs.Single().Char);
             }
 
@@ -713,7 +713,7 @@ namespace Vim.UnitTest
                 _map.MapWithNoRemap("aa", "b", KeyRemapMode.Normal);
 
                 var input = "a".Select(KeyInputUtil.CharToKeyInput).ToFSharpList();
-                var res = _map.GetKeyMapping(KeyInputSet.NewManyKeyInputs(input), KeyRemapMode.Normal);
+                var res = _map.GetKeyMapping(new KeyInputSet(input), KeyRemapMode.Normal);
                 Assert.True(res.IsNeedsMoreInput);
             }
 

--- a/Test/VimCoreTest/KeyNotationUtilTest.cs
+++ b/Test/VimCoreTest/KeyNotationUtilTest.cs
@@ -274,7 +274,7 @@ namespace Vim.UnitTest
             [Fact]
             public void EscapeLessThanLiteral()
             {
-                var set = KeyInputSet.NewTwoKeyInputs(
+                var set = new KeyInputSet(
                     KeyInputUtil.CharToKeyInput('\\'),
                     KeyInputUtil.VimKeyToKeyInput(VimKey.Home));
                 AssertMany(@"\<home>", set);

--- a/Test/VimCoreTest/MotionCaptureTest.cs
+++ b/Test/VimCoreTest/MotionCaptureTest.cs
@@ -479,7 +479,7 @@ namespace Vim.UnitTest
         [WpfFact]
         public void CommandMapSupportsAlternateKeys()
         {
-            Assert.True(MapModule.TryFind(KeyInputSet.NewOneKeyInput(KeyInputUtil.EnterKey), _captureRaw.MotionBindingsMap).IsSome());
+            Assert.True(MapModule.TryFind(new KeyInputSet(KeyInputUtil.EnterKey), _captureRaw.MotionBindingsMap).IsSome());
         }
 
         [WpfFact]

--- a/Test/VimCoreTest/NormalModeTest.cs
+++ b/Test/VimCoreTest/NormalModeTest.cs
@@ -1129,7 +1129,7 @@ namespace Vim.UnitTest
         {
             Create(s_defaultLines);
             var def = KeyInputUtil.CharWithControlToKeyInput(']');
-            var name = KeyInputSet.NewOneKeyInput(def);
+            var name = new KeyInputSet(def);
             Assert.True(_mode.CanProcess(def));
             Assert.Contains(name, _mode.CommandNames);
         }

--- a/Test/VimCoreTest/VisualModeTest.cs
+++ b/Test/VimCoreTest/VisualModeTest.cs
@@ -79,7 +79,7 @@ namespace Vim.UnitTest
             var commands = _mode.CommandNames.ToList();
             foreach (var item in list)
             {
-                var name = KeyInputSet.NewOneKeyInput(item);
+                var name = new KeyInputSet(item);
                 Assert.Contains(name, commands);
             }
         }


### PR DESCRIPTION
Profiling VsVim recently I discovered a couple of sources of significant and unneeded allocations:

1. Normal mode was using `ICommandRunners.Commands` to see if commands had been populated yet. Under the hood that was doing a transform on a large map and represented nearly half the allocations on unit testing and a significant amount of CPU time. 
1. `KeyInputSet.CompareTo` was allocating `KeyInput list` instances at a very high volume. 