### PR TITLE
Fix caret position when using put as a one-time command

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -2063,7 +2063,13 @@ type internal CommandUtil
                             let offset = text.Length - 1
                             let offset = max 0 offset
                             let point = SnapshotPointUtil.Add offset point
-                            if moveCaretAfterText then SnapshotPointUtil.AddOneOrCurrent point else point
+
+                            // Vim always moves the caret after the text when
+                            // a put is used as a one-time command.
+                            if moveCaretAfterText || _vimTextBuffer.InOneTimeCommand.IsSome then
+                                SnapshotPointUtil.AddOneOrCurrent point
+                            else
+                                point
                     | StringData.Block col, false ->
                         if moveCaretAfterText then
                             // Needs to be positioned after the last item in the collection

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -394,10 +394,13 @@ type internal CommonOperations
     /// this here
     member x.AdjustCaretForVirtualEdit() =
 
+        // Vim allows the caret past the end of the line if we are in a
+        // one-time command and returning to insert mode momentarily.
         let allowPastEndOfLine = 
             _vimTextBuffer.ModeKind = ModeKind.Insert ||
             _globalSettings.IsVirtualEditOneMore ||
-            VisualKind.IsAnySelect _vimTextBuffer.ModeKind
+            VisualKind.IsAnySelect _vimTextBuffer.ModeKind ||
+            _vimTextBuffer.InOneTimeCommand.IsSome
 
         if not allowPastEndOfLine && not (VisualKind.IsAnyVisual _vimTextBuffer.ModeKind) then
             let point = TextViewUtil.GetCaretPoint _textView

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4891,6 +4891,10 @@ and IVimTextBuffer =
     /// The end point of the last change or yank
     abstract LastChangeOrYankEnd: SnapshotPoint option with get, set
 
+    /// If we are in the middle of processing a "one time command" (<c-o>) then this will
+    /// hold the ModeKind which will be switched back to after it's completed
+    abstract InOneTimeCommand: ModeKind option with get, set
+
     /// The set of active local marks in the ITextBuffer
     abstract LocalMarks: (LocalMark * VirtualSnapshotPoint) seq
 

--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -191,11 +191,6 @@ type internal VimBuffer
     let mutable _processingInputCount = 0
     let mutable _isClosed = false
 
-    /// Are we in the middle of executing a single action in a given mode after which we
-    /// return back to insert mode.  When Some the value can only be Insert or Replace as 
-    /// they are the only modes to issue the command
-    let mutable _inOneTimeCommand: ModeKind option = None
-
     /// This is the buffered input when a remap request needs more than one 
     /// element
     let mutable _bufferedKeyInput: KeyInputSet option = None
@@ -244,8 +239,8 @@ type internal VimBuffer
         | Some keyInputSet -> keyInputSet.KeyInputs
 
     member x.InOneTimeCommand 
-        with get() = _inOneTimeCommand
-        and set value = _inOneTimeCommand <- value
+        with get() = _vimTextBuffer.InOneTimeCommand
+        and set value = _vimTextBuffer.InOneTimeCommand <- value
     
     member x.ModeMap = _modeMap
     member x.Mode = _modeMap.Mode
@@ -318,7 +313,7 @@ type internal VimBuffer
             elif keyInput.Key = VimKey.Nop then
                 // The nop key can be processed at all times
                 true
-            elif keyInput.Key = VimKey.Escape && Option.isSome _inOneTimeCommand then
+            elif keyInput.Key = VimKey.Escape && _vimTextBuffer.InOneTimeCommand.IsSome then
                 // Inside a one command state Escape is valid and returns us to the original
                 // mode.  This check is necessary because certain modes like Normal don't handle
                 // Escape themselves but Escape should force us back to Insert even here
@@ -492,14 +487,14 @@ type internal VimBuffer
                     // Certain types of commands can always cause the current mode to be exited for
                     // the previous one time command mode.  Handle them here
                     let maybeLeaveOneCommand() = 
-                        match _inOneTimeCommand with
+                        match _vimTextBuffer.InOneTimeCommand with
                         | Some modeKind ->
 
                             // A completed command ends one command mode for all modes but visual.  We
                             // stay in Visual Mode until it actually exists.  Else the simplest movement
                             // command like 'l' would cause it to exit immediately
                             if VisualKind.IsAnySelect modeKind || not (VisualKind.IsAnyVisual x.Mode.ModeKind) then
-                                _inOneTimeCommand <- None
+                                _vimTextBuffer.InOneTimeCommand <- None
                                 x.SwitchMode modeKind ModeArgument.None |> ignore
                         | None ->
                             ()
@@ -518,15 +513,15 @@ type internal VimBuffer
                         | ModeSwitch.SwitchPreviousMode -> 
                             // The previous mode is interpreted as Insert when we are in the middle
                             // of a one command
-                            match _inOneTimeCommand with
+                            match _vimTextBuffer.InOneTimeCommand with
                             | Some modeKind ->
-                                _inOneTimeCommand <-None
+                                _vimTextBuffer.InOneTimeCommand <-None
                                 x.SwitchMode modeKind ModeArgument.None |> ignore
                             | None ->
                                 x.SwitchPreviousMode() |> ignore
                         | ModeSwitch.SwitchModeOneTimeCommand modeKind ->
                             // Begins one command mode and immediately switches to the target mode
-                            _inOneTimeCommand <- Some x.Mode.ModeKind
+                            _vimTextBuffer.InOneTimeCommand <- Some x.Mode.ModeKind
                             x.SwitchMode modeKind ModeArgument.None |> ignore
                     | ProcessResult.HandledNeedMoreInput ->
                         ()

--- a/Src/VimCore/VimTextBuffer.fs
+++ b/Src/VimCore/VimTextBuffer.fs
@@ -31,6 +31,7 @@ type internal VimTextBuffer
     let mutable _lastChangeOrYankStart: ITrackingLineColumn option = None
     let mutable _lastChangeOrYankEnd: ITrackingLineColumn option = None
     let mutable _isSoftTabStopValidForBackspace = true
+    let mutable _inOneTimeCommand: ModeKind option = None
 
     /// Raise the mark set event
     member x.RaiseMarkSet localMark =
@@ -165,6 +166,10 @@ type internal VimTextBuffer
                     Some trackingLineColumn
 
             x.RaiseMarkSet LocalMark.LastChangeOrYankEnd
+
+     member x.InOneTimeCommand
+        with get() = _inOneTimeCommand
+        and set value = _inOneTimeCommand <- value
 
     member x.IsSoftTabStopValidForBackspace 
         with get() = _isSoftTabStopValidForBackspace
@@ -301,6 +306,9 @@ type internal VimTextBuffer
         member x.LastChangeOrYankEnd
             with get() = x.LastChangeOrYankEnd
             and set value = x.LastChangeOrYankEnd <- value
+        member x.InOneTimeCommand
+            with get() = x.InOneTimeCommand
+            and set value = x.InOneTimeCommand <- value
         member x.LocalMarks = x.LocalMarks
         member x.LocalSettings = _localSettings
         member x.ModeKind = _modeKind

--- a/Test/VimCoreTest/CommonOperationsTest.cs
+++ b/Test/VimCoreTest/CommonOperationsTest.cs
@@ -76,6 +76,7 @@ namespace Vim.UnitTest
                 undoRedoOperations: _undoRedoOperations,
                 factory: _factory);
             _vimTextBuffer.SetupGet(x => x.UseVirtualSpace).Returns(false);
+            _vimTextBuffer.SetupGet(x => x.InOneTimeCommand).Returns(FSharpOption<ModeKind>.None);
 
             // Create the VimBufferData instance with our Mock'd services
             _jumpList = _factory.Create<IJumpList>();

--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -1702,7 +1702,7 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
-            /// Execute a one time command of delete word
+            /// Execute a one time command of ':put'
             /// </summary>
             [WpfFact]
             public void OneTimeCommand_CommandMode_Put()
@@ -1728,6 +1728,42 @@ namespace Vim.UnitTest
                 Create("");
                 _vimBuffer.Process(KeyInputUtil.CharWithControlToKeyInput('o'));
                 _vimBuffer.Process(VimKey.Escape);
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.True(_vimBuffer.InOneTimeCommand.IsNone());
+            }
+
+            /// <summary>
+            /// Using put as a one-time command should always place the caret
+            /// after the inserted text
+            /// </summary>
+            [WpfFact]
+            public void OneTimeCommand_Put_MiddleOfLine()
+            {
+                // Reported in issue #1065.
+                Create("cat", "");
+                Vim.RegisterMap.GetRegister(RegisterName.Unnamed).UpdateValue("dog");
+                _textView.MoveCaretTo(1);
+                _vimBuffer.ProcessNotation("<C-o>p");
+                Assert.Equal("cadogt", _textBuffer.GetLine(0).GetText());
+                Assert.Equal(5, _textView.GetCaretPoint().Position);
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.True(_vimBuffer.InOneTimeCommand.IsNone());
+            }
+
+            /// <summary>
+            /// Using put as a one-time command should always place the caret
+            /// after the inserted text, even at the end of a line
+            /// </summary>
+            [WpfFact]
+            public void OneTimeCommand_Put_EndOfLine()
+            {
+                // Reported in issue #1065.
+                Create("cat", "");
+                Vim.RegisterMap.GetRegister(RegisterName.Unnamed).UpdateValue("dog");
+                _textView.MoveCaretTo(3);
+                _vimBuffer.ProcessNotation("<C-o>p");
+                Assert.Equal("catdog", _textBuffer.GetLine(0).GetText());
+                Assert.Equal(6, _textView.GetCaretPoint().Position);
                 Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
                 Assert.True(_vimBuffer.InOneTimeCommand.IsNone());
             }


### PR DESCRIPTION
#### Changes

- Push 'in one-time command' state down into vim text buffer
- Always use 'move caret after text' when putting as a one-time command
- Allow caret past the end of the line during a one-time command

#### Issues

- Fixes #1065
