### PR TITLE
Pattern line specifiers

### DIFF
--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -588,11 +588,8 @@ and [<RequireQualifiedAccess>] LineCommand =
     /// start the join after the line range
     | Join of LineRangeSpecifier * JoinKind
 
-    /// Jump to the specified line number 
-    | JumpToLine of int
-
-    /// Jump to the last line of the ITextBuffer
-    | JumpToLastLine
+    /// Jump to the last line of the specified line range
+    | JumpToLastLine of LineRangeSpecifier
 
     // Let command.  The first item is the name and the second is the value
     | Let of VariableName * Expression

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -379,7 +379,7 @@ type VimInterpreter
         let wordNavigator = _vimBufferData.VimTextBuffer.WordNavigator
         let result = _searchService.FindNextPattern startPoint searchData wordNavigator 1
         match result with
-        | SearchResult.Found (searchData, span, _, _) ->
+        | SearchResult.Found (_, span, _, _) ->
             span.Start 
             |> SnapshotPointUtil.GetContainingLine
             |> Some

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -330,6 +330,11 @@ type VimInterpreter
             x.GetLine lineSpecifier |> OptionUtil.map2 (getAdjustment adjustment)
 
         | LineSpecifier.NextLineWithPattern pattern ->
+            let pattern =
+                if pattern = "" then
+                    _vim.VimData.LastSearchData.Pattern
+                else
+                    pattern
             x.GetMatchingLine pattern SearchPath.Forward
             |> Option.map getLineAndNumber
 
@@ -348,6 +353,11 @@ type VimInterpreter
                 None
 
         | LineSpecifier.PreviousLineWithPattern pattern ->
+            let pattern =
+                if pattern = "" then
+                    _vim.VimData.LastSearchData.Pattern
+                else
+                    pattern
             x.GetMatchingLine pattern SearchPath.Backward
             |> Option.map getLineAndNumber
 

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1384,8 +1384,15 @@ type VimInterpreter
                 if StringUtil.IsNullOrEmpty pattern then _vimData.LastSearchData.Pattern
                 else pattern
     
-            // Searches start after the end of the specified line range
-            let startPoint = lineRange.End
+            // The search start after the end of the specified line range or
+            // before its beginning.
+            let startPoint =
+                match path with
+                | SearchPath.Forward ->
+                    lineRange.End
+                | SearchPath.Backward ->
+                    lineRange.Start
+
             let searchData = SearchData(pattern, path, _globalSettings.WrapScan)
             let result = _searchService.FindNextPattern startPoint searchData _vimBufferData.VimTextBuffer.WordNavigator 1
             _commonOperations.RaiseSearchResultMessage(result)

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -810,8 +810,7 @@ type Parser
             | LineCommand.IfEnd -> noRangeCommand
             | LineCommand.IfStart _ -> noRangeCommand
             | LineCommand.Join (_, joinKind) -> LineCommand.Join (lineRange, joinKind)
-            | LineCommand.JumpToLastLine -> noRangeCommand
-            | LineCommand.JumpToLine _ -> noRangeCommand
+            | LineCommand.JumpToLastLine _ -> LineCommand.JumpToLastLine lineRange
             | LineCommand.Let _ -> noRangeCommand
             | LineCommand.LetRegister _ -> noRangeCommand
             | LineCommand.Make _ -> noRangeCommand
@@ -1273,20 +1272,6 @@ type Parser
             LineCommand.Function func
         | _ -> LineCommand.ParseError Resources.Parser_Error
 
-    /// Parse out the :[digit] command
-    member x.ParseJumpToLine lineRange =
-        match lineRange with
-        | LineRangeSpecifier.SingleLine lineSpecifier ->
-            match lineSpecifier with
-            | LineSpecifier.Number number -> 
-                LineCommand.JumpToLine number
-            | LineSpecifier.LastLine ->
-                LineCommand.JumpToLastLine
-            | _ ->
-                LineCommand.ParseError Resources.Parser_Error
-        | _ ->
-            LineCommand.ParseError Resources.Parser_Error
-
     /// Parse a {pattern} out of the text.  The text will be consumed until the unescaped value 
     /// 'delimiter' is provided or the end of the input is reached.  The method will return a tuple
     /// of the pattern and a bool.  The bool will represent whether or not the delimiter was found.
@@ -1347,7 +1332,7 @@ type Parser
                     |> (fun number -> LineSpecifier.LineSpecifierWithAdjustment (LineSpecifier.CurrentLine, number))
                     |> Some
                 | _ ->
-                    Some LineSpecifier.CurrentLine
+                    LineSpecifier.CurrentLine |> Some
 
             elif _tokenizer.CurrentChar = '\'' then
                 let mark = _tokenizer.Mark
@@ -1363,7 +1348,7 @@ type Parser
 
             elif _tokenizer.CurrentChar = '$' || _tokenizer.CurrentChar = '%' then
                 _tokenizer.MoveNextToken()
-                Some LineSpecifier.LastLine
+                LineSpecifier.LastLine |> Some
 
             elif _tokenizer.CurrentChar = '\\' then
 
@@ -1386,34 +1371,24 @@ type Parser
             elif _tokenizer.CurrentChar = '/' then
 
                 // It's the / next search pattern.
-                let mark = _tokenizer.Mark
                 _tokenizer.MoveNextChar()
-                let pattern, foundDelimeter = x.ParsePattern '/'
-                if foundDelimeter then
-                    Some (LineSpecifier.NextLineWithPattern pattern)
-                else
-                    _tokenizer.MoveToMark mark
-                    None
+                let pattern, _ = x.ParsePattern '/'
+                LineSpecifier.NextLineWithPattern pattern |> Some
 
             elif _tokenizer.CurrentChar = '?' then
 
                 // It's the ? previous search pattern.
-                let mark = _tokenizer.Mark
                 _tokenizer.MoveNextChar()
-                let pattern, foundDelimeter = x.ParsePattern '?'
-                if foundDelimeter then
-                    Some (LineSpecifier.PreviousLineWithPattern pattern)
-                else
-                    _tokenizer.MoveToMark mark
-                    None
+                let pattern, _ = x.ParsePattern '?'
+                LineSpecifier.PreviousLineWithPattern pattern |> Some
 
             elif _tokenizer.CurrentChar = '+' || _tokenizer.CurrentChar = '-' then
-                Some LineSpecifier.CurrentLine
+                LineSpecifier.CurrentLine |> Some
 
             else 
                 match x.ParseNumber() with
                 | None -> None
-                | Some number -> Some (LineSpecifier.Number number)
+                | Some number -> LineSpecifier.Number number |> Some
 
         // Need to check for a trailing + or - 
         match lineSpecifier with
@@ -2454,8 +2429,8 @@ type Parser
 
             handleParseResult parseResult
 
-        // Get the command name and make sure to expand it to it's possible full
-        // name
+        // Get the command name and make sure to expand it to it's possible
+        // full name.
         match _tokenizer.CurrentTokenKind with
         | TokenKind.Word word ->
             _tokenizer.MoveNextToken()
@@ -2466,9 +2441,9 @@ type Parser
         | TokenKind.EndOfLine ->
             match lineRange with
             | LineRangeSpecifier.None -> handleParseResult LineCommand.Nop
-            | _ -> x.ParseJumpToLine lineRange |> handleParseResult
+            | _ -> LineCommand.JumpToLastLine lineRange |> handleParseResult
         | _ -> 
-            x.ParseJumpToLine lineRange |> handleParseResult
+            LineCommand.JumpToLastLine lineRange |> handleParseResult
 
     /// Parse out a single command.  Unlike ParseSingleLine this will parse linked commands.  So
     /// it won't ever return LineCommand.FuntionStart but instead will return LineCommand.Function

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -421,6 +421,26 @@ namespace Vim.UnitTest
                 Assert.Equal(_textBuffer.GetLine(1).Start, _textView.GetCaretPoint());
             }
 
+            [WpfFact]
+            public void ForwardMatchingCurrentLine()
+            {
+                Create("cat dog fish", "dog", "fish");
+                RunCommandRaw(":/dog");
+                Assert.Equal(_textBuffer.GetLine(1).Start, _textView.GetCaretPoint());
+            }
+
+            /// <summary>
+            /// Make sure that we can handle the incremental search command from the command line 
+            /// </summary>
+            [WpfFact]
+            public void BackwardMatchingCurrentLine()
+            {
+                Create("cat", "dog", "fish dog cat");
+                _textView.MoveCaretToLine(2);
+                RunCommandRaw(":?dog");
+                Assert.Equal(_textBuffer.GetLine(1).Start, _textView.GetCaretPoint());
+            }
+
             /// <summary>
             /// Make sure the match goes to the first non-whitespace character on the line 
             /// </summary>

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -2408,6 +2408,74 @@ namespace Vim.UnitTest
                 Assert.Equal(_textBuffer.GetLineRange(0, 2), lineRange);
             }
 
+            [WpfFact]
+            public void LineRange_NextLineWithPattern()
+            {
+                Create("cat", "dog frog", "bear", "frog", "tree");
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange("/frog/");
+                Assert.Equal(_textBuffer.GetLineRange(3, 3), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_PreviousLineWithPattern()
+            {
+                Create("cat", "dog", "bear", "frog dog", "tree");
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange("?dog?");
+                Assert.Equal(_textBuffer.GetLineRange(1, 1), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_NextLineWithEmptyPattern()
+            {
+                Create("cat", "dog", "bear", "frog", "tree");
+                _vimData.LastSearchData = new SearchData("frog", SearchPath.Forward);
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange("//");
+                Assert.Equal(_textBuffer.GetLineRange(3, 3), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_PreviousLineWithEmptyPattern()
+            {
+                Create("cat", "dog", "bear", "frog", "tree");
+                _vimData.LastSearchData = new SearchData("dog", SearchPath.Forward);
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange("??");
+                Assert.Equal(_textBuffer.GetLineRange(1, 1), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_NextLineWithPreviousPattern()
+            {
+                Create("cat", "dog", "bear", "frog", "tree");
+                _vimData.LastSearchData = new SearchData("frog", SearchPath.Forward);
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange(@"\/");
+                Assert.Equal(_textBuffer.GetLineRange(3, 3), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_PreviousLineWithPreviousPattern()
+            {
+                Create("cat", "dog", "bear", "frog", "tree");
+                _vimData.LastSearchData = new SearchData("dog", SearchPath.Forward);
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange(@"\?");
+                Assert.Equal(_textBuffer.GetLineRange(1, 1), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_NextLineWithPreviousSubstitutePattern()
+            {
+                Create("cat", "dog", "bear", "frog", "tree");
+                _vimData.LastSubstituteData = new SubstituteData("frog", "xyzzy", SubstituteFlags.None);
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange(@"\&");
+                Assert.Equal(_textBuffer.GetLineRange(3, 3), lineRange);
+            }
+
             /// <summary>
             /// Make sure we can clear out key mappings with the "mapc" command
             /// </summary>

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -715,6 +715,24 @@ namespace Vim.UnitTest
                 Assert.Equal("dog", _vimData.LastSearchData.Pattern);
                 Assert.Equal(SearchPath.Backward, _vimData.LastSearchData.Path);
             }
+
+            [WpfFact]
+            public void EmptyForwardSearchNoLastPattern()
+            {
+                Create("cat", "dog");
+                ParseAndRun(":/");
+                Assert.Equal(Resources.Range_Invalid, _statusUtil.LastError);
+            }
+
+            [WpfFact]
+            public void EmptyForwardSearchUsesLastPattern()
+            {
+                Create("cat", "dog");
+                _vimData.LastSearchData = new SearchData("dog", SearchPath.Backward);
+                ParseAndRun(":/");
+                Assert.Equal("dog", _vimData.LastSearchData.Pattern);
+                Assert.Equal(SearchPath.Forward, _vimData.LastSearchData.Path);
+            }
         }
 
         public sealed class RunScriptTest : InterpreterTest

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -2427,6 +2427,24 @@ namespace Vim.UnitTest
             }
 
             [WpfFact]
+            public void LineRange_NextLineWithPatternMatchingCurrentLine()
+            {
+                Create("cat", "dog frog", "bear frog dog", "frog", "tree");
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange("/frog/");
+                Assert.Equal(_textBuffer.GetLineRange(3, 3), lineRange);
+            }
+
+            [WpfFact]
+            public void LineRange_PreviousLineWithPatternMatchingCurrentLine()
+            {
+                Create("cat", "dog", "bear dog frog", "frog dog", "tree");
+                _textView.MoveCaretToLine(2);
+                var lineRange = ParseAndGetLineRange("?dog?");
+                Assert.Equal(_textBuffer.GetLineRange(1, 1), lineRange);
+            }
+
+            [WpfFact]
             public void LineRange_NextLineWithEmptyPattern()
             {
                 Create("cat", "dog", "bear", "frog", "tree");


### PR DESCRIPTION
#### Changes

- Implement `/pattern/` line specifier
- Implement `?pattern?` line specifier
- Implement `\/`, `\?`, and `\&` line specifiers
- Fix reverse search command `:?` to start prior to the current line

#### Issues

Fixes #1608
