### PR TITLE
Solution explorer key binding conflicts

### DIFF
--- a/Src/VsVimShared/Implementation/Misc/KeyBindingService.cs
+++ b/Src/VsVimShared/Implementation/Misc/KeyBindingService.cs
@@ -206,7 +206,7 @@ namespace Vim.VisualStudio.Implementation.Misc
         internal bool ShouldSkip(CommandKeyBinding binding)
         {
             var scope = binding.KeyBinding.Scope;
-            if (!_includeAllScopes && _scopeData.GetScopeKind(scope) == ScopeKind.Unknown)
+            if (!_includeAllScopes && (_scopeData.GetScopeKind(scope) == ScopeKind.Unknown || _scopeData.GetScopeKind(scope) == ScopeKind.SolutionExplorer))
             {
                 return true;
             }


### PR DESCRIPTION
This is intended to fix #2283.  I suspect that I am missing some detail since this seems a bit too simple; and if it were that simple, then someone more knowledgeable than myself would have already fixed the issue.

On the other hand, it seems to solve the specific problem that I have encountered:  Although I was previously able to assign a VS key binding such as CTRL+V to the Edit.Paste command in the "Solution Explorer" scope, configuring CTRL+V to be handled in VsVim would eventually remove the VS key binding, generally the next time VS was restarted.  After this change, VS key bindings scoped to "Solution Explorer" are left alone by VsVim, regardless of the "handled in" settings.