### PR TITLE
Fix duplicate ESC key processing when ReSharper is installed

### DIFF
--- a/Test/VsVimSharedTest/VsIntegrationTest.cs
+++ b/Test/VsVimSharedTest/VsIntegrationTest.cs
@@ -482,6 +482,53 @@ namespace Vim.VisualStudio.UnitTest
                     Assert.Equal(1, _escapeKeyCount);
                     Assert.False(_reSharperCommandTarget.IntellisenseDisplayed);
                 }
+
+                [WpfFact]
+                public void InsertPlusVisualWithIntellisenseInactive()
+                {
+                    Create("blah");
+                    _vimBuffer.SwitchMode(ModeKind.Insert, ModeArgument.None);
+                    _vimBuffer.Process(KeyInputUtil.ApplyKeyModifiersToKey(VimKey.Right, VimKeyModifiers.Shift));
+                    _vimBuffer.SwitchMode(ModeKind.VisualCharacter, ModeArgument.None);
+                    _reSharperCommandTarget.IntellisenseDisplayed = false;
+                    _vsSimulation.Run(VimKey.Escape);
+                    Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                    Assert.Equal(0, _reSharperCommandTarget.ExecEscapeCount);
+                    Assert.Equal(1, _escapeKeyCount);
+                    Assert.False(_reSharperCommandTarget.IntellisenseDisplayed);
+                }
+
+                [WpfFact]
+                public void InsertPlushOneTimeCommandWithIntellisenseInactive()
+                {
+                    Create("blah");
+                    _vimBuffer.SwitchMode(ModeKind.Insert, ModeArgument.None);
+                    _vimBuffer.Process(KeyInputUtil.CharWithControlToKeyInput('o'));
+                    _vimBuffer.SwitchMode(ModeKind.Normal, ModeArgument.None);
+                    _reSharperCommandTarget.IntellisenseDisplayed = false;
+                    _vsSimulation.Run(VimKey.Escape);
+                    Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                    Assert.Equal(0, _reSharperCommandTarget.ExecEscapeCount);
+                    Assert.Equal(1, _escapeKeyCount);
+                    Assert.False(_reSharperCommandTarget.IntellisenseDisplayed);
+                }
+                
+                [WpfFact]
+                public void InsertAfterOneTimeCommandWithIntellisenseActive()
+                {
+                    Create("blah");
+                    _vimBuffer.SwitchMode(ModeKind.Insert, ModeArgument.None);
+                    _vimBuffer.Process(KeyInputUtil.CharWithControlToKeyInput('o'));
+                    _vimBuffer.SwitchMode(ModeKind.Normal, ModeArgument.None);
+                    _vsSimulation.Run(KeyInputUtil.CharToKeyInput('w'));
+                    _vimBuffer.SwitchMode(ModeKind.Insert, ModeArgument.None);
+                    _reSharperCommandTarget.IntellisenseDisplayed = true;
+                    _vsSimulation.Run(VimKey.Escape);
+                    Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+                    Assert.Equal(1, _reSharperCommandTarget.ExecEscapeCount);
+                    Assert.Equal(1, _escapeKeyCount);
+                    Assert.False(_reSharperCommandTarget.IntellisenseDisplayed);
+                }
             }
 
             private ReSharperCommandTargetSimulation _reSharperCommandTarget;


### PR DESCRIPTION
Fixes #1373 

This works for me (in all scenarios that I can conceive of) with ReSharper and VS2017.  

**Approach**
Although we can't directly detect when an ESC **was** missed by the buffer, it's quite easy to detect when it **wasn't** missed by the buffer.  Since ReSharperKeyUtil.PreviewKeyUp always (AFAIK) sees the ESC key, we can reset the "seen" flag every time ESC is released.  Thus we can indirectly detect an ESC key that the buffer didn't see.

**Suggestion 1**
I'm assuming that the original rationale behind exiting insert mode when an intellisense popup is dismissed via ESC was to match Vim's suggestion popup behavior. This makes sense when the suggestion popup must be invoked through a special key combination such as `<C-n>` or `<C-p>`.  However, intellisense providers in VS can generally be configured to automatically popup suggestions based on characters being inserted into the buffer.  I personally have ReSharper configured to disable this behavior -- otherwise the intellisense is constantly popping up with unwanted suggestions while typing in insert mode.  These popups must be dismissed with ESC, which reverts to normal mode, forcing insert mode to be re-entered manually in order to continue typing.  I think it is worth considering making this "ESC passthrough" behavior optional to accommodate those who want to keep the automatic intellisense popup behavior enabled.

**Suggestion 2**
To improve consistency, we might consider applying the ESC passthrough behavior to all modes and not just insert mode. My reasoning here is that you can invoke the various ReSharper popups from just about any mode using key bindings that are not handled by VsVim.  Again, this is in contrast to Vim, in which (AFAIK) you can only get suggestions in insert mode.  For instance, from any VsVim mode, I can bring up a "type search" popup with `<C-.>` which I have configured to be handled by VS.  Hitting ESC to dismiss the popup returns me to normal mode when I am in insert mode, but does not return to normal mode if I'm in, say, visual mode.