### PR TITLE
Include empty lines in block insert

### DIFF
--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -227,9 +227,10 @@ type internal InsertUtil
                 // Only apply the edit to lines which were included in the original selection
                 let tabStop = _localSettings.TabStop
                 let column =
-                    if atEndOfLine then SnapshotColumn.GetLineEnd(currentLine)
-                    else SnapshotColumn.GetColumnForSpacesOrEnd(currentLine, spaces, tabStop)
-                if atEndOfLine || not column.IsLineBreakOrEnd || (column.Line.Length = 0 && spaces = 0) then
+                    if atEndOfLine then SnapshotColumn.GetLineEnd(currentLine) |> Some
+                    else SnapshotColumn.GetColumnForSpaces(currentLine, spaces, tabStop)
+                match column with 
+                | Some column ->
                     let position = column.StartPosition
                     let text =
                         if _localSettings.ExpandTab then
@@ -252,6 +253,7 @@ type internal InsertUtil
                     else
                         if not (textEdit.Insert(position, text)) then
                             abortChange <- true
+                | None -> ()
 
             if abortChange then
                 textEdit.Cancel()

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -229,7 +229,7 @@ type internal InsertUtil
                 let column =
                     if atEndOfLine then SnapshotColumn.GetLineEnd(currentLine)
                     else SnapshotColumn.GetColumnForSpacesOrEnd(currentLine, spaces, tabStop)
-                if atEndOfLine || not column.IsLineBreakOrEnd || column.Line.Length = 0 then
+                if atEndOfLine || not column.IsLineBreakOrEnd || (column.Line.Length = 0 && spaces = 0) then
                     let position = column.StartPosition
                     let text =
                         if _localSettings.ExpandTab then

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -229,7 +229,7 @@ type internal InsertUtil
                 let column =
                     if atEndOfLine then SnapshotColumn.GetLineEnd(currentLine)
                     else SnapshotColumn.GetColumnForSpacesOrEnd(currentLine, spaces, tabStop)
-                if atEndOfLine || not column.IsLineBreakOrEnd then
+                if atEndOfLine || not column.IsLineBreakOrEnd || column.Line.Length = 0 then
                     let position = column.StartPosition
                     let text =
                         if _localSettings.ExpandTab then

--- a/Src/VimTestUtils/VimTestBase.cs
+++ b/Src/VimTestUtils/VimTestBase.cs
@@ -26,6 +26,7 @@ using System.Text;
 using Vim.UnitTest.Utilities;
 using System.Windows.Threading;
 using Xunit.Sdk;
+using Vim.Extensions;
 
 namespace Vim.UnitTest
 {

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -1217,6 +1217,18 @@ namespace Vim.UnitTest
                     _vimBuffer.ProcessNotation(@"<C-q>jjI#<Esc>");
                     Assert.Equal(new[] { "#dog", "#", "#tree" }, _textBuffer.GetLines());
                 }
+
+                /// <summary>
+                /// A block insertion should add the text when the insertion is at the end column
+                /// of the line. 
+                /// </summary>
+                [WpfFact]
+                public void EndOfLine()
+                {
+                    Create("dog", "x", "tree");
+                    _vimBuffer.ProcessNotation(@"l<C-q>jjI#<Esc>");
+                    Assert.Equal(new[] { "d#og", "x#", "t#ree" }, _textBuffer.GetLines());
+                }
             }
 
             public sealed class InsertTabTest : BlockInsertTest

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -1204,8 +1204,20 @@ namespace Vim.UnitTest
                     Assert.Equal("og", _textView.GetLine(0).GetText());
                     Assert.Equal("cat", _textView.GetLine(1).GetText());
                 }
-            }
 
+                /// <summary>
+                /// When the block selection is in column zero then empty lines need to 
+                /// get the block insert applied as well
+                /// Issue 2342
+                /// </summary>
+                [WpfFact]
+                public void EmptyLineBlockAtStartOfLine()
+                {
+                    Create("dog", "", "tree");
+                    _vimBuffer.ProcessNotation(@"<C-q>jjI#<Esc>");
+                    Assert.Equal(new[] { "#dog", "#", "#tree" }, _textBuffer.GetLines());
+                }
+            }
 
             public sealed class InsertTabTest : BlockInsertTest
             {


### PR DESCRIPTION
The check for valid column position in block insert were excluding empty
lines.

closes #2342