### PR TITLE
fixes for one-commmand mode switching and display

### DIFF
--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4937,6 +4937,10 @@ and IVimTextBuffer =
     /// If we are in the middle of processing a "one time command" (<c-o>) then this will
     /// hold the ModeKind which will be switched back to after it's completed
     abstract InOneTimeCommand: ModeKind option with get, set
+    
+    /// True if we are processing a "one time command" initiated from a select mode,
+    /// or from a select mode initiated from within another "one time command", e.g. "(insert) SELECT".
+    abstract InSelectModeOneTimeCommand: bool with get, set
 
     /// The set of active local marks in the ITextBuffer
     abstract LocalMarks: (LocalMark * VirtualSnapshotPoint) seq

--- a/Src/VimCore/SelectionChangeTracker.fs
+++ b/Src/VimCore/SelectionChangeTracker.fs
@@ -213,7 +213,11 @@ type internal SelectionChangeTracker
             elif not _vimBuffer.IsClosed && not _selectionDirty then 
                 match getDesiredNewMode() with
                 | None -> ()
-                | Some modeKind -> _vimBuffer.SwitchMode modeKind ModeArgument.None |> ignore
+                | Some modeKind -> 
+                    // Switching from an insert mode to a visual/select mode automatically initiates one command mode
+                    if VisualKind.IsAnyVisualOrSelect modeKind && VimExtensions.IsAnyInsert _vimBuffer.ModeKind then
+                        _vimBuffer.VimTextBuffer.InOneTimeCommand <- Some _vimBuffer.ModeKind
+                    _vimBuffer.SwitchMode modeKind ModeArgument.None |> ignore
 
         match getDesiredNewMode() with
         | None ->

--- a/Src/VimCore/VimTextBuffer.fs
+++ b/Src/VimCore/VimTextBuffer.fs
@@ -32,6 +32,7 @@ type internal VimTextBuffer
     let mutable _lastChangeOrYankEnd: ITrackingLineColumn option = None
     let mutable _isSoftTabStopValidForBackspace = true
     let mutable _inOneTimeCommand: ModeKind option = None
+    let mutable _inSelectModeOneCommand: bool = false
 
     /// Raise the mark set event
     member x.RaiseMarkSet localMark =
@@ -171,6 +172,10 @@ type internal VimTextBuffer
         with get() = _inOneTimeCommand
         and set value = _inOneTimeCommand <- value
 
+    member x.InSelectModeOneTimeCommand
+        with get() = _inSelectModeOneCommand
+        and set value = _inSelectModeOneCommand <- value
+
     member x.IsSoftTabStopValidForBackspace 
         with get() = _isSoftTabStopValidForBackspace
         and set value = _isSoftTabStopValidForBackspace <- value
@@ -309,6 +314,9 @@ type internal VimTextBuffer
         member x.InOneTimeCommand
             with get() = x.InOneTimeCommand
             and set value = x.InOneTimeCommand <- value
+        member x.InSelectModeOneTimeCommand
+            with get() = x.InSelectModeOneTimeCommand
+            and set value = x.InSelectModeOneTimeCommand <- value
         member x.LocalMarks = x.LocalMarks
         member x.LocalSettings = _localSettings
         member x.ModeKind = _modeKind

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
@@ -83,15 +83,6 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                 case ModeKind.SubstituteConfirm:
                     status = GetStatusSubstituteConfirm(vimBuffer.SubstituteConfirmMode);
                     break;
-                case ModeKind.VisualBlock:
-                    status = GetStatusWithRegister(Resources.VisualBlockBanner, vimBuffer.VisualBlockMode.CommandRunner);
-                    break;
-                case ModeKind.VisualCharacter:
-                    status = GetStatusWithRegister(Resources.VisualCharacterBanner, vimBuffer.VisualCharacterMode.CommandRunner);
-                    break;
-                case ModeKind.VisualLine:
-                    status = GetStatusWithRegister(Resources.VisualLineBanner, vimBuffer.VisualLineMode.CommandRunner);
-                    break;
                 default:
                     status = GetStatusCommon(vimBuffer, currentMode);
                     break;
@@ -117,7 +108,6 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             }
 
             // Check if we can enable the command line to accept user input
-            var search = vimBuffer.IncrementalSearch;
             string status;
             switch (currentMode.ModeKind)
             {
@@ -151,13 +141,19 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                         : string.Format(Resources.VisualLineOneTimeCommandBanner, oneTimeArgument);
                     break;
                 case ModeKind.SelectBlock:
-                    status = Resources.SelectBlockBanner;
+                    status = string.IsNullOrEmpty(oneTimeArgument)
+                        ? Resources.SelectBlockBanner
+                        : string.Format(Resources.SelectBlockOneTimeCommandBanner, oneTimeArgument);
                     break;
                 case ModeKind.SelectCharacter:
-                    status = Resources.SelectCharacterBanner;
+                    status = string.IsNullOrEmpty(oneTimeArgument)
+                        ? Resources.SelectCharacterBanner
+                        : string.Format(Resources.SelectCharacterOneTimeCommandBanner, oneTimeArgument); 
                     break;
                 case ModeKind.SelectLine:
-                    status = Resources.SelectLineBanner;
+                    status = string.IsNullOrEmpty(oneTimeArgument)
+                        ? Resources.SelectLineBanner
+                        : string.Format(Resources.SelectLineOneTimeCommandBanner, oneTimeArgument); 
                     break;
                 case ModeKind.ExternalEdit:
                     status = Resources.ExternalEditBanner;
@@ -180,16 +176,6 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         {
             var replace = mode.CurrentSubstitute.SomeOrDefault("");
             return string.Format(Resources.SubstituteConfirmBannerFormat, replace);
-        }
-
-        private static string GetStatusWithRegister(string commandLine, ICommandRunner commandRunner)
-        {
-            if (commandRunner.HasRegisterName && commandRunner.RegisterName.Char.IsSome())
-            {
-                commandLine = $"{commandLine} \"{commandRunner.RegisterName.Char.Value}";
-            }
-
-            return commandLine;
         }
 
         #region ICommandMarginUtil

--- a/Src/VimWpf/Properties/Resources.Designer.cs
+++ b/Src/VimWpf/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Vim.UI.Wpf.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -106,6 +106,15 @@ namespace Vim.UI.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to -- ({0}) SELECT BLOCK --.
+        /// </summary>
+        internal static string SelectBlockOneTimeCommandBanner {
+            get {
+                return ResourceManager.GetString("SelectBlockOneTimeCommandBanner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to -- SELECT --.
         /// </summary>
         internal static string SelectCharacterBanner {
@@ -115,11 +124,29 @@ namespace Vim.UI.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to -- ({0}) SELECT --.
+        /// </summary>
+        internal static string SelectCharacterOneTimeCommandBanner {
+            get {
+                return ResourceManager.GetString("SelectCharacterOneTimeCommandBanner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to -- SELECT LINE --.
         /// </summary>
         internal static string SelectLineBanner {
             get {
                 return ResourceManager.GetString("SelectLineBanner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to -- ({0}) SELECT LINE --.
+        /// </summary>
+        internal static string SelectLineOneTimeCommandBanner {
+            get {
+                return ResourceManager.GetString("SelectLineOneTimeCommandBanner", resourceCulture);
             }
         }
         

--- a/Src/VimWpf/Properties/Resources.resx
+++ b/Src/VimWpf/Properties/Resources.resx
@@ -132,11 +132,20 @@
   <data name="SelectBlockBanner" xml:space="preserve">
     <value>-- SELECT BLOCK --</value>
   </data>
+  <data name="SelectBlockOneTimeCommandBanner" xml:space="preserve">
+    <value>-- ({0}) SELECT BLOCK --</value>
+  </data>
   <data name="SelectCharacterBanner" xml:space="preserve">
     <value>-- SELECT --</value>
   </data>
+  <data name="SelectCharacterOneTimeCommandBanner" xml:space="preserve">
+    <value>-- ({0}) SELECT --</value>
+  </data>
   <data name="SelectLineBanner" xml:space="preserve">
     <value>-- SELECT LINE --</value>
+  </data>
+  <data name="SelectLineOneTimeCommandBanner" xml:space="preserve">
+    <value>-- ({0}) SELECT LINE --</value>
   </data>
   <data name="SubstituteConfirmBannerFormat" xml:space="preserve">
     <value>replace with {0} (y/n/a/q/l/^E/^Y)?</value>

--- a/Test/VimCoreTest/CommandProcessorLegacyTest.cs
+++ b/Test/VimCoreTest/CommandProcessorLegacyTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.FSharp.Core;
 using Vim.EditorHost;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -57,6 +58,7 @@ namespace Vim.UnitTest
                 vim: _vim.Object,
                 localSettings: localSettings,
                 factory: _factory);
+            vimTextBuffer.Setup(x => x.InOneTimeCommand).Returns(FSharpOption<ModeKind>.None);
             var vimBufferData = CreateVimBufferData(
                 vimTextBuffer.Object,
                 _textView,

--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -1670,7 +1670,7 @@ namespace Vim.UnitTest
             {
                 Create("");
                 _vimBuffer.ProcessNotation("<C-o>v:");
-                Assert.Equal(ModeKind.VisualCharacter, _vimBuffer.ModeKind);
+                Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
                 Assert.Equal(ModeKind.Insert, _vimBuffer.InOneTimeCommand);
                 _vimBuffer.ProcessNotation("<Esc>");
                 Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);

--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -1597,6 +1597,170 @@ namespace Vim.UnitTest
             }
         }
 
+        public sealed class OneTimeCommandTests : InsertModeIntegrationTest
+        {
+            [WpfFact]
+            public void Esc()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>");
+                Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+                Assert.Equal(ModeKind.Insert, _vimBuffer.InOneTimeCommand);
+                _vimBuffer.ProcessNotation("<Esc>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
+            public void Replace_Esc()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>R");
+                Assert.Equal(ModeKind.Replace, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+                _vimBuffer.ProcessNotation("<Esc>");
+                Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
+            public void ExCommand_Esc()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>:");
+                Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
+                Assert.Equal(ModeKind.Insert, _vimBuffer.InOneTimeCommand);
+                _vimBuffer.ProcessNotation("<Esc>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
+            public void ExCommand()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>:pwd<CR>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
+            public void Visual_Esc()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>v");
+                Assert.Equal(ModeKind.VisualCharacter, _vimBuffer.ModeKind);
+                Assert.Equal(ModeKind.Insert, _vimBuffer.InOneTimeCommand);
+                _vimBuffer.ProcessNotation("<Esc>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
+            public void Visual_ExCommand()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>v:pwd<CR>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
+            public void Visual_ExCommand_Esc()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>v:");
+                Assert.Equal(ModeKind.VisualCharacter, _vimBuffer.ModeKind);
+                Assert.Equal(ModeKind.Insert, _vimBuffer.InOneTimeCommand);
+                _vimBuffer.ProcessNotation("<Esc>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
+            public void SelectModeOneCommand_Visual_Esc()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>gh<C-g>");
+                Assert.Equal(ModeKind.VisualCharacter, _vimBuffer.ModeKind);
+                Assert.Equal(ModeKind.Insert, _vimBuffer.InOneTimeCommand);
+                _vimBuffer.ProcessNotation("<Esc>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
+            public void SelectModeOneCommand_Visual_ExCommand_Esc()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>gh<C-g>:");
+                Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
+                Assert.Equal(ModeKind.Insert, _vimBuffer.InOneTimeCommand);
+                _vimBuffer.ProcessNotation("<Esc>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
+            public void SelectModeOneCommand_ExCommand()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>gh<C-o>:pwd<CR>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
+            public void SelectModeOneCommand_ExCommand_Esc()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>gh<C-o>:<Esc>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
+            public void SelectModeOneCommand_Printable()
+            {
+                Create("foo bar baz");
+                _vimBuffer.ProcessNotation("<C-o>gh<C-o>e");
+                Assert.Equal("foo", _textView.GetSelectionSpan().GetText());
+                Assert.Equal(ModeKind.SelectCharacter, _vimBuffer.ModeKind);
+                Assert.Equal(ModeKind.Insert, _vimBuffer.InOneTimeCommand);
+                _vimBuffer.ProcessNotation("x");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+                Assert.Equal("x bar baz", _textBuffer.GetLine(0).GetText());
+            }
+            
+            [WpfFact]
+            public void SelectModeOneCommand_Esc()
+            {
+                Create("foo bar baz");
+                _vimBuffer.ProcessNotation("<C-o>gh<C-o><Esc>");
+                Assert.Equal(null, _vimBuffer.InOneTimeCommand);
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+                Assert.Equal("foo bar baz", _textBuffer.GetLine(0).GetText());
+            }
+            
+            [WpfFact]
+            public void SelectModeOneCommand_CursorMove_StartStopSelection()
+            {
+                Create("foo bar baz");
+                _globalSettings.SelectModeOptions = SelectModeOptions.Keyboard;
+                _globalSettings.KeyModelOptions = KeyModelOptions.StartSelection | KeyModelOptions.StopSelection;
+                _vimBuffer.ProcessNotation("<C-o><S-Right><S-Right>");
+                Assert.Equal("foo", _textView.GetSelectionSpan().GetText());
+                Assert.Equal(ModeKind.SelectCharacter, _vimBuffer.ModeKind);
+                Assert.Equal(ModeKind.Insert, _vimBuffer.InOneTimeCommand);
+                _vimBuffer.ProcessNotation("<Right>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+                Assert.Equal(null, _vimBuffer.InOneTimeCommand);
+            }
+        }
+
         public sealed class MiscTest : InsertModeIntegrationTest
         {
             /// <summary>

--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -1645,6 +1645,15 @@ namespace Vim.UnitTest
             }
             
             [WpfFact]
+            public void ExCommand_Normal()
+            {
+                Create("");
+                _vimBuffer.ProcessNotation("<C-o>:norm d<CR>");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
+            }
+            
+            [WpfFact]
             public void Visual_Esc()
             {
                 Create("");

--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -1738,7 +1738,7 @@ namespace Vim.UnitTest
             {
                 Create("foo bar baz");
                 _vimBuffer.ProcessNotation("<C-o>gh<C-o><Esc>");
-                Assert.Equal(null, _vimBuffer.InOneTimeCommand);
+                Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
                 Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
                 Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
                 Assert.Equal("foo bar baz", _textBuffer.GetLine(0).GetText());
@@ -1757,7 +1757,6 @@ namespace Vim.UnitTest
                 _vimBuffer.ProcessNotation("<Right>");
                 Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
                 Assert.Equal(FSharpOption<ModeKind>.None, _vimBuffer.InOneTimeCommand);
-                Assert.Equal(null, _vimBuffer.InOneTimeCommand);
             }
         }
 

--- a/Test/VimCoreTest/SelectModeIntegrationTest.cs
+++ b/Test/VimCoreTest/SelectModeIntegrationTest.cs
@@ -902,8 +902,34 @@ namespace Vim.UnitTest
                 _vimBuffer.ProcessNotation("bear ");
                 Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
                 Assert.Equal("cat bear eel", _textBuffer.GetLine(0).GetText());
-            }
+            }    
 
+            [WpfFact]
+            public void SelectOneTimeCommand_Esc()
+            {
+                Create("cat dog eel");
+                _vimBuffer.ProcessNotation("gh<C-o><Esc>");
+                Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+            }   
+
+            [WpfFact]
+            public void SelectOneTimeCommand_ExCommand_Esc()
+            {
+                Create("cat dog eel");
+                _vimBuffer.ProcessNotation("gh<C-o>:");
+                Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
+                _vimBuffer.ProcessNotation("<Esc>");
+                Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+            }   
+
+            [WpfFact]
+            public void SelectOneTimeCommand_ExCommand()
+            {
+                Create("cat dog eel");
+                _vimBuffer.ProcessNotation("gh<C-o>:pwd<CR>");
+                Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+            }   
+            
             [WpfFact]
             public void Issue1317()
             {


### PR DESCRIPTION
Fixes #2346 

This is the most "invasive" change I've made so far in this codebase, so I expect a fair amount of scrutiny.  The biggest challenge is to deal with the very large number of code paths that can lead to a mode switch without resorting to adding a lot of special case logic, or modifying the mode-specific code.  The more I experimented with gVim, the more I was surprised by features (or "features") that I didn't know existed.  Hopefully, I've hit all or nearly all of them.