### PR TITLE
Use explicit names in discriminated unions

### DIFF
--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3174,17 +3174,17 @@ type NormalCommand =
 type VisualCommand = 
 
     /// Add count to the word in each line of the selection, optionally progressively
-    | AddToSelection of bool
+    | AddToSelection of IsProgressive: bool
 
     /// Change the case of the selected text in the specified manner
-    | ChangeCase of ChangeCharacterKind
+    | ChangeCase of ChangeCharacterKind: ChangeCharacterKind
 
     /// Delete the selection and begin insert mode.  Implements the 'c' and 's' commands
     | ChangeSelection
 
     /// Delete the selected lines and begin insert mode ('S' and 'C' commands).  The bool parameter
     /// is whether or not to treat block selection as a special case
-    | ChangeLineSelection of bool
+    | ChangeLineSelection of SpecialCaseBlockSelection: bool
 
     /// Close a fold in the selection
     | CloseFoldInSelection
@@ -3202,7 +3202,7 @@ type VisualCommand =
     | DeleteSelection
 
     /// Extend the selection to the next match for the last pattern searched for
-    | ExtendSelectionToNextMatch of SearchPath
+    | ExtendSelectionToNextMatch of SearchPath: SearchPath
 
     /// Filter the selected text
     | FilterLines
@@ -3214,7 +3214,7 @@ type VisualCommand =
     | FormatCodeLines
 
     /// Format the selected text lines, optionally preserving the caret position
-    | FormatTextLines of bool
+    | FormatTextLines of PreserveCaretPosition: bool
 
     /// GoTo the file under the cursor in a new window
     | GoToFileInSelectionInNewWindow
@@ -3223,15 +3223,15 @@ type VisualCommand =
     | GoToFileInSelection
 
     /// Join the selected lines
-    | JoinSelection of JoinKind
+    | JoinSelection of JoinKind: JoinKind
 
     /// Invert the selection by swapping the caret and anchor points.  When true it means that block mode should
     /// be special cased to invert the column only 
-    | InvertSelection of bool
+    | InvertSelection of ColumnOnlyInBlock: bool
 
     /// Move the caret to the result of the given Motion.  This movement is from a 
     /// text-object selection.  Certain motions 
-    | MoveCaretToTextObject of Motion * TextObjectKind
+    | MoveCaretToTextObject of Motion: Motion * TextObjectKind: TextObjectKind
 
     /// Open all folds in the selection
     | OpenAllFoldsInSelection
@@ -3241,10 +3241,10 @@ type VisualCommand =
 
     /// Put the contents af the register after the selection.  The bool is for whether or not the
     // caret should be placed after the inserted text
-    | PutOverSelection of bool
+    | PutOverSelection of PlaceCaretAfterInsertedText: bool
 
     /// Replace the visual span with the provided character
-    | ReplaceSelection of KeyInput
+    | ReplaceSelection of KeyInput: KeyInput
 
     /// Shift the selected lines left
     | ShiftLinesLeft
@@ -3253,17 +3253,17 @@ type VisualCommand =
     | ShiftLinesRight
 
     /// Subtract count from the word in each line of the selection, optionally progressively
-    | SubtractFromSelection of bool
+    | SubtractFromSelection of IsProgressive: bool
 
     /// Switch the mode to insert and possibly a block insert. The bool specifies whether
     /// the insert is at the end of the line
-    | SwitchModeInsert of bool
+    | SwitchModeInsert of AtEndOfLine: bool
 
     /// Switch to the previous mode
     | SwitchModePrevious
 
     /// Switch to the specified visual mode
-    | SwitchModeVisual of VisualKind
+    | SwitchModeVisual of VisualKind: VisualKind
 
     /// Toggle one fold in the selection
     | ToggleFoldInSelection
@@ -3304,26 +3304,26 @@ type InsertCommand  =
     /// Block edit of the specified TextChange value.  The bool signifies whether
     /// the insert is at the end of the line. The int represents the number of 
     /// lines on which this block insert should take place
-    | BlockInsert of string * bool * int
+    | BlockInsert of Text: string * AtEndOfLine: bool * Height: int
 
     /// This is an insert command which is a combination of other insert commands
-    | Combined of InsertCommand * InsertCommand
+    | Combined of Left: InsertCommand * Right: InsertCommand
 
     /// Complete the Insert Mode session.  This is done as a command so that it will 
     /// be a bookend of insert mode for the repeat infrastructure
     ///
     /// The bool value represents whether or not the caret needs to be moved to the
     /// left
-    | CompleteMode of bool
+    | CompleteMode of MoveCaretLeft: bool
 
     /// Delete the character under the caret
     | Delete
 
     /// Delete count characters to the left of the caret
-    | DeleteLeft of int 
+    | DeleteLeft of ColumnCount: int 
 
     /// Delete count characters to the right of the caret
-    | DeleteRight of int
+    | DeleteRight of ColumnCount: int
 
     /// Delete all indentation on the current line
     | DeleteAllIndent
@@ -3341,28 +3341,28 @@ type InsertCommand  =
     | InsertNewLine
 
     /// Insert previously inserted text, optionally stopping insert
-    | InsertPreviouslyInsertedText of bool
+    | InsertPreviouslyInsertedText of StopInsert: bool
 
     /// Insert a tab into the ITextBuffer
     | InsertTab
 
     /// Insert of text into the ITextBuffer at the caret position 
-    | Insert of string
+    | Insert of Text: string
 
     /// Move the caret in the given direction
-    | MoveCaret of Direction
+    | MoveCaret of Direction: Direction
 
     /// Move the caret in the given direction with an arrow key
-    | MoveCaretWithArrow of Direction
+    | MoveCaretWithArrow of Direction: Direction
 
     /// Move the caret in the given direction by a whole word
-    | MoveCaretByWord of Direction
+    | MoveCaretByWord of Direction: Direction
 
     /// Move the caret to the end of the line
     | MoveCaretToEndOfLine
 
     /// Replace the character under the caret with the specified value
-    | Replace of char
+    | Replace of Character: char
 
     /// Replace the character which is immediately above the caret
     | ReplaceCharacterAboveCaret
@@ -3371,7 +3371,7 @@ type InsertCommand  =
     | ReplaceCharacterBelowCaret
 
     /// Overwrite the characters under the caret with the specified string
-    | Overwrite of string
+    | Overwrite of Text: string
 
     /// Shift the current line one indent width to the left
     | ShiftLineLeft 
@@ -3456,13 +3456,13 @@ type InsertCommand  =
 type Command =
 
     /// A Normal Mode Command
-    | NormalCommand of NormalCommand * CommandData
+    | NormalCommand of NormalCommand: NormalCommand * CommandData: CommandData
 
     /// A Visual Mode Command
-    | VisualCommand of VisualCommand * CommandData * VisualSpan
+    | VisualCommand of VisualCommand: VisualCommand * CommandData: CommandData * VisualSpan: VisualSpan
 
     /// An Insert / Replace Mode Command
-    | InsertCommand of InsertCommand
+    | InsertCommand of InsertCommand: InsertCommand
 
 /// This is the result of attemping to bind a series of KeyInput values into a Motion
 /// Command, etc ... 
@@ -3470,10 +3470,10 @@ type Command =
 type BindResult<'T> = 
 
     /// Successfully bound to a value
-    | Complete of 'T 
+    | Complete of Result: 'T 
 
     /// More input is needed to complete the binding operation
-    | NeedMoreInput of BindData<'T>
+    | NeedMoreInput of BindData: BindData<'T>
 
     /// There was an error completing the binding operation
     | Error
@@ -3548,10 +3548,10 @@ and BindData<'T> = {
 type BindDataStorage<'T> =
 
     /// Simple BindData<'T> which doesn't require activation
-    | Simple of BindData<'T> 
+    | Simple of BindData: BindData<'T> 
 
     /// Complex BindData<'T> which does require activation
-    | Complex of (unit -> BindData<'T>)
+    | Complex of CreateBindDataFunc: (unit -> BindData<'T>)
 
     with
 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -442,10 +442,10 @@ type PatternDataEventArgs(_patternData: PatternData) =
 [<DebuggerDisplay("{ToString(),nq}")>]
 type SearchOffsetData =
     | None
-    | Line of int
-    | Start of int
-    | End of int
-    | Search of PatternData
+    | Line of Line: int
+    | Start of Start: int
+    | End of End: int
+    | Search of PatternData: PatternData
 
     with 
 
@@ -654,15 +654,15 @@ type SearchResult =
     ///
     /// The bool at the end of the tuple represents whether not
     /// a wrap occurred while searching for the value
-    | Found of SearchData * SnapshotSpan * SnapshotSpan * bool
+    | Found of SearchData: SearchData * SpanWithOffset: SnapshotSpan * Span: SnapshotSpan * DidWrap: bool
 
     /// The pattern was not found.  The bool is true if the word was present in the ITextBuffer
     /// but wasn't found do to the lack of a wrap in the SearchData value
-    | NotFound of SearchData * bool
+    | NotFound of SeachData: SearchData * CanFindWithWrap: bool
 
     /// There was an error converting the pattern to a searchable value.  The string value is the
     /// error message
-    | Error of SearchData * string
+    | Error of SearchData: SearchData * Error: string
 
     with
 
@@ -1000,10 +1000,10 @@ type TagBlockKind =
 type Motion =
 
     /// Implement the all block motion
-    | AllBlock of BlockKind
+    | AllBlock of BlockKind: BlockKind
 
     /// Implement the 'aw' motion.  This is called once the a key is seen.
-    | AllWord of WordKind
+    | AllWord of WordKind: WordKind
 
     /// Implement the 'ap' motion
     | AllParagraph 
@@ -1018,7 +1018,7 @@ type Motion =
     | BeginingOfLine
 
     /// Implement the 'ge' / 'gE' motion.  Goes backward to the end of the previous word 
-    | BackwardEndOfWord of WordKind
+    | BackwardEndOfWord of WordKind: WordKind
 
     /// The left motion for h
     | CharLeft 
@@ -1039,7 +1039,7 @@ type Motion =
     | ArrowRight
 
     /// Implements the f, F, t and T motions
-    | CharSearch of CharSearchKind * SearchPath * char
+    | CharSearch of CharSearchKind: CharSearchKind * SearchPath: SearchPath * Character: char
 
     /// Get the span of "count" display lines upward.  Display lines can differ when
     /// wrap is enabled
@@ -1064,7 +1064,7 @@ type Motion =
 
     /// Implement the 'e' motion.  This goes to the end of the current word.  If we're
     /// not currently on a word it will find the next word and then go to the end of that
-    | EndOfWord of WordKind
+    | EndOfWord of WordKind: WordKind
     
     /// Implement an end of line motion.  Typically in response to the $ key.  Even though
     /// this motion deals with lines, it's still a character wise motion motion. 
@@ -1079,19 +1079,19 @@ type Motion =
     | FirstNonBlankOnLine
 
     /// Forces a line wise version of the specified motion 
-    | ForceLineWise of Motion
+    | ForceLineWise of Motion: Motion
 
     /// Forces a characterwise version of the specified motion
-    | ForceCharacterWise of Motion
+    | ForceCharacterWise of Motion: Motion
 
     /// Inner word motion
-    | InnerWord of WordKind
+    | InnerWord of WordKind: WordKind
 
     /// Inner paragraph motion
     | InnerParagraph
 
     /// Inner block motion
-    | InnerBlock of BlockKind
+    | InnerBlock of BlockKind: BlockKind
 
     /// Find the last non-blank character on the line.  Count causes it to go "count" lines
     /// down and perform the search
@@ -1099,7 +1099,7 @@ type Motion =
 
     /// Find the next occurrence of the last search.  The bool parameter is true if the search
     /// should be in the opposite direction
-    | LastSearch of bool
+    | LastSearch of UseOppositeDirection: bool
 
     /// Handle the lines down to first non-blank motion.  This is one of the motions which 
     /// can accept a count of 0.
@@ -1135,12 +1135,12 @@ type Motion =
 
     /// Get the motion to the specified mark.  This is typically accessed via
     /// the ` (back tick) operator and results in an exclusive motion
-    | Mark of LocalMark
+    | Mark of LocalMark: LocalMark
 
     /// Get the motion to the line of the specified mark.  This is typically
     /// accessed via the ' (single quote) operator and results in a 
     /// line wise motion
-    | MarkLine of LocalMark
+    | MarkLine of LocalMark: LocalMark
 
     /// Get the matching token from the next token on the line.  This is used to implement
     /// the % motion
@@ -1148,19 +1148,19 @@ type Motion =
     | MatchingTokenOrDocumentPercent 
 
     /// Get the motion to the nearest lowercase mark in the specified direction
-    | NextMark of SearchPath
+    | NextMark of SearchPath: SearchPath
 
     /// Get the motion to the nearest lowercase mark line in the specified direction
-    | NextMarkLine of SearchPath
+    | NextMarkLine of SearchPath: SearchPath
 
     /// Operate on the next match for last pattern searched for
-    | NextMatch of SearchPath
+    | NextMatch of SearchPath: SearchPath
 
     /// Search for the next occurrence of the word under the caret
-    | NextWord of SearchPath
+    | NextWord of SearchPath: SearchPath
 
     /// Search for the next partial occurrence of the word under the caret
-    | NextPartialWord of SearchPath
+    | NextPartialWord of SearchPath: SearchPath
 
     /// Count paragraphs backwards
     | ParagraphBackward
@@ -1169,10 +1169,10 @@ type Motion =
     | ParagraphForward
 
     /// The quoted string including the quotes
-    | QuotedString of char
+    | QuotedString of Character: char
 
     /// The quoted string excluding the quotes
-    | QuotedStringContents of char
+    | QuotedStringContents of Character: char
 
     /// Repeat the last CharSearch value
     | RepeatLastCharSearch
@@ -1181,7 +1181,7 @@ type Motion =
     | RepeatLastCharSearchOpposite
 
     /// A search for the specified pattern
-    | Search of SearchData
+    | Search of SearchData: SearchData
 
     /// Backward a section in the editor or to a close brace
     | SectionBackwardOrCloseBrace
@@ -1205,16 +1205,16 @@ type Motion =
     | ScreenColumn
 
     /// Matching xml / html tags
-    | TagBlock of TagBlockKind
+    | TagBlock of TagBlockKind: TagBlockKind
 
     /// The [(, ]), ]}, [{ motions
-    | UnmatchedToken of SearchPath * UnmatchedTokenKind
+    | UnmatchedToken of SearchPattern: SearchPath * UnmatchedTokenKind: UnmatchedTokenKind
 
     /// Implement the b/B motion
-    | WordBackward of WordKind
+    | WordBackward of WordKind: WordKind
 
     /// Implement the w/W motion
-    | WordForward of WordKind 
+    | WordForward of WordKind: WordKind 
 
 /// Interface for running Motion instances against an ITextView
 and IMotionUtil =
@@ -1464,19 +1464,19 @@ type KeyMappingResult =
 
     /// The values were mapped completely and require no further mapping. This 
     /// could be a result of a no-op mapping though
-    | Mapped of KeyInputSet
+    | Mapped of KeyInputSet: KeyInputSet
 
     /// The values were partially mapped but further mapping is required once the
     /// keys which were mapped are processed.  The values are 
     ///
     ///  mapped KeyInputSet * remaining KeyInputSet
-    | PartiallyMapped of KeyInputSet * KeyInputSet
+    | PartiallyMapped of MappedKeyInputSet: KeyInputSet * RemainingKeyInputSet: KeyInputSet
 
     /// The mapping encountered a recursive element that had to be broken 
     | Recursive
 
     /// More input is needed to resolve this mapping.
-    | NeedsMoreInput of KeyInputSet
+    | NeedsMoreInput of KeyInputSet: KeyInputSet
 
     with 
 
@@ -2143,14 +2143,14 @@ type VisualSpan =
 type VisualSelection =
 
     /// The underlying span and whether or not this is a forward looking span.  
-    | Character of CharacterSpan * SearchPath
+    | Character of CharacterSpan: CharacterSpan * SearchPath: SearchPath
 
     /// The underlying range, whether or not is forwards or backwards and the int 
     /// is which column in the range the caret should be placed in
-    | Line of SnapshotLineRange * SearchPath * int 
+    | Line of LineRange: SnapshotLineRange * SearchPath: SearchPath * ColumnNumber: int 
 
     /// Just keep the BlockSpan and the caret information for the block
-    | Block of BlockSpan * BlockCaretLocation
+    | Block of BlockSpan: BlockSpan * BlockCaretLocation: BlockCaretLocation
 
     with
 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1864,13 +1864,13 @@ type BlockCaretLocation =
 type VisualSpan =
 
     /// A character wise span.  The 'End' of the span is not selected.
-    | Character of CharacterSpan
+    | Character of CharacterSpan: CharacterSpan
 
     /// A line wise span
-    | Line of SnapshotLineRange
+    | Line of LineRange: SnapshotLineRange
 
     /// A block span.  
-    | Block of BlockSpan
+    | Block of BlockSpan: BlockSpan
 
     with
 
@@ -2486,7 +2486,7 @@ type VisualSelection =
 type StoredVisualSelection =
     | Character of Width: int
     | CharacterLine of LineCount: int * LastLineMaxOffset : int 
-    | Line of lineCount: int
+    | Line of LineCount: int
 
     with 
 
@@ -2562,31 +2562,31 @@ type ModeArgument =
     /// Passed to visual mode to indicate what the initial selection should be.  The SnapshotPoint
     /// option provided is meant to be the initial caret point.  If not provided the actual 
     /// caret point is used
-    | InitialVisualSelection of VisualSelection * SnapshotPoint option
+    | InitialVisualSelection of Selection: VisualSelection * CaretPoint: SnapshotPoint option
 
     /// Begins a block insertion.  This can possibly have a linked undo transaction that needs
     /// to be carried forward through the insert
-    | InsertBlock of BlockSpan * bool * ILinkedUndoTransaction
+    | InsertBlock of BlockSpan: BlockSpan * AtEndOfLine: bool * LinkedUndoTransaction: ILinkedUndoTransaction
 
     /// Begins insert mode with a specified count.  This means the text inserted should
     /// be repeated a total of 'count - 1' times when insert mode exits
-    | InsertWithCount of int
+    | InsertWithCount of Count: int
 
     /// Begins insert mode with a specified count.  This means the text inserted should
     /// be repeated a total of 'count - 1' times when insert mode exits.  Each extra time
     /// should be on a new line
-    | InsertWithCountAndNewLine of int * ILinkedUndoTransaction
+    | InsertWithCountAndNewLine of Count: int * LinkedUndoTransaction: ILinkedUndoTransaction
 
     /// Begins insert mode with an existing UndoTransaction.  This is used to link 
     /// change commands with text changes.  For example C, c, etc ...
-    | InsertWithTransaction of ILinkedUndoTransaction
+    | InsertWithTransaction of LinkedUndoTransaction: ILinkedUndoTransaction
 
     /// Passing the substitute to confirm to Confirm mode.  The SnapshotSpan is the first
     /// match to process and the range is the full range to consider for a replace
-    | Substitute of SnapshotSpan * SnapshotLineRange * SubstituteData
+    | Substitute of Span: SnapshotSpan * LineRange: SnapshotLineRange * SubstituteData: SubstituteData
 
     /// Enter command mode with a partially entered command and then return to normal mode
-    | PartialCommand of string
+    | PartialCommand of Command: string
 
 with
 
@@ -2609,13 +2609,13 @@ with
 [<NoEquality>]
 type ModeSwitch =
     | NoSwitch
-    | SwitchMode of ModeKind
-    | SwitchModeWithArgument of ModeKind * ModeArgument
+    | SwitchMode of ModeKind: ModeKind
+    | SwitchModeWithArgument of ModeKind: ModeKind * ModeArgument: ModeArgument
     | SwitchPreviousMode 
 
     /// Switch to the given mode for a single command.  After the command is processed switch
     /// back to the original mode
-    | SwitchModeOneTimeCommand of ModeKind
+    | SwitchModeOneTimeCommand of ModeKind: ModeKind
 
 [<RequireQualifiedAccess>]
 [<NoComparison>]
@@ -2623,7 +2623,7 @@ type CommandResult =
 
     /// The command completed and requested a switch to the provided Mode which 
     /// may just be a no-op
-    | Completed of ModeSwitch
+    | Completed of ModeSwitch: ModeSwitch
 
     /// An error was encountered and the command was unable to run.  If this is encountered
     /// during a macro run it will cause the macro to stop executing
@@ -2633,8 +2633,8 @@ type CommandResult =
 [<NoComparison>]
 [<NoEquality>]
 type VimResult<'T> =
-    | Result of 'T
-    | Error of string
+    | Result of Result: 'T
+    | Error of Error: string
 
 /// Information about the attributes of Command
 [<System.Flags>]
@@ -2755,16 +2755,16 @@ type NormalCommand =
 
     /// Deletes the text specified by the motion and begins insert mode. Implements the "c" 
     /// command
-    | ChangeMotion of MotionData
+    | ChangeMotion of MotionData: MotionData
 
     /// Change the characters on the caret line 
-    | ChangeCaseCaretLine of ChangeCharacterKind
+    | ChangeCaseCaretLine of ChangeCharacterKind: ChangeCharacterKind
 
     /// Change the characters on the caret line 
-    | ChangeCaseCaretPoint of ChangeCharacterKind
+    | ChangeCaseCaretPoint of ChangeCharacterKind: ChangeCharacterKind
 
     /// Change case of the specified motion
-    | ChangeCaseMotion of ChangeCharacterKind * MotionData
+    | ChangeCaseMotion of ChangeCharacterKind: ChangeCharacterKind * MotionData: MotionData
 
     /// Delete 'count' lines and begin insert mode
     | ChangeLines
@@ -2807,7 +2807,7 @@ type NormalCommand =
     | DeleteLines
 
     /// Delete the specified motion of text
-    | DeleteMotion of MotionData
+    | DeleteMotion of MotionData: MotionData
 
     /// Delete till the end of the line and 'count - 1' more lines down
     | DeleteTillEndOfLine
@@ -2825,29 +2825,29 @@ type NormalCommand =
     | FilterLines
 
     /// Filter the specified motion
-    | FilterMotion of MotionData
+    | FilterMotion of MotionData: MotionData
 
     /// Create a fold over the specified motion 
-    | FoldMotion of MotionData
+    | FoldMotion of MotionData: MotionData
 
     /// Format the code in the specified lines
     | FormatCodeLines
 
     /// Format the code in the specified motion
-    | FormatCodeMotion of MotionData
+    | FormatCodeMotion of MotionData: MotionData
 
     /// Format the text in the specified lines, optionally preserving the caret position
-    | FormatTextLines of bool
+    | FormatTextLines of PreserveCaretPosition: bool
 
     /// Format the text in the specified motion
-    | FormatTextMotion of bool * MotionData
+    | FormatTextMotion of PreserveCaretPosition: bool * MotionData: MotionData
 
     /// Go to the definition of hte word under the caret.
     | GoToDefinition
 
     /// GoTo the file under the cursor.  The bool represents whether or not this should occur in
     /// a different window
-    | GoToFileUnderCaret of bool
+    | GoToFileUnderCaret of UseNewWindow: bool
 
     /// Go to the global declaration of the word under the caret
     | GoToGlobalDeclaration
@@ -2856,10 +2856,10 @@ type NormalCommand =
     | GoToLocalDeclaration
 
     /// Go to the next tab in the specified direction
-    | GoToNextTab of SearchPath
+    | GoToNextTab of SearchPath: SearchPath
 
     /// Go to the window of the specified kind
-    | GoToWindow of WindowKind
+    | GoToWindow of WindowKind: WindowKind
 
     /// Go to the nth most recent view
     | GoToRecentView
@@ -2886,13 +2886,13 @@ type NormalCommand =
     | InsertLineBelow
 
     /// Join the specified lines
-    | JoinLines of JoinKind
+    | JoinLines of JoinKind: JoinKind
 
     /// Jump to the specified mark 
-    | JumpToMark of Mark
+    | JumpToMark of Mark: Mark
 
     /// Jump to the start of the line for the specified mark
-    | JumpToMarkLine of Mark
+    | JumpToMarkLine of Mark: Mark
 
     /// Jump to the next older item in the tag list
     | JumpToOlderPosition
@@ -2901,7 +2901,7 @@ type NormalCommand =
     | JumpToNewerPosition
 
     /// Move the caret to the result of the given Motion.
-    | MoveCaretToMotion of Motion
+    | MoveCaretToMotion of Motion: Motion
 
     /// Undo count operations in the ITextBuffer
     | Undo
@@ -2926,11 +2926,11 @@ type NormalCommand =
 
     /// Not actually a Vim Command.  This is a simple ping command which makes 
     /// testing items like complex repeats significantly easier
-    | Ping of PingData
+    | Ping of PingData: PingData
 
     /// Put the contents of the register into the buffer after the cursor.  The bool is 
     /// whether or not the caret should be placed after the inserted text
-    | PutAfterCaret of bool
+    | PutAfterCaret of PlaceCaretAfterInsertedText: bool
 
     /// Put the contents of the register into the buffer after the cursor and respecting 
     /// the indent of the current line
@@ -2942,7 +2942,7 @@ type NormalCommand =
 
     /// Put the contents of the register into the buffer before the cursor.  The bool is 
     /// whether or not the caret should be placed after the inserted text
-    | PutBeforeCaret of bool
+    | PutBeforeCaret of PlaceCaretAfterInsertedText: bool
 
     /// Put the contents of the register into the buffer before the cursor and respecting 
     /// the indent of the current line
@@ -2952,7 +2952,7 @@ type NormalCommand =
     | PrintFileInformation
 
     /// Start the recording of a macro to the specified Register
-    | RecordMacroStart of char
+    | RecordMacroStart of RegisterName: char
 
     /// Stop the recording of a macro to the specified Register
     | RecordMacroStop
@@ -2967,44 +2967,44 @@ type NormalCommand =
     /// whether or not the flags from the last substitute should be reused as
     /// well. The second bool value is for whether the substitute should
     /// operate on the whole buffer
-    | RepeatLastSubstitute of bool * bool
+    | RepeatLastSubstitute of UseSameFlags: bool * UseWholeBuffer: bool
 
     /// Replace the text starting at the text by starting insert mode
     | ReplaceAtCaret
 
     /// Replace the char under the cursor with the given char
-    | ReplaceChar of KeyInput
+    | ReplaceChar of KeyInput: KeyInput
 
     /// Run an 'at' command for the specified character
-    | RunAtCommand of char
+    | RunAtCommand of Character: char
 
     /// Set the specified mark to the current value of the caret
-    | SetMarkToCaret of char
+    | SetMarkToCaret of Character: char
 
     /// Scroll the caret in the specified direciton.  The bool is whether to use
     /// the 'scroll' option or 'count'
-    | ScrollLines of ScrollDirection * bool
+    | ScrollLines of ScrollDirection: ScrollDirection * UseScrollOption: bool
 
     /// Move the display a single page in the specified direction
-    | ScrollPages of ScrollDirection
+    | ScrollPages of ScrollDirection: ScrollDirection
 
     /// Scroll the window in the specified direction by 'count' lines
-    | ScrollWindow of ScrollDirection
+    | ScrollWindow of ScrollDirection: ScrollDirection
 
     /// Scroll the current line to the top of the ITextView.  The bool is whether or not
     /// to leave the caret in the same column
-    | ScrollCaretLineToTop of bool
+    | ScrollCaretLineToTop of MaintainCaretColumn: bool
 
     /// Scroll the caret line to the middle of the ITextView.  The bool is whether or not
     /// to leave the caret in the same column
-    | ScrollCaretLineToMiddle of bool
+    | ScrollCaretLineToMiddle of MaintainCaretColumn: bool
 
     /// Scroll the caret line to the bottom of the ITextView.  The bool is whether or not
     /// to leave the caret in the same column
-    | ScrollCaretLineToBottom of bool
+    | ScrollCaretLineToBottom of MaintainCaretColumn: bool
 
     /// Select the next match for the last pattern searched for
-    | SelectNextMatch of SearchPath
+    | SelectNextMatch of SearchPath: SearchPath
 
     /// Shift 'count' lines from the cursor left
     | ShiftLinesLeft
@@ -3013,10 +3013,10 @@ type NormalCommand =
     | ShiftLinesRight
 
     /// Shift 'motion' lines from the cursor left
-    | ShiftMotionLinesLeft of MotionData
+    | ShiftMotionLinesLeft of MotionData: MotionData
 
     /// Shift 'motion' lines from the cursor right
-    | ShiftMotionLinesRight of MotionData
+    | ShiftMotionLinesRight of MotionData: MotionData
 
     /// Split the view horizontally
     | SplitViewHorizontally
@@ -3031,22 +3031,22 @@ type NormalCommand =
     | SubtractFromWord
 
     /// Switch modes with the specified information
-    | SwitchMode of ModeKind * ModeArgument
+    | SwitchMode of ModeKind: ModeKind * ModeArgument: ModeArgument
 
     /// Switch to the visual mode specified by 'selectmode=cmd'
-    | SwitchModeVisualCommand of VisualKind
+    | SwitchModeVisualCommand of VisualKind: VisualKind
 
     /// Switch to the previous Visual Mode selection
     | SwitchPreviousVisualMode
 
     /// Switch to a selection dictated by the given caret movement
-    | SwitchToSelection of CaretMovement
+    | SwitchToSelection of CaretMovement: CaretMovement
 
     /// Write out the ITextBuffer and quit
     | WriteBufferAndQuit
 
     /// Yank the given motion into a register
-    | Yank of MotionData
+    | Yank of MotionData: MotionData
 
     /// Yank the specified number of lines
     | YankLines

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -70,7 +70,7 @@ type VimRcState =
     /// The load succeeded of the specified file.  If there were any errors actually
     /// processing the load they will be captured in the string[] parameter.
     /// The load succeeded and the specified file was used 
-    | LoadSucceeded of VimRcPath * string[]
+    | LoadSucceeded of VimRcPath: VimRcPath * Errors: string[]
 
     /// The load failed 
     | LoadFailed
@@ -263,10 +263,10 @@ type IUndoRedoOperations =
 /// Represents a set of changes to a contiguous region. 
 [<RequireQualifiedAccess>]
 type TextChange = 
-    | DeleteLeft of int
-    | DeleteRight of int
-    | Insert of string
-    | Combination of TextChange * TextChange
+    | DeleteLeft of Count: int
+    | DeleteRight of Count: int
+    | Insert of Text: string
+    | Combination of Left: TextChange * Right: TextChange
 
     with 
 
@@ -3575,22 +3575,22 @@ type BindDataStorage<'T> =
 type CommandBinding = 
 
     /// KeyInputSet bound to a particular NormalCommand instance
-    | NormalBinding of KeyInputSet * CommandFlags * NormalCommand
+    | NormalBinding of KeyInputSet: KeyInputSet * CommandFlags: CommandFlags * NormalCommand: NormalCommand
 
     /// KeyInputSet bound to a complex NormalCommand instance
-    | ComplexNormalBinding of KeyInputSet * CommandFlags * BindDataStorage<NormalCommand>
+    | ComplexNormalBinding of KeyInputSet: KeyInputSet * CommandFlags: CommandFlags * BindDataStorage: BindDataStorage<NormalCommand>
 
     /// KeyInputSet bound to a particular NormalCommand instance which takes a Motion Argument
-    | MotionBinding of KeyInputSet * CommandFlags * (MotionData -> NormalCommand)
+    | MotionBinding of KeyInputSet: KeyInputSet * CommandFlags: CommandFlags * Func: (MotionData -> NormalCommand)
 
     /// KeyInputSet bound to a particular VisualCommand instance
-    | VisualBinding of KeyInputSet * CommandFlags * VisualCommand
+    | VisualBinding of KeyInputSet: KeyInputSet * CommandFlags: CommandFlags * VisualCommand: VisualCommand
 
     /// KeyInputSet bound to an insert mode command
-    | InsertBinding of KeyInputSet * CommandFlags * InsertCommand
+    | InsertBinding of KeyInputSet: KeyInputSet * CommandFlags: CommandFlags * InsertCommand: InsertCommand
 
     /// KeyInputSet bound to a complex VisualCommand instance
-    | ComplexVisualBinding of KeyInputSet * CommandFlags * BindDataStorage<VisualCommand>
+    | ComplexVisualBinding of KeyInputSet: KeyInputSet * CommandFlags: CommandFlags * BindDataStorage: BindDataStorage<VisualCommand>
 
     with 
 
@@ -3691,17 +3691,17 @@ type StoredVisualSpan =
 type StoredCommand =
 
     /// The stored information about a NormalCommand
-    | NormalCommand of NormalCommand * CommandData * CommandFlags
+    | NormalCommand of NormalCommand: NormalCommand * CommandData: CommandData * CommandFlags: CommandFlags
 
     /// The stored information about a VisualCommand
-    | VisualCommand of VisualCommand * CommandData * StoredVisualSpan * CommandFlags
+    | VisualCommand of VisualCommand: VisualCommand * CommandData: CommandData * StoredVisualSpan: StoredVisualSpan * CommandFlags: CommandFlags
 
     /// The stored information about a InsertCommand
-    | InsertCommand of InsertCommand * CommandFlags
+    | InsertCommand of InsertCommand: InsertCommand * CommandFlags: CommandFlags
 
     /// A Linked Command links together 2 other StoredCommand objects so they
     /// can be repeated together.
-    | LinkedCommand of StoredCommand * StoredCommand
+    | LinkedCommand of Left: StoredCommand * Right: StoredCommand
 
     with
 
@@ -3768,11 +3768,11 @@ type MotionBinding =
     /// Simple motion which comprises of a single KeyInput and a function which given 
     /// a start point and count will produce the motion.  None is returned in the 
     /// case the motion is not valid
-    | Static of KeyInputSet * MotionFlags * Motion
+    | Static of KeyInputSet: KeyInputSet * MotionFlags: MotionFlags * Motion: Motion
 
     /// Complex motion commands take more than one KeyInput to complete.  For example 
     /// the f,t,F and T commands all require at least one additional input.
-    | Dynamic of KeyInputSet * MotionFlags * BindDataStorage<Motion>
+    | Dynamic of KeyInputSet: KeyInputSet * MotionFlags: MotionFlags * BindDataStorage: BindDataStorage<Motion>
 
     with
 
@@ -4087,7 +4087,7 @@ type IMacroRecorder =
 type ProcessResult = 
 
     /// The input was processed and provided the given ModeSwitch
-    | Handled of ModeSwitch
+    | Handled of ModeSwitch: ModeSwitch
 
     /// The input was processed but more input is needed in order to complete
     /// an operation

--- a/Src/VimCore/CoreTypes.fs
+++ b/Src/VimCore/CoreTypes.fs
@@ -319,8 +319,8 @@ type NumberMark =
 [<StructuralEquality>]
 [<NoComparison>]
 type LocalMark =
-    | Letter of Letter
-    | Number of NumberMark
+    | Letter of Letter: Letter
+    | Number of NumberMark: NumberMark
     | LastInsertExit
     | LastSelectionStart
     | LastSelectionEnd
@@ -377,10 +377,10 @@ type LocalMark =
 type Mark =
 
     /// Marks which are local to the IVimTextBuffer
-    | LocalMark of LocalMark
+    | LocalMark of LocalMark: LocalMark
 
     /// Marks which are global to vim
-    | GlobalMark of Letter
+    | GlobalMark of Letter: Letter
 
     /// The last jump which is specific to a window
     | LastJump 

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -3311,10 +3311,10 @@ module TrackingPointUtil =
 [<RequireQualifiedAccess>]
 type EditSpan = 
     /// Common case of an edit operation which occurs over a single SnapshotSpan
-    | Single of SnapshotColumnSpan 
+    | Single of ColumnSpan: SnapshotColumnSpan 
 
     /// Occurs during block edits
-    | Block of NonEmptyCollection<SnapshotOverlapColumnSpan>
+    | Block of ColumnSpans: NonEmptyCollection<SnapshotOverlapColumnSpan>
 
     with
 

--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -33,12 +33,12 @@ type VariableType =
 
 [<RequireQualifiedAccess>]
 type VariableValue =
-    | Number of int
-    | Float of float
-    | String of string
-    | FunctionRef of string
-    | List of VariableValue list
-    | Dictionary of Map<string, VariableValue>
+    | Number of Number: int
+    | Float of Float: float
+    | String of String: string
+    | FunctionRef of FunctionName: string
+    | List of VariableValues: VariableValue list
+    | Dictionary of Map: Map<string, VariableValue>
     | Error
 
     with
@@ -68,8 +68,8 @@ type VariableMap = System.Collections.Generic.Dictionary<string, VariableValue>
 
 [<RequireQualifiedAccess>]
 type EvaluateResult = 
-    | Succeeded of VariableValue
-    | Failed of string
+    | Succeeded of Value: VariableValue
+    | Failed of Failed: string
 
 /// The set of events Vim supports.  Defined in ':help autocmd-events'
 ///
@@ -162,7 +162,7 @@ type EventKind =
 [<StructuralEquality>]
 type AutoCommandGroup = 
     | Default
-    | Named of string 
+    | Named of Name: string 
 
 type AutoCommand = {
     Group: AutoCommandGroup
@@ -387,11 +387,11 @@ type FileNameModifier =
 [<RequireQualifiedAccess>]
 type SymbolicPathComponent =
     /// '%' + modifiers
-    | CurrentFileName of FileNameModifier list
+    | CurrentFileName of FileNameModifiers: FileNameModifier list
     /// '#'[number] + modifiers
-    | AlternateFileName of int * FileNameModifier list
+    | AlternateFileName of Count: int * FileNameModifiers: FileNameModifier list
     /// Literal text
-    | Literal of string
+    | Literal of Literal: string
 
 type SymbolicPath = SymbolicPathComponent list
 
@@ -399,9 +399,9 @@ type SymbolicPath = SymbolicPathComponent list
 [<RequireQualifiedAccess>]
 type CommandOption =
     | StartAtLastLine
-    | StartAtLine of int
-    | StartAtPattern of string
-    | ExecuteLineCommand of LineCommand
+    | StartAtLine of LineNumber: int
+    | StartAtPattern of Pattern: string
+    | ExecuteLineCommand of LineCommand: LineCommand
 
 and Function = {
 
@@ -432,25 +432,25 @@ with
 and [<RequireQualifiedAccess>] Expression =
 
     /// Binary expression
-    | Binary of BinaryKind * Expression * Expression
+    | Binary of BinaryKind: BinaryKind * Left: Expression * Right: Expression
 
     /// A constant value
-    | ConstantValue of VariableValue 
+    | ConstantValue of Value: VariableValue 
 
     /// The name of an option/setting
-    | OptionName of string
+    | OptionName of OptionName: string
 
     /// The name of a register
-    | RegisterName of RegisterName
+    | RegisterName of RegisterName: RegisterName
 
     /// The name of a variable
-    | VariableName of VariableName
+    | VariableName of VariableName: VariableName
 
     /// Invocation of a function
-    | FunctionCall of VariableName * Expression list
+    | FunctionCall of VariableName: VariableName * Arguments: Expression list
 
     /// List of expressions
-    | List of Expression list
+    | List of Expressions: Expression list
 
 and [<RequireQualifiedAccess>] LineCommand =
 

--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -455,26 +455,26 @@ and [<RequireQualifiedAccess>] Expression =
 and [<RequireQualifiedAccess>] LineCommand =
 
     /// Add a new AutoCommand to the set of existing AutoCommand values
-    | AddAutoCommand of AutoCommandDefinition
+    | AddAutoCommand of AutoCommandDefinition: AutoCommandDefinition
 
     /// The :behave command to set common behaviors in certain environments
-    | Behave of string
+    | Behave of Text: string
 
     /// The :call command to invoke a function.  The first string is the 
-    | Call of CallInfo
+    | Call of CallInfo: CallInfo
 
     /// Change the current directory to the given value
-    | ChangeDirectory of SymbolicPath
+    | ChangeDirectory of SymbolicPath: SymbolicPath
 
     /// Change the current directory for the local window
-    | ChangeLocalDirectory of SymbolicPath
+    | ChangeLocalDirectory of SymbolicPath: SymbolicPath
 
     /// Clear out the keyboard map for the given modes
-    | ClearKeyMap of KeyRemapMode list * KeyMapArgument list
+    | ClearKeyMap of KeyRemapModes: KeyRemapMode list * KeyMapArguments: KeyMapArgument list
 
     /// The :close command.  The bool value represents whether or not the 
     /// bang modifier was added
-    | Close of bool
+    | Close of HasBang: bool
 
     /// Compose two line commands
     | Compose of LineCommand * LineCommand
@@ -482,7 +482,7 @@ and [<RequireQualifiedAccess>] LineCommand =
     /// Copy the specific line range to the given position.  The first line range is the 
     /// source and the second is the destination.  The last entry is an optional count
     /// which can be specified
-    | CopyTo of LineRangeSpecifier * LineRangeSpecifier * int option
+    | CopyTo of Source: LineRangeSpecifier * Destination: LineRangeSpecifier * Count: int option
 
     /// Delete the specified marks
     | DeleteMarks of Mark list
@@ -492,68 +492,68 @@ and [<RequireQualifiedAccess>] LineCommand =
 
     /// Move the specific line range to the given position.  The first line range is the 
     /// source and the second is the destination
-    | MoveTo of LineRangeSpecifier * LineRangeSpecifier * int option
+    | MoveTo of Source: LineRangeSpecifier * Destination: LineRangeSpecifier * Count: int option
 
     /// The :delete command
-    | Delete of LineRangeSpecifier * RegisterName option
+    | Delete of LineRangeSpecifier: LineRangeSpecifier * RegisterName: RegisterName option
 
     /// The beginning of a function definition.  When 'None' is present that means there was
     /// an error parsing the function definition.
-    | FunctionStart of FunctionDefinition option
+    | FunctionStart of FunctionDefinition: FunctionDefinition option
 
     /// The :endfunc member
     | FunctionEnd
 
     /// A complete function 
-    | Function of Function
+    | Function of Function: Function
 
     /// Add the specified digraphs to the digraph mapping
     | Digraphs of (char * char * int) list
 
     /// Display the contents of registers.  Unless a specific register name is 
     /// given all registers will be displayed
-    | DisplayRegisters of RegisterName list
+    | DisplayRegisters of RegisterNames: RegisterName list
 
     /// Display the specified marks.  If no Mark values are provided then display 
     /// all marks
-    | DisplayMarks of Mark list
+    | DisplayMarks of Marks: Mark list
 
     /// Display the keymap for the given modes.  Restrict the display to the provided
     /// key notation if it's provided
-    | DisplayKeyMap of KeyRemapMode list * string option
+    | DisplayKeyMap of KeyRemapModes: KeyRemapMode list * Notation: string option
 
     /// Display the specified let value
-    | DisplayLet of VariableName list
+    | DisplayLet of VariableNames: VariableName list
 
     /// Display the specified line range with the specified flags
     | DisplayLines of LineRangeSpecifier * LineCommandFlags
 
     // The :echo command
-    | Echo of Expression
+    | Echo of Expression: Expression
 
     // The :execute command
-    | Execute of Expression
+    | Execute of Expression: Expression
 
     /// The :edit command.  The values range as follows
     ///  - ! option present
     ///  - The provided ++opt
     ///  - The provided +cmd 
     ///  - The provided file to edit 
-    | Edit of bool * FileOption list * CommandOption option * SymbolicPath
+    | Edit of HasBang: bool * FileOptions: FileOption list * CommandOptions: CommandOption option * SymbolicPath: SymbolicPath
 
     /// List recent files
     | Files
 
     /// Fold the selected LineRange
-    | Fold of LineRangeSpecifier
+    | Fold of LineRangeSpecifier: LineRangeSpecifier
 
     /// Run the given command against all lines in the specified range (default is the 
     /// entire buffer) which match the predicate pattern.  If the bool provided is false
     /// then it will be run on the lines which don't match the pattern
-    | Global of LineRangeSpecifier * string * bool * LineCommand
+    | Global of LineRangeSpecifier: LineRangeSpecifier * Pattern: string * MatchPattern: bool * LineCommand: LineCommand
 
     // Executes the given key strokes as if they were typed in normal mode
-    | Normal of LineRangeSpecifier * KeyInput list
+    | Normal of LineRangeSpecifier: LineRangeSpecifier * KeyInputs: KeyInput list
 
     /// Go to the first tab 
     | GoToFirstTab
@@ -562,10 +562,10 @@ and [<RequireQualifiedAccess>] LineCommand =
     | GoToLastTab
 
     /// Go to the next tab
-    | GoToNextTab of int option
+    | GoToNextTab of Count: int option
 
     /// Go to the previous tab
-    | GoToPreviousTab of int option
+    | GoToPreviousTab of Count: int option
 
     /// Get help on VsVim
     | Help
@@ -574,20 +574,20 @@ and [<RequireQualifiedAccess>] LineCommand =
     | History
 
     /// Run a host command.  The first string is the command and the second string is the argument
-    | HostCommand of string * string
+    | HostCommand of Command: string * Argument: string
 
     /// Process the 'split' command.  The values range as follows
     ///  - Height of the window if specified.  Expressed as a range.  The actual documentation
     ///    doesn't specify a range can be used here but usage indicates it can
     ///  - The provided ++opt
     ///  - The provided +cmd
-    | HorizontalSplit of LineRangeSpecifier * FileOption list * CommandOption option
+    | HorizontalSplit of LineRangeSpecifier: LineRangeSpecifier * FileOptiosn: FileOption list * CommandOption: CommandOption option
 
     /// The if command
-    | If of ConditionalBlock list
+    | If of Blocks: ConditionalBlock list
 
     /// The :if definition command
-    | IfStart of Expression
+    | IfStart of Expression: Expression
 
     /// The :endif definition
     | IfEnd
@@ -596,29 +596,29 @@ and [<RequireQualifiedAccess>] LineCommand =
     | Else
 
     /// The :elseif definition 
-    | ElseIf of Expression
+    | ElseIf of Expression: Expression
 
     /// Join the lines in the specified range.  Optionally provides a count of lines to 
     /// start the join after the line range
-    | Join of LineRangeSpecifier * JoinKind
+    | Join of LineRangeSpecifier: LineRangeSpecifier * JoinKind: JoinKind
 
     /// Jump to the last line of the specified line range
-    | JumpToLastLine of LineRangeSpecifier
+    | JumpToLastLine of LineRangeSpecifier: LineRangeSpecifier
 
     // Let command.  The first item is the name and the second is the value
-    | Let of VariableName * Expression
+    | Let of VariableName: VariableName * Expression: Expression
 
     // Let command applied to a register. The first item is the name and the second is the value
-    | LetRegister of RegisterName * Expression
+    | LetRegister of RegisterName: RegisterName * Expression: Expression
 
     /// Make command.  The options are as follows
     ///   - The ! option
     ///   - All of the text after the !
-    | Make of bool * string
+    | Make of HasBang: bool * Text: string
 
     /// Map the key notation in the given modes.  The bool is whether or not the right
     /// notation can allow remapping
-    | MapKeys of string * string * KeyRemapMode list * bool * KeyMapArgument list
+    | MapKeys of LeftKeyNotation: string * RightKeyNotation: string * KeyRemapModes: KeyRemapMode list * AllowRemap: bool * KeyMapArguments: KeyMapArgument list
 
     /// Temporarily disable the 'hlsearch' option
     | NoHighlightSearch
@@ -630,35 +630,35 @@ and [<RequireQualifiedAccess>] LineCommand =
     | Only
 
     /// There was a parse error on the specified line
-    | ParseError of string
+    | ParseError of Error: string
 
     /// Print out the current directory
     | PrintCurrentDirectory
 
     /// Put the contents of the given register after the line identified by the
     /// LineRange (defaults to current)
-    | PutAfter of LineRangeSpecifier * RegisterName option
+    | PutAfter of LineRangeSpecifier: LineRangeSpecifier * RegisterName: RegisterName option
 
     /// Put the contents of the given register before the line identified by the
     /// LineRange (defaults to current)
-    | PutBefore of LineRangeSpecifier * RegisterName option
+    | PutBefore of LineRangeSpecifier: LineRangeSpecifier * RegisterName: RegisterName option
 
     /// Display the quick fix window
     | QuickFixWindow
 
     /// Next error in the quick fix list.  int is for count and bool is for the bang option
-    | QuickFixNext of int option * bool
+    | QuickFixNext of Count: int option * HasBang: bool
 
     /// Previous error in the quick fix list.  int is for count and bool is for the bang option
-    | QuickFixPrevious of int option * bool
+    | QuickFixPrevious of Count: int option * HasBang: bool
 
     /// Quit the curren window without writing it's content.  If the boolean option
     /// is present (for !) then don't warn about a dirty window
-    | Quit of bool
+    | Quit of HasBang: bool
 
     /// Quit all windows without writing their content and exit Vim.  If the boolean
     /// option is present then don't warn about writing a dirty window
-    | QuitAll of bool
+    | QuitAll of HasBang: bool
 
     /// Quit the current window after writing out it's contents.  The values range as 
     /// follows
@@ -666,97 +666,97 @@ and [<RequireQualifiedAccess>] LineCommand =
     ///  - ! option present
     ///  - The provided ++opt
     ///  - The provided +cmd
-    | QuitWithWrite of LineRangeSpecifier * bool * FileOption list * string option 
+    | QuitWithWrite of LineRangeSpecifier: LineRangeSpecifier * HasBang: bool * FileOptions: FileOption list * FilePath: string option 
 
     /// Read the contents of the specified file and put it after the specified
     /// line range or the caret
-    | ReadFile of LineRangeSpecifier * FileOption list * string
+    | ReadFile of LineRangeSpecifier: LineRangeSpecifier * FileOptions: FileOption list * FilePath: string
 
     /// Read the contens of the specified command and put it after the specified
     /// line range or the caret
-    | ReadCommand of LineRangeSpecifier * string
+    | ReadCommand of LineRangeSpecifier: LineRangeSpecifier * CommandText: string
 
     /// Redo the last item on the undo stack
     | Redo
 
     /// Remove all auto commands with the specified definition
-    | RemoveAutoCommands of AutoCommandDefinition
+    | RemoveAutoCommands of AutoCommandDefinition: AutoCommandDefinition
 
     /// Retab the specified LineRange.  The options are as follows
     ///  - The LineRange to change (defaults to entire buffer)
     ///  - True to replace both tabs and spaces, false for just spaces
     ///  - new tabstop value
-    | Retab of LineRangeSpecifier * bool * int option
+    | Retab of LineRangeSpecifier: LineRangeSpecifier * HasBang: bool * TabStop: int option
 
     /// Process the 'set' command
-    | Set of SetArgument list
+    | Set of SetArguments: SetArgument list
 
     /// Process the '/' and '?' commands
-    | Search of LineRangeSpecifier * SearchPath * string
+    | Search of LineRangeSpecifier: LineRangeSpecifier * SearchPath: SearchPath * Pattern: string
 
     /// Start a shell window
     | Shell
 
     /// Filter the given line range through shell command
-    | ShellCommand of LineRangeSpecifier * string
+    | ShellCommand of LineRangeSpecifier: LineRangeSpecifier * CommandText: string
 
     /// Process the '<' shift left command
-    | ShiftLeft of LineRangeSpecifier * int
+    | ShiftLeft of LineRangeSpecifier: LineRangeSpecifier * Count: int
 
     /// Process the '>' shift right command
-    | ShiftRight of LineRangeSpecifier * int
+    | ShiftRight of LineRangeSpecifier: LineRangeSpecifier * Count: int
 
     /// Sort the specified LineRange.  The options are as follows:
     /// - The LineRange to change (defaults to entire buffer)
     /// - True to reverse sort
     /// - sort flags
     /// - optional pattern
-    | Sort of LineRangeSpecifier * bool * SortFlags * string option
+    | Sort of LineRangeSpecifier: LineRangeSpecifier * HasBang: bool * SortFlags: SortFlags * Pattern: string option
 
     /// Process the 'source' command.  
-    | Source of bool * string
+    | Source of HasBang: bool * FilePath: string
 
     // Close all tabs but this one
     | TabOnly
 
     /// Process the 'tabnew' / 'tabedit' commands.  The optional string represents the file path 
-    | TabNew of SymbolicPath
+    | TabNew of SymbolicPath: SymbolicPath
 
     /// The version command
     | Version
 
     /// Process the 'vsplit' command. Values are as per HorizontalSplit
-    | VerticalSplit of LineRangeSpecifier * FileOption list * CommandOption option
+    | VerticalSplit of LineRangeSpecifier: LineRangeSpecifier * FileOptions: FileOption list * CommandOption: CommandOption option
 
     /// The :substitute command.  The argument order is range, pattern, replace,
     /// substitute flags and count
-    | Substitute of LineRangeSpecifier * string * string * SubstituteFlags
+    | Substitute of LineRangeSpecifier: LineRangeSpecifier * Pattern: string * Replace: string * SubstituteFlags: SubstituteFlags
 
     /// The variant of the :substitute command which repeats the last :subsitute with
     /// different flags and count
-    | SubstituteRepeat of LineRangeSpecifier * SubstituteFlags
+    | SubstituteRepeat of LineRangeSpecifier: LineRangeSpecifier * SubstituteFlags: SubstituteFlags
 
     /// Undo the last change
     | Undo
 
     /// Unlet a value.  
-    | Unlet of bool * string list
+    | Unlet of HasBang: bool * Names: string list
 
     /// Unmap the key notation in the given modes
-    | UnmapKeys of string * KeyRemapMode list * KeyMapArgument list
+    | UnmapKeys of KeyNotation: string * KeyRemapModes: KeyRemapMode list * KeyMapArguments: KeyMapArgument list
 
     /// Write the 
     ///  - The line range to write out
     ///  - Whether or not a ! was provided
     ///  - The provided ++opt
     ///  - The file name to write to
-    | Write of LineRangeSpecifier * bool * FileOption list * string option
+    | Write of LineRangeSpecifier: LineRangeSpecifier * HasBang: bool * FileOptions: FileOption list * FilePath: string option
 
     /// Write out all changed buffers
-    | WriteAll of bool * bool
+    | WriteAll of HasBang: bool * Quit: bool
 
     /// Yank the line range into the given register with the specified count
-    | Yank of LineRangeSpecifier * RegisterName option * int option
+    | Yank of LineRangeSpecifier: LineRangeSpecifier * RegisterNames: RegisterName option * Count: int option
 
 with 
 

--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -485,7 +485,7 @@ and [<RequireQualifiedAccess>] LineCommand =
     | CopyTo of Source: LineRangeSpecifier * Destination: LineRangeSpecifier * Count: int option
 
     /// Delete the specified marks
-    | DeleteMarks of Mark list
+    | DeleteMarks of Marks: Mark list
 
     /// Delete all of the marks except A-Z and 0-9
     | DeleteAllMarks 
@@ -772,10 +772,10 @@ with
 [<NoEquality>]
 [<RequireQualifiedAccess>]
 type BuiltinFunctionCall =
-    | Escape of string * string
-    | Exists of string
+    | Escape of Value: string * EscapeCharacters: string
+    | Exists of Name: string
     | Localtime
-    | Nr2char of int
+    | Nr2char of Nr: int
 
 /// Engine which interprets Vim commands and expressions
 type IVimInterpreter =

--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -477,7 +477,7 @@ and [<RequireQualifiedAccess>] LineCommand =
     | Close of HasBang: bool
 
     /// Compose two line commands
-    | Compose of LineCommand * LineCommand
+    | Compose of First: LineCommand * Second: LineCommand
 
     /// Copy the specific line range to the given position.  The first line range is the 
     /// source and the second is the destination.  The last entry is an optional count
@@ -508,7 +508,7 @@ and [<RequireQualifiedAccess>] LineCommand =
     | Function of Function: Function
 
     /// Add the specified digraphs to the digraph mapping
-    | Digraphs of (char * char * int) list
+    | Digraphs of Digraphs: (char * char * int) list
 
     /// Display the contents of registers.  Unless a specific register name is 
     /// given all registers will be displayed
@@ -526,7 +526,7 @@ and [<RequireQualifiedAccess>] LineCommand =
     | DisplayLet of VariableNames: VariableName list
 
     /// Display the specified line range with the specified flags
-    | DisplayLines of LineRangeSpecifier * LineCommandFlags
+    | DisplayLines of LineRangeSpecifier: LineRangeSpecifier * LineCommandFlags: LineCommandFlags
 
     // The :echo command
     | Echo of Expression: Expression

--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -189,7 +189,7 @@ type AutoCommandDefinition = {
 type LineSpecifier = 
 
     /// The line with the specified number
-    | Number of int
+    | Number of Number: int
 
     /// The current line: '.'
     | CurrentLine
@@ -198,10 +198,10 @@ type LineSpecifier =
     | LastLine
 
     /// The line containing the specified mark
-    | MarkLine of Mark
+    | MarkLine of Mark: Mark
 
     /// The next line where the given pattern matches
-    | NextLineWithPattern of string
+    | NextLineWithPattern of Pattern: string
 
     /// The next line where the previous search pattern occurs
     | NextLineWithPreviousPattern
@@ -210,13 +210,13 @@ type LineSpecifier =
     | NextLineWithPreviousSubstitutePattern
 
     /// The previous line where the given pattern matches
-    | PreviousLineWithPattern of string
+    | PreviousLineWithPattern of Pattern: string
 
     /// The previous line where the previous search pattern occurs
     | PreviousLineWithPreviousPattern
 
     /// LineSpecifier with the given line adjustment
-    | LineSpecifierWithAdjustment of LineSpecifier * int
+    | LineSpecifierWithAdjustment of LineSpecifier: LineSpecifier * Adjustment: int
 
 /// A line range in the file 
 [<RequireQualifiedAccess>]
@@ -229,25 +229,25 @@ type LineRangeSpecifier =
     | EntireBuffer 
 
     /// A single line range
-    | SingleLine of LineSpecifier
+    | SingleLine of LineSpecifier: LineSpecifier
 
     /// A range defined by two lines.  The bool is whether or not the cursor should be
     /// adjusted for the for the second line specifier (true when ';' is used to separate
     /// the LineSpecifier values)
-    | Range of LineSpecifier * LineSpecifier * bool
+    | Range of StartLineSpecifier: LineSpecifier * LastLineSpecifier: LineSpecifier * AdjustCaret: bool
 
     /// The range is an end count on top of another LineRange value.  It's possible for the 
     /// end count to exist in the abscence a range
-    | WithEndCount of LineRangeSpecifier * int
+    | WithEndCount of LineRangeSpecifier: LineRangeSpecifier * Count: int
 
     /// The LineRange value for Join is heavily special cased
-    | Join of LineRangeSpecifier * int option
+    | Join of LineRangeSpecifier: LineRangeSpecifier * Count: int option
 
 /// Represents the values for '++opt' which can occur on commands like :edit
 [<RequireQualifiedAccess>]
 type FileOption =
-    | FileFormat of string
-    | Encoding of string
+    | FileFormat of FileFormat: string
+    | Encoding of Encoding: string
     | Binary 
     | NoBinary
     | Bad
@@ -282,35 +282,35 @@ type SetArgument  =
     | DisplayAllTerminal
 
     /// Display the specified setting
-    | DisplaySetting of string
+    | DisplaySetting of SettingName: string
 
     /// The 'all&' argument.  Resets all setting to their default value
     | ResetAllToDefault
 
     /// Use the setting.  Produced when an setting name is used without arguments.  The behavior 
     /// depends on the type of the setting once it's bound
-    | UseSetting of string
+    | UseSetting of SettingName: string
 
     /// Toggle the setting value off.  How the toggle works depends on the type of the setting
-    | ToggleOffSetting of string
+    | ToggleOffSetting of SettingName: string
 
     /// Invert the setting
-    | InvertSetting of string
+    | InvertSetting of SettingName: string
 
     /// Reset the setting to it's default value
-    | ResetSetting of string
+    | ResetSetting of SettingName: string
 
     /// Set the setting to the specified value
-    | AssignSetting of string * string
+    | AssignSetting of SettingName: string * Value: string
 
     /// Add the value to the setting
-    | AddSetting of string * string
+    | AddSetting of SettingName: string * Value: string
 
     /// Multiply the value of the setting with the value
-    | MultiplySetting of string * string 
+    | MultiplySetting of SettingName: string * Value: string 
 
     /// Subtracte the value of the setting with the value
-    | SubtractSetting of string * string
+    | SubtractSetting of SettingName: string * Value: string
 
 [<RequireQualifiedAccess>]
 type BinaryKind = 

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -12,8 +12,8 @@ type ParseRegisterName =
 
 [<RequireQualifiedAccess>]
 type ParseResult<'T> = 
-    | Succeeded of 'T
-    | Failed of string
+    | Succeeded of Value: 'T
+    | Failed of Error: string
 
     with 
 

--- a/Src/VimCore/Interpreter_Parser.fsi
+++ b/Src/VimCore/Interpreter_Parser.fsi
@@ -5,8 +5,8 @@ open Vim
 
 [<RequireQualifiedAccess>]
 type ParseResult<'T> = 
-    | Succeeded of 'T
-    | Failed of string
+    | Succeeded of Value: 'T
+    | Failed of Error: string
 
 [<Sealed>]
 [<Class>]

--- a/Src/VimCore/Interpreter_Tokens.fs
+++ b/Src/VimCore/Interpreter_Tokens.fs
@@ -12,13 +12,13 @@ type TokenKind =
     | Blank
 
     /// A decimal number 
-    | Number of int
+    | Number of Number: int
 
     /// A contiguous set of letters in the text
-    | Word of string
+    | Word of Word: string
 
     /// A single non-letter character
-    | Character of char
+    | Character of Character: char
 
     /// The end of the line
     | EndOfLine

--- a/Src/VimCore/MefInterfaces.fs
+++ b/Src/VimCore/MefInterfaces.fs
@@ -250,7 +250,7 @@ type IClipboardDevice =
 [<NoEquality>]
 type Result = 
     | Succeeded
-    | Failed of string
+    | Failed of Error: string
 
 [<Flags>]
 type ViewFlags = 
@@ -290,7 +290,7 @@ type MaintainCaretColumn =
 
     /// This number is kept as a count of spaces.  Tabs need to be adjusted for when applying
     /// this setting to a motion
-    | Spaces of int
+    | Spaces of Count: int
 
     /// The caret was moved with the $ motion and the further moves should move to the end of 
     /// the line 

--- a/Src/VimCore/Register.fs
+++ b/Src/VimCore/Register.fs
@@ -7,8 +7,8 @@ open System.Diagnostics
 /// Representation of StringData stored in a Register
 [<RequireQualifiedAccess>]
 type StringData = 
-    | Simple of string
-    | Block of NonEmptyCollection<string>
+    | Simple of Text: string
+    | Block of BlockTexts: NonEmptyCollection<string>
     with 
 
     member x.ApplyCount count =
@@ -363,14 +363,14 @@ type SelectionAndDropRegister =
 type RegisterName =
     /// The unnamed register.  This is the default register for many types of operations
     | Unnamed
-    | Numbered of NumberedRegister
+    | Numbered of NumberedRegister: NumberedRegister
     | SmallDelete
     /// The A-Z and a-z registers
-    | Named of NamedRegister
+    | Named of NamedRegister: NamedRegister
     /// The 4 read only registers :, ., % and #
-    | ReadOnly of ReadOnlyRegister
+    | ReadOnly of ReadOnlyRegister: ReadOnlyRegister
     | Expression 
-    | SelectionAndDrop of SelectionAndDropRegister
+    | SelectionAndDrop of SelectionAndDropRegister: SelectionAndDropRegister
     | Blackhole
     | LastSearchPattern 
     with

--- a/Src/VimCore/VimSettingsInterface.fs
+++ b/Src/VimCore/VimSettingsInterface.fs
@@ -127,7 +127,7 @@ type KeyModelOptions =
 type PathOption =
 
     /// An actual named path
-    | Named of string
+    | Named of Named: string
 
     /// Use the current directory
     | CurrentDirectory
@@ -153,9 +153,9 @@ type SettingKind =
 [<StructuralEquality>]
 [<NoComparison>]
 type SettingValue =
-    | Number of int
-    | String of string
-    | Toggle of bool
+    | Number of Number: int
+    | String of String: string
+    | Toggle of Toggle: bool
 
     member x.Kind = 
         match x with
@@ -178,11 +178,11 @@ type IVimCustomSettingSource =
 /// default
 [<RequireQualifiedAccess>]
 type LiveSettingValue =
-    | Number of int * int
-    | String of string * string
-    | Toggle of bool * bool
-    | CalculatedNumber of int option * (unit -> int)
-    | Custom of string * IVimCustomSettingSource
+    | Number of Value: int * DefaultValue: int
+    | String of Value: string * DefaultValue: string
+    | Toggle of Value: bool * DefaultValue: bool
+    | CalculatedNumber of Value: int option * DefaultValueFunc: (unit -> int)
+    | Custom of Value: string * DefaultValueSource: IVimCustomSettingSource
 
     /// Is this a calculated value
     member x.IsCalculated = 

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -231,12 +231,12 @@ namespace Vim.UnitTest
 
         public static T AsResult<T>(this VimResult<T> vimResult)
         {
-            return ((VimResult<T>.Result)vimResult).Item;
+            return ((VimResult<T>.Result)vimResult).Result;
         }
 
         public static string AsError<T>(this VimResult<T> vimResult)
         {
-            return ((VimResult<T>.Error)vimResult).Item;
+            return ((VimResult<T>.Error)vimResult).Error; ;
         }
 
         #endregion
@@ -538,7 +538,7 @@ namespace Vim.UnitTest
 
         public static bool IsSwitchMode(this ModeSwitch mode, ModeKind kind)
         {
-            return mode.IsSwitchMode && ((ModeSwitch.SwitchMode)mode).Item == kind;
+            return mode.IsSwitchMode && ((ModeSwitch.SwitchMode)mode).ModeKind == kind;
         }
 
         public static bool IsSwitchModeWithArgument(this ModeSwitch mode, ModeKind kind, ModeArgument argument)
@@ -549,7 +549,7 @@ namespace Vim.UnitTest
             }
 
             var value = (ModeSwitch.SwitchModeWithArgument)mode;
-            return value.Item1 == kind && value.Item2.Equals(argument);
+            return value.ModeKind == kind && value.ModeArgument.Equals(argument);
         }
 
         #endregion

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -396,7 +396,7 @@ namespace Vim.UnitTest
         /// </summary>
         public static bool IsFailed<T>(this ParseResult<T> parseResult, string message)
         {
-            return parseResult.IsFailed && message == parseResult.AsFailed().Item;
+            return parseResult.IsFailed && message == parseResult.AsFailed().Error;
         }
 
         #endregion
@@ -658,7 +658,7 @@ namespace Vim.UnitTest
 
         public static IEnumerable<KeyInput> GetKeyMapping(this IKeyMap keyMap, KeyInputSet kiSet, KeyRemapMode mode)
         {
-            return keyMap.GetKeyMapping(kiSet, mode).AsMapped().Item.KeyInputs;
+            return keyMap.GetKeyMapping(kiSet, mode).AsMapped().KeyInputSet.KeyInputs;
         }
 
         public static KeyMappingResult GetKeyMappingResult(this IKeyMap keyMap, KeyInput ki, KeyRemapMode mode)
@@ -701,11 +701,11 @@ namespace Vim.UnitTest
         {
             if (res.IsMapped)
             {
-                return res.AsMapped().Item;
+                return res.AsMapped().KeyInputSet;
             }
 
             var partialMap = res.AsPartiallyMapped();
-            return KeyInputSetUtil.Combine(partialMap.item1, partialMap.item2);
+            return KeyInputSetUtil.Combine(partialMap.MappedKeyInputSet, partialMap.RemainingKeyInputSet);
         }
 
         #endregion
@@ -1406,7 +1406,7 @@ namespace Vim.UnitTest
 
         public static bool IsFound(this SearchResult result, int startPosition)
         {
-            return result.IsFound && result.AsFound().Item2.Start == startPosition;
+            return result.IsFound && result.AsFound().SpanWithOffset.Start == startPosition;
         }
 
         #endregion

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -473,27 +473,27 @@ namespace Vim.UnitTest
 
         public static bool IsSwitchModeOneTimeCommand(this ProcessResult result)
         {
-            return result.IsHandled && result.AsHandled().Item.IsSwitchModeOneTimeCommand;
+            return result.IsHandled && result.AsHandled().ModeSwitch.IsSwitchModeOneTimeCommand;
         }
 
         public static bool IsSwitchMode(this ProcessResult result, ModeKind kind)
         {
-            return result.IsHandled && result.AsHandled().Item.IsSwitchMode(kind);
+            return result.IsHandled && result.AsHandled().ModeSwitch.IsSwitchMode(kind);
         }
 
         public static bool IsSwitchModeWithArgument(this ProcessResult result, ModeKind kind, ModeArgument argument)
         {
-            return result.IsHandled && result.AsHandled().Item.IsSwitchModeWithArgument(kind, argument);
+            return result.IsHandled && result.AsHandled().ModeSwitch.IsSwitchModeWithArgument(kind, argument);
         }
 
         public static bool IsSwitchPreviousMode(this ProcessResult result)
         {
-            return result.IsHandled && result.AsHandled().Item.IsSwitchPreviousMode;
+            return result.IsHandled && result.AsHandled().ModeSwitch.IsSwitchPreviousMode;
         }
 
         public static bool IsHandledNoSwitch(this ProcessResult result)
         {
-            return result.IsHandled && result.AsHandled().Item.IsNoSwitch;
+            return result.IsHandled && result.AsHandled().ModeSwitch.IsNoSwitch;
         }
 
         #endregion
@@ -1457,17 +1457,17 @@ namespace Vim.UnitTest
 
         public static bool IsInsert(this TextChange change, string text)
         {
-            return change.IsInsert && change.AsInsert().Item == text;
+            return change.IsInsert && change.AsInsert().Text == text;
         }
 
         public static bool IsDeleteLeft(this TextChange change, int count)
         {
-            return change.IsDeleteLeft && change.AsDeleteLeft().Item == count;
+            return change.IsDeleteLeft && change.AsDeleteLeft().Count == count;
         }
 
         public static bool IsDeleteRight(this TextChange change, int count)
         {
-            return change.IsDeleteRight && change.AsDeleteRight().Item == count;
+            return change.IsDeleteRight && change.AsDeleteRight().Count == count;
         }
 
         #endregion

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -421,7 +421,7 @@ namespace Vim.UnitTest
 
         public static bool IsParseError(this LineCommand lineCommand, string message)
         {
-            return lineCommand.IsParseError && lineCommand.AsParseError().Item == message;
+            return lineCommand.IsParseError && lineCommand.AsParseError().Error == message;
         }
 
         #endregion

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -1355,7 +1355,7 @@ namespace Vim.UnitTest
             {
                 var keyInput = KeyInputUtil.CharToKeyInput(text[i]);
                 Assert.True(result.IsNeedMoreInput);
-                result = result.AsNeedMoreInput().Item.BindFunction.Invoke(keyInput);
+                result = result.AsNeedMoreInput().BindData.BindFunction.Invoke(keyInput);
             }
 
             return result;
@@ -1367,7 +1367,7 @@ namespace Vim.UnitTest
             {
                 var keyInput = KeyInputUtil.VimKeyToKeyInput(cur);
                 Assert.True(result.IsNeedMoreInput);
-                result = result.AsNeedMoreInput().Item.BindFunction.Invoke(keyInput);
+                result = result.AsNeedMoreInput().BindData.BindFunction.Invoke(keyInput);
             }
             return result;
         }

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -346,7 +346,7 @@ namespace Vim.UnitTest
 
         public static bool IsNumber(this LineSpecifier lineSpecifier, int number)
         {
-            return lineSpecifier.IsNumber && lineSpecifier.AsNumber().Item == number;
+            return lineSpecifier.IsNumber && lineSpecifier.AsNumber().Number == number;
         }
 
         public static LineSpecifier.NextLineWithPattern AsNextLineWithPattern(this LineSpecifier lineSpecifier)
@@ -367,8 +367,8 @@ namespace Vim.UnitTest
         public static bool IsCurrentLineWithAdjustment(this LineSpecifier lineSpecifier, int count)
         {
             return lineSpecifier.IsLineSpecifierWithAdjustment &&
-                lineSpecifier.AsLineSpecifierWithAdjustment().Item1.IsCurrentLine &&
-                lineSpecifier.AsLineSpecifierWithAdjustment().Item2 == count;
+                lineSpecifier.AsLineSpecifierWithAdjustment().LineSpecifier.IsCurrentLine &&
+                lineSpecifier.AsLineSpecifierWithAdjustment().Adjustment == count;
         }
 
         #endregion

--- a/Src/VimTestUtils/Mock/Extensions.cs
+++ b/Src/VimTestUtils/Mock/Extensions.cs
@@ -112,7 +112,7 @@ namespace Vim.UnitTest.Mock
             commandUtil
                 .Setup(x => x.RunCommand(It.Is<Command>(c =>
                     c.IsNormalCommand &&
-                    c.AsNormalCommand().Item1 is T)))
+                    c.AsNormalCommand().NormalCommand is T)))
                 .Returns(CommandResult.NewCompleted(ModeSwitch.NoSwitch))
                 .Verifiable();
         }
@@ -135,8 +135,8 @@ namespace Vim.UnitTest.Mock
                 commandUtil
                     .Setup(x => x.RunCommand(It.Is<Command>(command =>
                             command.IsVisualCommand &&
-                            command.AsVisualCommand().Item1.Equals(visualCommand) &&
-                            command.AsVisualCommand().Item2.Equals(commandData))))
+                            command.AsVisualCommand().VisualCommand.Equals(visualCommand) &&
+                            command.AsVisualCommand().CommandData.Equals(commandData))))
                     .Returns(CommandResult.NewCompleted(ModeSwitch.SwitchPreviousMode))
                     .Verifiable();
             }

--- a/Src/VsVimShared/Extensions.cs
+++ b/Src/VsVimShared/Extensions.cs
@@ -1158,7 +1158,7 @@ namespace Vim.VisualStudio
 
         public static bool IsInsert(this InsertCommand command, string text)
         {
-            return command.IsInsert && command.AsInsert().Item == text;
+            return command.IsInsert && command.AsInsert().Text == text;
         }
 
         #endregion

--- a/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
+++ b/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
@@ -56,7 +56,7 @@ namespace Vim.VisualStudio.Implementation.Misc
 
             if (result.IsMapped)
             {
-                var set = ((KeyMappingResult.Mapped)result).Item;
+                var set = ((KeyMappingResult.Mapped)result).KeyInputSet;
                 if (set.Length != 1)
                 {
                     mapped = null;

--- a/Src/VsVimShared/Implementation/UpgradeNotification/VimRcLoadNotificationMarginProvider.cs
+++ b/Src/VsVimShared/Implementation/UpgradeNotification/VimRcLoadNotificationMarginProvider.cs
@@ -84,7 +84,7 @@ namespace Vim.VisualStudio.Implementation.UpgradeNotification
             var state = ((VimRcState.LoadSucceeded)_vim.VimRcState);
 
             // If the notification has occured then there is nothing else to do.  We are done
-            if (!_vimApplicationSettings.HaveNotifiedVimRcLoad && state.Item1.VimRcKind == VimRcKind.VimRc)
+            if (!_vimApplicationSettings.HaveNotifiedVimRcLoad && state.VimRcPath.VimRcKind == VimRcKind.VimRc)
             {
                 var linkBanner = new LinkBanner
                 {
@@ -95,10 +95,10 @@ namespace Vim.VisualStudio.Implementation.UpgradeNotification
                 _toastNotificationServiceProvider.GetToastNoficationService(wpfTextView).Display(_notifyToastKey, linkBanner, OnNotifyClosed);
             }
 
-            if (!_vimApplicationSettings.HaveNotifiedVimRcErrors && state.Item2.Length != 0)
+            if (!_vimApplicationSettings.HaveNotifiedVimRcErrors && state.Errors.Length != 0)
             {
                 var errorBanner = new ErrorBanner();
-                errorBanner.ViewClick += (sender, e) => OnViewClick(state.Item2);
+                errorBanner.ViewClick += (sender, e) => OnViewClick(state.Errors);
                 _toastNotificationServiceProvider.GetToastNoficationService(wpfTextView).Display(_errorToastKey, errorBanner, OnErrorClosed);
             }
         }

--- a/Src/VsVimShared/VsCommandTarget.cs
+++ b/Src/VsVimShared/VsCommandTarget.cs
@@ -163,9 +163,9 @@ namespace Vim.VisualStudio
             if (command.IsInsert)
             {
                 var insert = (InsertCommand.Insert)command;
-                if (insert.Item != null && insert.Item.Length == 1)
+                if (insert.Text != null && insert.Text.Length == 1)
                 {
-                    commandData = OleCommandData.CreateTypeChar(insert.Item[0]);
+                    commandData = OleCommandData.CreateTypeChar(insert.Text[0]);
                     return true;
                 }
             }

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -106,7 +106,7 @@ namespace Vim.VisualStudio
                     return;
                 }
 
-                var value = ((SettingValue.Toggle)settingValue).Item;
+                var value = ((SettingValue.Toggle)settingValue).Toggle;
                 switch (name)
                 {
                     case UseEditorIndentName:

--- a/Test/VimCoreTest/CodeHygieneTest.cs
+++ b/Test/VimCoreTest/CodeHygieneTest.cs
@@ -96,6 +96,44 @@ namespace Vim.UnitTest
                     : list.Aggregate((x, y) => x + Environment.NewLine + y);
                 Assert.True(0 == list.Count, msg);
             }
+
+            /// <summary>
+            /// Make sure all discriminated union values have explicit names
+            /// </summary>
+            [Fact]
+            public void UseExplicitRecordNames()
+            {
+                var any = false;
+                var list = new List<string>();
+                var types = _sourceAssembly
+                    .GetTypes()
+                    .Where(x => x.BaseType != null && IsDiscriminatedUnion(x.BaseType))
+                    .Where(x => !IsFSharpCore(x));
+                foreach (var type in types)
+                {
+                    any = true;
+                    var anyItem = false;
+                    foreach (var prop in type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly))
+                    {
+                        if (prop.Name.StartsWith("Item"))
+                        {
+                            anyItem = true;
+                            break;
+                        }
+                    }
+
+                    if (anyItem)
+                    {
+                        list.Add($"{type.BaseType.Name}.{type.Name} values do not have an expliict name");
+                    }
+                }
+
+                Assert.True(any);
+                var msg = list.Count == 0
+                    ? string.Empty
+                    : list.Aggregate((x, y) => x + Environment.NewLine + y);
+                Assert.True(0 == list.Count, msg);
+            }
         }
 
         /// <summary>

--- a/Test/VimCoreTest/CodeHygieneTest.cs
+++ b/Test/VimCoreTest/CodeHygieneTest.cs
@@ -131,7 +131,7 @@ namespace Vim.UnitTest
                 Assert.True(any);
                 var msg = list.Count == 0
                     ? string.Empty
-                    : list.Aggregate((x, y) => x + Environment.NewLine + y);
+                    : $"{list.Count} union values do not have explicit names" + Environment.NewLine + list.Aggregate((x, y) => x + Environment.NewLine + y);
                 Assert.True(0 == list.Count, msg);
             }
         }

--- a/Test/VimCoreTest/CommandUtilTest.cs
+++ b/Test/VimCoreTest/CommandUtilTest.cs
@@ -95,11 +95,11 @@ namespace Vim.UnitTest
         protected void AssertInsertWithTransaction(CommandResult result)
         {
             Assert.True(result.IsCompleted);
-            var modeSwitch = result.AsCompleted().Item;
+            var modeSwitch = result.AsCompleted().ModeSwitch;
             Assert.True(modeSwitch.IsSwitchModeWithArgument);
             var data = modeSwitch.AsSwitchModeWithArgument();
-            Assert.Equal(ModeKind.Insert, data.Item1);
-            Assert.True(data.Item2.IsInsertWithTransaction);
+            Assert.Equal(ModeKind.Insert, data.ModeKind);
+            Assert.True(data.ModeArgument.IsInsertWithTransaction);
         }
 
         /// <summary>
@@ -1412,7 +1412,7 @@ namespace Vim.UnitTest
                 _textView.MoveCaretTo(1);
                 var restored = _commandUtil.CalculateVisualSpan(stored);
                 var expected = new SnapshotSpan(_textView.GetPoint(1), _textView.GetLine(1).Start.Add(1));
-                Assert.Equal(expected, restored.AsCharacter().Item.Span);
+                Assert.Equal(expected, restored.AsCharacter().CharacterSpan.Span);
             }
 
             /// <summary>
@@ -1429,7 +1429,7 @@ namespace Vim.UnitTest
                 _textView.MoveCaretTo(1);
                 var restored = _commandUtil.CalculateVisualSpan(stored);
                 var expected = new SnapshotSpan(_textView.GetPoint(1), 4);
-                Assert.Equal(expected, restored.AsCharacter().Item.Span);
+                Assert.Equal(expected, restored.AsCharacter().CharacterSpan.Span);
             }
 
             /// <summary>
@@ -1442,7 +1442,7 @@ namespace Vim.UnitTest
                 var span = new SnapshotSpan(_textBuffer.GetPoint(0), _textBuffer.GetLine(1).Start.Add(1));
                 var stored = StoredVisualSpan.OfVisualSpan(VimUtil.CreateVisualSpanCharacter(span));
                 var restored = _commandUtil.CalculateVisualSpan(stored);
-                Assert.Equal(_textBuffer.GetSpan(0, 7), restored.AsCharacter().Item.Span);
+                Assert.Equal(_textBuffer.GetSpan(0, 7), restored.AsCharacter().CharacterSpan.Span);
             }
 
             /// <summary>
@@ -1469,7 +1469,7 @@ namespace Vim.UnitTest
                 var stored = StoredVisualSpan.OfVisualSpan(span);
                 _textView.MoveCaretToLine(1);
                 var restored = _commandUtil.CalculateVisualSpan(stored);
-                Assert.Equal(_textView.GetLineRange(1, 2), restored.AsLine().Item);
+                Assert.Equal(_textView.GetLineRange(1, 2), restored.AsLine().LineRange);
             }
 
             /// <summary>
@@ -1484,7 +1484,7 @@ namespace Vim.UnitTest
                 var stored = StoredVisualSpan.OfVisualSpan(span);
                 _textView.MoveCaretToLine(3);
                 var restored = _commandUtil.CalculateVisualSpan(stored);
-                Assert.Equal(_textView.GetLineRange(3, 3), restored.AsLine().Item);
+                Assert.Equal(_textView.GetLineRange(3, 3), restored.AsLine().LineRange);
             }
 
             /// <summary>
@@ -1521,7 +1521,7 @@ namespace Vim.UnitTest
                     _textView.GetLineSpan(0, 1, 1),
                     _textView.GetLineSpan(1, 1, 1)
                 },
-                    restored.AsBlock().Item.BlockSpans);
+                    restored.AsBlock().BlockSpan.BlockSpans);
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/CommonOperationsTest.cs
+++ b/Test/VimCoreTest/CommonOperationsTest.cs
@@ -393,7 +393,7 @@ namespace Vim.UnitTest
                 _vimHost.Setup(x => x.GoToDefinition()).Returns(false);
                 var res = _operations.GoToDefinition();
                 Assert.True(res.IsFailed);
-                Assert.Contains("foo", ((Result.Failed)res).Item);
+                Assert.Contains("foo", ((Result.Failed)res).Error);
             }
 
             /// <summary>
@@ -415,7 +415,7 @@ namespace Vim.UnitTest
                 _vimHost.Setup(x => x.GoToDefinition()).Returns(false);
                 var res = _operations.GoToDefinition();
                 Assert.True(res.IsFailed);
-                Assert.Equal(Resources.Common_GotoDefNoWordUnderCursor, res.AsFailed().Item);
+                Assert.Equal(Resources.Common_GotoDefNoWordUnderCursor, res.AsFailed().Error);
             }
 
             [WpfFact]
@@ -425,7 +425,7 @@ namespace Vim.UnitTest
                 _vimHost.Setup(x => x.GoToDefinition()).Returns(false);
                 var res = _operations.GoToDefinition();
                 Assert.True(res.IsFailed);
-                Assert.Equal(Resources.Common_GotoDefFailed("foo"), res.AsFailed().Item);
+                Assert.Equal(Resources.Common_GotoDefFailed("foo"), res.AsFailed().Error);
             }
 
             /// <summary>
@@ -851,7 +851,7 @@ namespace Vim.UnitTest
                     desiredColumn: CaretColumn.NewInLastLine(2),
                     flags: MotionResultFlags.MaintainCaretColumn);
                 _operations.MoveCaretToMotionResult(motionResult);
-                Assert.Equal(2, _operationsRaw.MaintainCaretColumn.AsSpaces().Item);
+                Assert.Equal(2, _operationsRaw.MaintainCaretColumn.AsSpaces().Count);
             }
 
             /// <summary>
@@ -866,7 +866,7 @@ namespace Vim.UnitTest
                     motionKind: MotionKind.CharacterWiseExclusive,
                     desiredColumn: CaretColumn.NewScreenColumn(100));
                 _operations.MoveCaretToMotionResult(motionResult);
-                Assert.Equal(100, _operationsRaw.MaintainCaretColumn.AsSpaces().Item);
+                Assert.Equal(100, _operationsRaw.MaintainCaretColumn.AsSpaces().Count);
             }
 
 

--- a/Test/VimCoreTest/CountCaptureTest.cs
+++ b/Test/VimCoreTest/CountCaptureTest.cs
@@ -16,10 +16,10 @@ namespace Vim.UnitTest
             var result = CountCapture.GetCount(KeyRemapMode.None, first);
             if (text.Length > 1)
             {
-                return result.Run(text.Substring(1)).AsComplete().Item;
+                return result.Run(text.Substring(1)).AsComplete().Result;
             }
 
-            return result.AsComplete().Item;
+            return result.AsComplete().Result;
         }
 
         /// <summary>

--- a/Test/VimCoreTest/ExpressionInterpreterTest.cs
+++ b/Test/VimCoreTest/ExpressionInterpreterTest.cs
@@ -26,13 +26,13 @@ namespace Vim.UnitTest
         private void Run(string expr, string expected)
         {
             var value = Run(expr);
-            Assert.Equal(expected, value.AsString().Item);
+            Assert.Equal(expected, value.AsString().String);
         }
 
         private void Run(string expr, int expected)
         {
             var value = Run(expr);
-            Assert.Equal(expected, value.AsNumber().Item);
+            Assert.Equal(expected, value.AsNumber().Number);
         }
 
         /// <summary>
@@ -59,13 +59,13 @@ namespace Vim.UnitTest
         [Fact]
         public void Empty_list()
         {
-            Assert.True(Run("[]").AsList().Item.IsEmpty);
+            Assert.True(Run("[]").AsList().VariableValues.IsEmpty);
         }
 
         [Fact]
         public void Run_builtin_function_of_no_arguments()
         {
-            Assert.NotEqual(0, Run("localtime()").AsNumber().Item);
+            Assert.NotEqual(0, Run("localtime()").AsNumber().Number);
         }
 
         [Fact]

--- a/Test/VimCoreTest/ExpressionInterpreterTest.cs
+++ b/Test/VimCoreTest/ExpressionInterpreterTest.cs
@@ -20,7 +20,7 @@ namespace Vim.UnitTest
         {
             var parseResult = VimUtil.ParseExpression(expr);
             Assert.True(parseResult.IsSucceeded, "Expression failed to parse");
-            return _interpreter.RunExpression(parseResult.AsSucceeded().Item);
+            return _interpreter.RunExpression(parseResult.AsSucceeded().Value);
         }
 
         private void Run(string expr, string expected)

--- a/Test/VimCoreTest/GlobalSettingsTest.cs
+++ b/Test/VimCoreTest/GlobalSettingsTest.cs
@@ -47,7 +47,7 @@ namespace Vim.UnitTest
                     Assert.Equal(name, Name);
                     if (settingValue.IsString)
                     {
-                        Value = ((SettingValue.String)settingValue).Item;
+                        Value = ((SettingValue.String)settingValue).String;
                     }
                 }
             }
@@ -55,7 +55,7 @@ namespace Vim.UnitTest
             private string GetStringValue(string name)
             {
                 var setting = _globalSettings.GetSetting(name).Value;
-                return ((SettingValue.String)setting.LiveSettingValue.Value).Item;
+                return ((SettingValue.String)setting.LiveSettingValue.Value).String;
             }
 
             [Fact]
@@ -317,7 +317,7 @@ namespace Vim.UnitTest
                 Assert.Equal("", _globalSettings.SelectMode);
                 Assert.Equal(SelectModeOptions.None, _globalSettings.SelectModeOptions);
                 var setting = _globalSettings.GetSetting(GlobalSettingNames.SelectModeName).Value;
-                Assert.Equal("", setting.DefaultValue.AsString().Item);
+                Assert.Equal("", setting.DefaultValue.AsString().String);
             }
         }
     }

--- a/Test/VimCoreTest/HistorySessionTest.cs
+++ b/Test/VimCoreTest/HistorySessionTest.cs
@@ -79,7 +79,7 @@ namespace Vim.UnitTest
         {
             var result = _bindData.BindFunction.Invoke(keyInput);
             _bindData = result.IsNeedMoreInput
-                ? ((BindResult<int>.NeedMoreInput)result).Item
+                ? ((BindResult<int>.NeedMoreInput)result).BindData
                 : null;
         }
 

--- a/Test/VimCoreTest/IncrementalSearchTest.cs
+++ b/Test/VimCoreTest/IncrementalSearchTest.cs
@@ -254,7 +254,7 @@ namespace Vim.UnitTest
             {
                 Create("foo bar");
                 _globalSettings.WrapScan = false;
-                var result = _search.Begin(SearchPath.Forward).Run("f").Run(VimKey.Enter).AsComplete().Item;
+                var result = _search.Begin(SearchPath.Forward).Run("f").Run(VimKey.Enter).AsComplete().Result;
                 Assert.True(result.IsNotFound);
                 Assert.True(result.AsNotFound().Item2);
             }
@@ -269,7 +269,7 @@ namespace Vim.UnitTest
                 Create("cat bar");
                 _globalSettings.WrapScan = false;
                 _textView.MoveCaretTo(2);
-                var result = _search.Begin(SearchPath.Backward).Run("t").Run(VimKey.Enter).AsComplete().Item;
+                var result = _search.Begin(SearchPath.Backward).Run("t").Run(VimKey.Enter).AsComplete().Result;
                 Assert.True(result.IsNotFound);
             }
         }
@@ -427,7 +427,7 @@ namespace Vim.UnitTest
                 for (var i = 0; i < 5; i++)
                 {
                     _textView.MoveCaretTo(0);
-                    var searchResult = _search.DoSearch("el", enter: true).AsComplete().Item;
+                    var searchResult = _search.DoSearch("el", enter: true).AsComplete().Result;
                     Assert.True(searchResult.IsFound);
                     var span = searchResult.AsFound().Item2;
                     Assert.Equal(new Span(1, 2), span.Span);

--- a/Test/VimCoreTest/IncrementalSearchTest.cs
+++ b/Test/VimCoreTest/IncrementalSearchTest.cs
@@ -256,7 +256,7 @@ namespace Vim.UnitTest
                 _globalSettings.WrapScan = false;
                 var result = _search.Begin(SearchPath.Forward).Run("f").Run(VimKey.Enter).AsComplete().Result;
                 Assert.True(result.IsNotFound);
-                Assert.True(result.AsNotFound().Item2);
+                Assert.True(result.AsNotFound().CanFindWithWrap);
             }
 
             /// <summary>
@@ -429,7 +429,7 @@ namespace Vim.UnitTest
                     _textView.MoveCaretTo(0);
                     var searchResult = _search.DoSearch("el", enter: true).AsComplete().Result;
                     Assert.True(searchResult.IsFound);
-                    var span = searchResult.AsFound().Item2;
+                    var span = searchResult.AsFound().SpanWithOffset;
                     Assert.Equal(new Span(1, 2), span.Span);
                     _search.DoSearch("wo", enter: false);
                     Assert.True(_search.InSearch);

--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -1630,7 +1630,7 @@ namespace Vim.UnitTest
                     {
                         if (command.IsInsert)
                         {
-                            Assert.Equal("#", command.AsInsert().Item);
+                            Assert.Equal("#", command.AsInsert().Text);
                             _textBuffer.Insert(0, "hello ");
                             return true;
                         }
@@ -1709,7 +1709,7 @@ namespace Vim.UnitTest
                     {
                         if (command.IsInsert)
                         {
-                            Assert.Equal("#", command.AsInsert().Item);
+                            Assert.Equal("#", command.AsInsert().Text);
                             _textBuffer.Insert(0, "hello ");
                             return true;
                         }

--- a/Test/VimCoreTest/KeyMapTest.cs
+++ b/Test/VimCoreTest/KeyMapTest.cs
@@ -39,8 +39,8 @@ namespace Vim.UnitTest
             else
             {
                 Assert.True(result.IsPartiallyMapped);
-                Assert.Equal(lhs.FirstKeyInput.Value, result.AsPartiallyMapped().Item1.FirstKeyInput.Value);
-                Assert.Equal(1, result.AsPartiallyMapped().Item1.Length);
+                Assert.Equal(lhs.FirstKeyInput.Value, result.AsPartiallyMapped().MappedKeyInputSet.FirstKeyInput.Value);
+                Assert.Equal(1, result.AsPartiallyMapped().MappedKeyInputSet.Length);
             }
 
             Assert.Equal(lhs, result.GetMappedKeyInputs());
@@ -71,8 +71,8 @@ namespace Vim.UnitTest
             Assert.True(ret.IsPartiallyMapped);
 
             var partiallyMapped = ret.AsPartiallyMapped();
-            Assert.Equal(KeyInputSetUtil.OfString(expectedMapped), partiallyMapped.Item1);
-            Assert.Equal(KeyInputSetUtil.OfString(expectedRemaining), partiallyMapped.Item2);
+            Assert.Equal(KeyInputSetUtil.OfString(expectedMapped), partiallyMapped.MappedKeyInputSet);
+            Assert.Equal(KeyInputSetUtil.OfString(expectedRemaining), partiallyMapped.RemainingKeyInputSet);
         }
 
         public sealed class MapWithNoRemapTest : KeyMapTest
@@ -183,7 +183,7 @@ namespace Vim.UnitTest
             {
                 Assert.True(_map.MapWithNoRemap("a", @"\<Home>", KeyRemapMode.Normal));
                 var result = _map.GetKeyMappingResult("a", KeyRemapMode.Normal);
-                Assert.Equal(KeyNotationUtil.StringToKeyInputSet(@"\<Home>"), result.AsMapped().Item);
+                Assert.Equal(KeyNotationUtil.StringToKeyInputSet(@"\<Home>"), result.AsMapped().KeyInputSet);
             }
 
             [Fact]
@@ -191,7 +191,7 @@ namespace Vim.UnitTest
             {
                 Assert.True(_map.MapWithNoRemap("a", "<lt>lt>", KeyRemapMode.Normal));
                 var result = _map.GetKeyMappingResult("a", KeyRemapMode.Normal);
-                Assert.Equal(KeyInputSetUtil.OfString("<lt>"), result.AsMapped().Item);
+                Assert.Equal(KeyInputSetUtil.OfString("<lt>"), result.AsMapped().KeyInputSet);
             }
 
             [Fact]
@@ -259,7 +259,7 @@ namespace Vim.UnitTest
                 Assert.True(_map.MapWithNoRemap("aaa", "bar", KeyRemapMode.Normal));
                 var ret = _map.GetKeyMappingResult("aaa", KeyRemapMode.Normal);
                 Assert.True(ret.IsMapped);
-                Assert.Equal(KeyInputSetUtil.OfString("bar"), ret.AsMapped().Item);
+                Assert.Equal(KeyInputSetUtil.OfString("bar"), ret.AsMapped().KeyInputSet);
             }
 
             /// <summary>
@@ -587,7 +587,7 @@ namespace Vim.UnitTest
                 Assert.True(_map.MapWithNoRemap("a", "b", KeyRemapMode.Normal));
                 var res = _map.GetKeyMappingResult(KeyInputUtil.CharToKeyInput('a'), KeyRemapMode.Normal);
                 Assert.True(res.IsMapped);
-                Assert.Equal('b', res.AsMapped().Item.KeyInputs.Single().Char);
+                Assert.Equal('b', res.AsMapped().KeyInputSet.KeyInputs.Single().Char);
             }
 
             [Fact]
@@ -596,7 +596,7 @@ namespace Vim.UnitTest
                 Assert.True(_map.MapWithNoRemap("a", "bc", KeyRemapMode.Normal));
                 var res = _map.GetKeyMappingResult(KeyInputUtil.CharToKeyInput('a'), KeyRemapMode.Normal);
                 Assert.True(res.IsMapped);
-                var list = res.AsMapped().Item.KeyInputs.ToList();
+                var list = res.AsMapped().KeyInputSet.KeyInputs.ToList();
                 Assert.Equal(2, list.Count);
                 Assert.Equal('b', list[0].Char);
                 Assert.Equal('c', list[1].Char);
@@ -618,8 +618,8 @@ namespace Vim.UnitTest
             public void GetKeyMappingResult_RemainderIsMappable()
             {
                 var result = _map.GetKeyMappingResult("dog", KeyRemapMode.Normal).AsPartiallyMapped();
-                Assert.Equal(KeyInputSetUtil.OfString("d"), result.Item1);
-                Assert.Equal(KeyInputSetUtil.OfString("og"), result.Item2);
+                Assert.Equal(KeyInputSetUtil.OfString("d"), result.MappedKeyInputSet);
+                Assert.Equal(KeyInputSetUtil.OfString("og"), result.RemainingKeyInputSet);
             }
 
             /// <summary>
@@ -644,7 +644,7 @@ namespace Vim.UnitTest
                 _map.Clear(KeyRemapMode.Normal);
                 var res = _map.GetKeyMappingResult(KeyInputUtil.CharToKeyInput('a'), KeyRemapMode.Insert);
                 Assert.True(res.IsMapped);
-                Assert.Equal('b', res.AsMapped().Item.KeyInputs.Single().Char);
+                Assert.Equal('b', res.AsMapped().KeyInputSet.KeyInputs.Single().Char);
             }
 
             [Fact]
@@ -704,7 +704,7 @@ namespace Vim.UnitTest
 
                 var input = "aa".Select(KeyInputUtil.CharToKeyInput).ToFSharpList();
                 var res = _map.GetKeyMapping(new KeyInputSet(input), KeyRemapMode.Normal);
-                Assert.Equal('b', res.AsMapped().Item.KeyInputs.Single().Char);
+                Assert.Equal('b', res.AsMapped().KeyInputSet.KeyInputs.Single().Char);
             }
 
             [Fact]

--- a/Test/VimCoreTest/MotionCaptureTest.cs
+++ b/Test/VimCoreTest/MotionCaptureTest.cs
@@ -41,13 +41,13 @@ namespace Vim.UnitTest
             {
                 Assert.True(res.IsNeedMoreInput);
                 var needMore = res.AsNeedMoreInput();
-                res = needMore.Item.BindFunction.Invoke(KeyInputUtil.CharToKeyInput(cur));
+                res = needMore.BindData.BindFunction.Invoke(KeyInputUtil.CharToKeyInput(cur));
             }
 
             if (enter)
             {
                 var needMore = res.AsNeedMoreInput();
-                res = needMore.Item.BindFunction.Invoke(KeyInputUtil.EnterKey);
+                res = needMore.BindData.BindFunction.Invoke(KeyInputUtil.EnterKey);
             }
 
             return res.Convert(x => x.Item1);
@@ -57,14 +57,14 @@ namespace Vim.UnitTest
         {
             var result = Process(text);
             Assert.True(result.IsComplete);
-            Assert.Equal(motion, result.AsComplete().Item);
+            Assert.Equal(motion, result.AsComplete().Result);
         }
 
         private void AssertMotion(KeyInput keyInput, Motion motion)
         {
             var result = _capture.GetMotionAndCount(keyInput);
             Assert.True(result.IsComplete);
-            Assert.Equal(motion, result.AsComplete().Item.Item1);
+            Assert.Equal(motion, result.AsComplete().Result.Item1);
         }
 
         private void AssertMotion(VimKey key, Motion motion)
@@ -356,7 +356,7 @@ namespace Vim.UnitTest
         {
             _textView.TextBuffer.SetText("hello world");
             _textView.MoveCaretTo(_textView.GetEndPoint().Position);
-            var motionResult = Process("?world", enter: true).AsComplete().Item;
+            var motionResult = Process("?world", enter: true).AsComplete().Result;
             var searchData = ((Motion.Search)motionResult).Item;
             Assert.Equal("world", searchData.Pattern);
             Assert.Equal(SearchPath.Backward, searchData.Path);
@@ -367,7 +367,7 @@ namespace Vim.UnitTest
         public void IncrementalSearch_Forward()
         {
             _textView.SetText("hello world", caret: 0);
-            var motionResult = Process("/world", enter: true).AsComplete().Item;
+            var motionResult = Process("/world", enter: true).AsComplete().Result;
             var searchData = ((Motion.Search)motionResult).Item;
             Assert.Equal("world", searchData.Pattern);
             Assert.Equal(SearchPath.Forward, searchData.Path);
@@ -442,7 +442,7 @@ namespace Vim.UnitTest
             _textView.SetText("cat dog");
             var result = _capture.GetMotionAndCount(KeyInputUtil.CharToKeyInput('/'));
             Assert.True(result.IsNeedMoreInput);
-            Assert.Equal(result.AsNeedMoreInput().Item.KeyRemapMode, KeyRemapMode.Command);
+            Assert.Equal(result.AsNeedMoreInput().BindData.KeyRemapMode, KeyRemapMode.Command);
         }
 
         /// <summary>
@@ -454,9 +454,9 @@ namespace Vim.UnitTest
         {
             _textView.SetText("cat dog");
             var result = _capture.GetMotionAndCount(KeyInputUtil.CharToKeyInput('/'));
-            result = result.AsNeedMoreInput().Item.BindFunction.Invoke(KeyInputUtil.CharToKeyInput('a'));
+            result = result.AsNeedMoreInput().BindData.BindFunction.Invoke(KeyInputUtil.CharToKeyInput('a'));
             Assert.True(result.IsNeedMoreInput);
-            Assert.Equal(result.AsNeedMoreInput().Item.KeyRemapMode, KeyRemapMode.Command);
+            Assert.Equal(result.AsNeedMoreInput().BindData.KeyRemapMode, KeyRemapMode.Command);
         }
 
         [WpfFact]
@@ -524,7 +524,7 @@ namespace Vim.UnitTest
         {
             var result = _capture.GetMotionAndCount('/');
             Assert.True(result.IsNeedMoreInput);
-            result.AsNeedMoreInput().Item.BindFunction.Invoke(KeyInputUtil.VimKeyToKeyInput(VimKey.Escape));
+            result.AsNeedMoreInput().BindData.BindFunction.Invoke(KeyInputUtil.VimKeyToKeyInput(VimKey.Escape));
             Assert.False(_incrementalSearch.InSearch);
         }
 

--- a/Test/VimCoreTest/MotionCaptureTest.cs
+++ b/Test/VimCoreTest/MotionCaptureTest.cs
@@ -357,7 +357,7 @@ namespace Vim.UnitTest
             _textView.TextBuffer.SetText("hello world");
             _textView.MoveCaretTo(_textView.GetEndPoint().Position);
             var motionResult = Process("?world", enter: true).AsComplete().Result;
-            var searchData = ((Motion.Search)motionResult).Item;
+            var searchData = ((Motion.Search)motionResult).SearchData;
             Assert.Equal("world", searchData.Pattern);
             Assert.Equal(SearchPath.Backward, searchData.Path);
             Assert.True(searchData.Kind.IsBackwardWithWrap);
@@ -368,7 +368,7 @@ namespace Vim.UnitTest
         {
             _textView.SetText("hello world", caret: 0);
             var motionResult = Process("/world", enter: true).AsComplete().Result;
-            var searchData = ((Motion.Search)motionResult).Item;
+            var searchData = ((Motion.Search)motionResult).SearchData;
             Assert.Equal("world", searchData.Pattern);
             Assert.Equal(SearchPath.Forward, searchData.Path);
             Assert.True(searchData.Kind.IsForwardWithWrap);

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -2836,7 +2836,7 @@ namespace Vim.UnitTest
                 Create("");
                 _vimBuffer.Process(@":let mapleader=""x""", enter: true);
                 var value = Vim.VariableMap["mapleader"];
-                Assert.Equal("x", value.AsString().Item);
+                Assert.Equal("x", value.AsString().String);
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/NormalModeTest.cs
+++ b/Test/VimCoreTest/NormalModeTest.cs
@@ -574,7 +574,7 @@ namespace Vim.UnitTest
                 .Setup(x => x.GetMotion(Motion.LineOrLastToFirstNonBlank, arg))
                 .Returns(FSharpOption.Create(VimUtil.CreateMotionResult(span, motionKind: MotionKind.LineWise)));
             _commandUtil
-                .Setup(x => x.RunCommand(It.Is<Command>(y => y.AsNormalCommand().Item2.Count.IsNone())))
+                .Setup(x => x.RunCommand(It.Is<Command>(y => y.AsNormalCommand().CommandData.Count.IsNone())))
                 .Returns(CommandResult.NewCompleted(ModeSwitch.NoSwitch))
                 .Verifiable();
             _mode.Process("yG");

--- a/Test/VimCoreTest/ParserTest.cs
+++ b/Test/VimCoreTest/ParserTest.cs
@@ -65,7 +65,7 @@ namespace Vim.UnitTest
                 var parser = CreateParser(text);
                 var parseResult = parser.ParseStringLiteral();
                 Assert.True(parseResult.IsSucceeded);
-                return parseResult.AsSucceeded().Item.AsConstantValue().Value.AsString().String;
+                return parseResult.AsSucceeded().Value.AsConstantValue().Value.AsString().String;
             }
 
             [Fact]
@@ -634,7 +634,7 @@ let x = 42
                 var parser = CreateParser(text);
                 var parseResult = parser.ParseNumberConstant();
                 Assert.True(parseResult.IsSucceeded);
-                return parseResult.AsSucceeded().Item.AsConstantValue().Value;
+                return parseResult.AsSucceeded().Value.AsConstantValue().Value;
             }
 
             private int ParseNumber(string text)
@@ -748,7 +748,7 @@ let x = 42
                 var parser = CreateParser(text);
                 var parseResult = parser.ParseList();
                 Assert.True(parseResult.IsSucceeded);
-                return parseResult.AsSucceeded().Item.AsList().Expressions;
+                return parseResult.AsSucceeded().Value.AsList().Expressions;
             }
 
             [Fact]
@@ -813,7 +813,7 @@ let x = 42
                 parser.Tokenizer.TokenizerFlags = TokenizerFlags.AllowDoubleQuote;
                 var parseResult = parser.ParseStringConstant();
                 Assert.True(parseResult.IsSucceeded);
-                return parseResult.AsSucceeded().Item.AsConstantValue().Value.AsString().String;
+                return parseResult.AsSucceeded().Value.AsConstantValue().Value.AsString().String;
             }
 
             [Fact]

--- a/Test/VimCoreTest/ParserTest.cs
+++ b/Test/VimCoreTest/ParserTest.cs
@@ -689,7 +689,7 @@ let x = 42
             {
                 var range = ParseLineRange(".");
                 Assert.True(range.IsSingleLine);
-                Assert.True(range.AsSingleLine().Item.IsCurrentLine);
+                Assert.True(range.AsSingleLine().LineSpecifier.IsCurrentLine);
             }
 
             [Fact]
@@ -697,7 +697,7 @@ let x = 42
             {
                 var range = ParseLineRange(".2");
                 Assert.True(range.IsSingleLine);
-                Assert.True(range.AsSingleLine().Item.IsCurrentLineWithAdjustment(2));
+                Assert.True(range.AsSingleLine().LineSpecifier.IsCurrentLineWithAdjustment(2));
             }
 
             [Fact]
@@ -705,39 +705,39 @@ let x = 42
             {
                 var range = ParseLineRange(".+3");
                 Assert.True(range.IsSingleLine);
-                Assert.True(range.AsSingleLine().Item.IsCurrentLineWithAdjustment(3));
+                Assert.True(range.AsSingleLine().LineSpecifier.IsCurrentLineWithAdjustment(3));
             }
 
             [Fact]
             public void CurrentLineWithAdjustmentRange()
             {
                 var range = ParseLineRange(".2,.3").AsRange();
-                Assert.True(range.Item1.IsCurrentLineWithAdjustment(2));
-                Assert.True(range.Item2.IsCurrentLineWithAdjustment(3));
+                Assert.True(range.StartLineSpecifier.IsCurrentLineWithAdjustment(2));
+                Assert.True(range.LastLineSpecifier.IsCurrentLineWithAdjustment(3));
             }
 
             [Fact]
             public void CurrentLineWithAdjustmentRangeUsingPlus()
             {
                 var range = ParseLineRange(".+2,.+3").AsRange();
-                Assert.True(range.Item1.IsCurrentLineWithAdjustment(2));
-                Assert.True(range.Item2.IsCurrentLineWithAdjustment(3));
+                Assert.True(range.StartLineSpecifier.IsCurrentLineWithAdjustment(2));
+                Assert.True(range.LastLineSpecifier.IsCurrentLineWithAdjustment(3));
             }
 
             [Fact]
             public void CurrentLineAndCurrentLine()
             {
                 var range = ParseLineRange(".,.").AsRange();
-                Assert.True(range.Item1.IsCurrentLine);
-                Assert.True(range.Item2.IsCurrentLine);
+                Assert.True(range.StartLineSpecifier.IsCurrentLine);
+                Assert.True(range.LastLineSpecifier.IsCurrentLine);
             }
 
             [Fact]
             public void CurrentLineAndFixed()
             {
                 var range = ParseLineRange(".,5").AsRange();
-                Assert.True(range.Item1.IsCurrentLine);
-                Assert.True(range.Item2.IsNumber(5));
+                Assert.True(range.StartLineSpecifier.IsCurrentLine);
+                Assert.True(range.LastLineSpecifier.IsNumber(5));
             }
         }
 
@@ -1149,7 +1149,7 @@ let x = 42
             {
                 var command = ParseLineCommand("set example?").AsSet();
                 var option = command.SetArguments.Single().AsDisplaySetting();
-                Assert.Equal("example", option.Item);
+                Assert.Equal("example", option.SettingName);
             }
 
             /// <summary>
@@ -1160,7 +1160,7 @@ let x = 42
             {
                 var command = ParseLineCommand("set example").AsSet();
                 var option = command.SetArguments.Single().AsUseSetting();
-                Assert.Equal("example", option.Item);
+                Assert.Equal("example", option.SettingName);
             }
 
             /// <summary>
@@ -1171,7 +1171,7 @@ let x = 42
             {
                 var command = ParseLineCommand("set noexample").AsSet();
                 var option = command.SetArguments.Single().AsToggleOffSetting();
-                Assert.Equal("example", option.Item);
+                Assert.Equal("example", option.SettingName);
             }
 
             /// <summary>
@@ -1182,7 +1182,7 @@ let x = 42
             {
                 var command = ParseLineCommand("set example!").AsSet();
                 var option = command.SetArguments.Single().AsInvertSetting();
-                Assert.Equal("example", option.Item);
+                Assert.Equal("example", option.SettingName);
             }
 
             /// <summary>
@@ -1194,7 +1194,7 @@ let x = 42
             {
                 var command = ParseLineCommand("set invexample").AsSet();
                 var option = command.SetArguments.Single().AsInvertSetting();
-                Assert.Equal("example", option.Item);
+                Assert.Equal("example", option.SettingName);
             }
 
             /// <summary>
@@ -1205,8 +1205,8 @@ let x = 42
             {
                 var command = ParseLineCommand("set x=y").AsSet();
                 var option = command.SetArguments.Single().AsAssignSetting();
-                Assert.Equal("x", option.Item1);
-                Assert.Equal("y", option.Item2);
+                Assert.Equal("x", option.SettingName);
+                Assert.Equal("y", option.Value);
             }
 
             /// <summary>
@@ -1218,8 +1218,8 @@ let x = 42
             {
                 var command = ParseLineCommand("set x:y").AsSet();
                 var option = command.SetArguments.Single().AsAssignSetting();
-                Assert.Equal("x", option.Item1);
-                Assert.Equal("y", option.Item2);
+                Assert.Equal("x", option.SettingName);
+                Assert.Equal("y", option.Value);
             }
 
             /// <summary>
@@ -1230,8 +1230,8 @@ let x = 42
             {
                 var command = ParseLineCommand("set vb=").AsSet();
                 var option = command.SetArguments.Single().AsAssignSetting();
-                Assert.Equal("vb", option.Item1);
-                Assert.Equal("", option.Item2);
+                Assert.Equal("vb", option.SettingName);
+                Assert.Equal("", option.Value);
             }
 
             /// <summary>
@@ -1242,8 +1242,8 @@ let x = 42
             {
                 var command = ParseLineCommand("set x+=y").AsSet();
                 var option = command.SetArguments.Single().AsAddSetting();
-                Assert.Equal("x", option.Item1);
-                Assert.Equal("y", option.Item2);
+                Assert.Equal("x", option.SettingName);
+                Assert.Equal("y", option.Value);
             }
 
             /// <summary>
@@ -1254,8 +1254,8 @@ let x = 42
             {
                 var command = ParseLineCommand("set x-=y").AsSet();
                 var option = command.SetArguments.Single().AsSubtractSetting();
-                Assert.Equal("x", option.Item1);
-                Assert.Equal("y", option.Item2);
+                Assert.Equal("x", option.SettingName);
+                Assert.Equal("y", option.Value);
             }
 
             /// <summary>
@@ -1268,11 +1268,11 @@ let x = 42
                 Assert.Equal(2, command.SetArguments.Length);
 
                 var set = command.SetArguments[0];
-                Assert.Equal("vb", set.AsAssignSetting().Item1);
-                Assert.Equal("", set.AsAssignSetting().Item2);
+                Assert.Equal("vb", set.AsAssignSetting().SettingName);
+                Assert.Equal("", set.AsAssignSetting().Value);
 
                 set = command.SetArguments[1];
-                Assert.Equal("ai", set.AsUseSetting().Item);
+                Assert.Equal("ai", set.AsUseSetting().SettingName);
             }
 
             /// <summary>
@@ -1283,8 +1283,8 @@ let x = 42
             {
                 var command = ParseLineCommand("set x^=y").AsSet();
                 var option = command.SetArguments.Single().AsMultiplySetting();
-                Assert.Equal("x", option.Item1);
-                Assert.Equal("y", option.Item2);
+                Assert.Equal("x", option.SettingName);
+                Assert.Equal("y", option.Value);
             }
 
             /// <summary>
@@ -1334,7 +1334,7 @@ let x = 42
             {
                 var lineRange = ParseLineRange("42");
                 Assert.True(lineRange.IsSingleLine);
-                Assert.True(lineRange.AsSingleLine().Item.IsNumber(42));
+                Assert.True(lineRange.AsSingleLine().LineSpecifier.IsNumber(42));
             }
 
             /// <summary>
@@ -1344,9 +1344,9 @@ let x = 42
             public void RangeOfCurrentLine()
             {
                 var lineRange = ParseLineRange(".,.");
-                Assert.True(lineRange.AsRange().Item1.IsCurrentLine);
-                Assert.True(lineRange.AsRange().Item2.IsCurrentLine);
-                Assert.False(lineRange.AsRange().item3);
+                Assert.True(lineRange.AsRange().StartLineSpecifier.IsCurrentLine);
+                Assert.True(lineRange.AsRange().LastLineSpecifier.IsCurrentLine);
+                Assert.False(lineRange.AsRange().AdjustCaret);
             }
 
             /// <summary>
@@ -1356,9 +1356,9 @@ let x = 42
             public void RangeOfNumbers()
             {
                 var lineRange = ParseLineRange("1,2");
-                Assert.True(lineRange.AsRange().Item1.IsNumber(1));
-                Assert.True(lineRange.AsRange().Item2.IsNumber(2));
-                Assert.False(lineRange.AsRange().item3);
+                Assert.True(lineRange.AsRange().StartLineSpecifier.IsNumber(1));
+                Assert.True(lineRange.AsRange().LastLineSpecifier.IsNumber(2));
+                Assert.False(lineRange.AsRange().AdjustCaret);
             }
 
             /// <summary>
@@ -1369,9 +1369,9 @@ let x = 42
             public void RangeOfNumbersWithAdjustCaret()
             {
                 var lineRange = ParseLineRange("1;2");
-                Assert.True(lineRange.AsRange().Item1.IsNumber(1));
-                Assert.True(lineRange.AsRange().Item2.IsNumber(2));
-                Assert.True(lineRange.AsRange().item3);
+                Assert.True(lineRange.AsRange().StartLineSpecifier.IsNumber(1));
+                Assert.True(lineRange.AsRange().LastLineSpecifier.IsNumber(2));
+                Assert.True(lineRange.AsRange().AdjustCaret);
             }
 
             /// <summary>
@@ -1381,8 +1381,8 @@ let x = 42
             public void Marks()
             {
                 var lineRange = ParseLineRange("'a,'b");
-                Assert.True(lineRange.AsRange().Item1.IsMarkLine);
-                Assert.True(lineRange.AsRange().Item2.IsMarkLine);
+                Assert.True(lineRange.AsRange().StartLineSpecifier.IsMarkLine);
+                Assert.True(lineRange.AsRange().LastLineSpecifier.IsMarkLine);
             }
 
             /// <summary>
@@ -1392,8 +1392,8 @@ let x = 42
             public void MarksWithTrailing()
             {
                 var lineRange = ParseLineRange("'a,'bc");
-                Assert.True(lineRange.AsRange().Item1.IsMarkLine);
-                Assert.True(lineRange.AsRange().Item2.IsMarkLine);
+                Assert.True(lineRange.AsRange().StartLineSpecifier.IsMarkLine);
+                Assert.True(lineRange.AsRange().LastLineSpecifier.IsMarkLine);
             }
 
             /// <summary>
@@ -1403,7 +1403,7 @@ let x = 42
             public void NextPatternSpecifier()
             {
                 var lineSpecifier = ParseLineSpecifier("/dog/");
-                Assert.Equal("dog", lineSpecifier.AsNextLineWithPattern().Item);
+                Assert.Equal("dog", lineSpecifier.AsNextLineWithPattern().Pattern);
             }
 
             /// <summary>
@@ -1413,7 +1413,7 @@ let x = 42
             public void PreviousPatternSpecifier()
             {
                 var lineSpecifier = ParseLineSpecifier("?dog?");
-                Assert.Equal("dog", lineSpecifier.AsPreviousLineWithPattern().Item);
+                Assert.Equal("dog", lineSpecifier.AsPreviousLineWithPattern().Pattern);
             }
         }
 
@@ -1823,7 +1823,7 @@ let x = 42
             {
                 var lineCommand = ParseLineCommand("delete 2");
                 var lineRange = lineCommand.AsDelete().LineRangeSpecifier;
-                Assert.Equal(2, lineRange.AsWithEndCount().Item2);
+                Assert.Equal(2, lineRange.AsWithEndCount().Count);
             }
 
             [Fact]

--- a/Test/VimCoreTest/ParserTest.cs
+++ b/Test/VimCoreTest/ParserTest.cs
@@ -65,7 +65,7 @@ namespace Vim.UnitTest
                 var parser = CreateParser(text);
                 var parseResult = parser.ParseStringLiteral();
                 Assert.True(parseResult.IsSucceeded);
-                return parseResult.AsSucceeded().Item.AsConstantValue().Item.AsString().Item;
+                return parseResult.AsSucceeded().Item.AsConstantValue().Value.AsString().String;
             }
 
             [Fact]
@@ -634,12 +634,12 @@ let x = 42
                 var parser = CreateParser(text);
                 var parseResult = parser.ParseNumberConstant();
                 Assert.True(parseResult.IsSucceeded);
-                return parseResult.AsSucceeded().Item.AsConstantValue().Item;
+                return parseResult.AsSucceeded().Item.AsConstantValue().Value;
             }
 
             private int ParseNumber(string text)
             {
-                return ParseNumberValue(text).AsNumber().Item;
+                return ParseNumberValue(text).AsNumber().Number;
             }
 
             [Fact]
@@ -748,7 +748,7 @@ let x = 42
                 var parser = CreateParser(text);
                 var parseResult = parser.ParseList();
                 Assert.True(parseResult.IsSucceeded);
-                return parseResult.AsSucceeded().Item.AsList().Item;
+                return parseResult.AsSucceeded().Item.AsList().Expressions;
             }
 
             [Fact]
@@ -813,7 +813,7 @@ let x = 42
                 parser.Tokenizer.TokenizerFlags = TokenizerFlags.AllowDoubleQuote;
                 var parseResult = parser.ParseStringConstant();
                 Assert.True(parseResult.IsSucceeded);
-                return parseResult.AsSucceeded().Item.AsConstantValue().Item.AsString().Item;
+                return parseResult.AsSucceeded().Item.AsConstantValue().Value.AsString().String;
             }
 
             [Fact]
@@ -1715,7 +1715,7 @@ let x = 42
                 var command = ParseLineCommand("cd test.txt").AsChangeDirectory();
                 Assert.Equal(1, command.SymbolicPath.Length);
                 Assert.True(command.SymbolicPath.First().IsLiteral);
-                Assert.Equal("test.txt", ((SymbolicPathComponent.Literal) command.SymbolicPath.First()).Item);
+                Assert.Equal("test.txt", ((SymbolicPathComponent.Literal) command.SymbolicPath.First()).Literal);
             }
 
             /// <summary>
@@ -1728,7 +1728,7 @@ let x = 42
                 var command = ParseLineCommand("cd! test.txt").AsChangeDirectory();
                 Assert.Equal(1, command.SymbolicPath.Length);
                 Assert.True(command.SymbolicPath.First().IsLiteral);
-                Assert.Equal("test.txt", ((SymbolicPathComponent.Literal) command.SymbolicPath.First()).Item);
+                Assert.Equal("test.txt", ((SymbolicPathComponent.Literal) command.SymbolicPath.First()).Literal);
             }
 
             /// <summary>
@@ -1750,7 +1750,7 @@ let x = 42
                 var command = ParseLineCommand("lcd test.txt").AsChangeLocalDirectory();
                 Assert.Equal(1, command.SymbolicPath.Length);
                 Assert.True(command.SymbolicPath.First().IsLiteral);
-                Assert.Equal("test.txt", ((SymbolicPathComponent.Literal) command.SymbolicPath.First()).Item);
+                Assert.Equal("test.txt", ((SymbolicPathComponent.Literal) command.SymbolicPath.First()).Literal);
             }
 
             /// <summary>
@@ -1763,7 +1763,7 @@ let x = 42
                 var command = ParseLineCommand("lcd! test.txt").AsChangeLocalDirectory();
                 Assert.Equal(1, command.SymbolicPath.Length);
                 Assert.True(command.SymbolicPath.First().IsLiteral);
-                Assert.Equal("test.txt", ((SymbolicPathComponent.Literal) command.SymbolicPath.First()).Item);
+                Assert.Equal("test.txt", ((SymbolicPathComponent.Literal) command.SymbolicPath.First()).Literal);
             }
 
             /// <summary>

--- a/Test/VimCoreTest/SearchOffsetDataTest.cs
+++ b/Test/VimCoreTest/SearchOffsetDataTest.cs
@@ -14,21 +14,21 @@ namespace Vim.UnitTest
             {
                 var data = SearchOffsetData.Parse(offset);
                 Assert.True(data.IsLine);
-                Assert.Equal(count, ((SearchOffsetData.Line)data).Item);
+                Assert.Equal(count, ((SearchOffsetData.Line)data).Line);
             }
 
             private static void AssertEnd(string offset, int count)
             {
                 var data = SearchOffsetData.Parse(offset);
                 Assert.True(data.IsEnd);
-                Assert.Equal(count, ((SearchOffsetData.End)data).Item);
+                Assert.Equal(count, ((SearchOffsetData.End)data).End);
             }
 
             private static void AssertStart(string offset, int count)
             {
                 var data = SearchOffsetData.Parse(offset);
                 Assert.True(data.IsStart);
-                Assert.Equal(count, ((SearchOffsetData.Start)data).Item);
+                Assert.Equal(count, ((SearchOffsetData.Start)data).Start);
             }
 
             private static void AssertSearch(string offset, string search, SearchPath direction = null)
@@ -36,8 +36,8 @@ namespace Vim.UnitTest
                 direction = direction ?? SearchPath.Forward;
                 var data = SearchOffsetData.Parse(offset);
                 Assert.True(data.IsSearch);
-                Assert.Equal(search, ((SearchOffsetData.Search)data).Item.Pattern);
-                Assert.Equal(direction, ((SearchOffsetData.Search)data).Item.Path);
+                Assert.Equal(search, ((SearchOffsetData.Search)data).PatternData.Pattern);
+                Assert.Equal(direction, ((SearchOffsetData.Search)data).PatternData.Path);
             }
 
             [Fact]

--- a/Test/VimCoreTest/SearchServiceTest.cs
+++ b/Test/VimCoreTest/SearchServiceTest.cs
@@ -204,7 +204,7 @@ namespace Vim.UnitTest
                 Create(@"cat bthe thedog");
                 var data = VimUtil.CreateSearchData(@"\<the");
                 var result = _search.FindNext(_textBuffer.GetPoint(0), data, _wordNavigator);
-                Assert.Equal(9, result.AsFound().Item2.Start.Position);
+                Assert.Equal(9, result.AsFound().SpanWithOffset.Start.Position);
             }
 
             /// <summary>
@@ -241,7 +241,7 @@ namespace Vim.UnitTest
                 Create(" cat dog cat");
                 var data = VimUtil.CreateSearchData("cat");
                 var result = _search.FindNextPattern(_textBuffer.GetPoint(0), data, _wordNavigator, 2);
-                Assert.Equal(9, result.AsFound().Item2.Start.Position);
+                Assert.Equal(9, result.AsFound().SpanWithOffset.Start.Position);
             }
         }
 
@@ -256,8 +256,8 @@ namespace Vim.UnitTest
                 Create("cat dog cat", "cat");
                 var result = FindNextPattern("cat", SearchPath.Forward, _textBuffer.GetPoint(0), 2);
                 Assert.True(result.IsFound);
-                Assert.Equal(_textBuffer.GetLine(1).Extent, result.AsFound().Item2);
-                Assert.False(result.AsFound().Item4);
+                Assert.Equal(_textBuffer.GetLine(1).Extent, result.AsFound().SpanWithOffset);
+                Assert.False(result.AsFound().DidWrap);
             }
 
             /// <summary>
@@ -317,7 +317,7 @@ namespace Vim.UnitTest
             {
                 Create("foo bar", "foo");
                 var result = FindNextPattern("foo", SearchPath.Forward, _textBuffer.GetPoint(0), 1);
-                Assert.Equal(_textBuffer.GetLine(1).Start, result.AsFound().Item2.Start);
+                Assert.Equal(_textBuffer.GetLine(1).Start, result.AsFound().SpanWithOffset.Start);
             }
 
             /// <summary>
@@ -329,7 +329,7 @@ namespace Vim.UnitTest
             {
                 Create("foo bar", "foo");
                 var result = FindNextPattern("foo", SearchPath.Backward, _textBuffer.GetLine(1).Start, 1);
-                Assert.Equal(_textBuffer.GetPoint(0), result.AsFound().Item2.Start);
+                Assert.Equal(_textBuffer.GetPoint(0), result.AsFound().SpanWithOffset.Start);
             }
 
             /// <summary>
@@ -342,7 +342,7 @@ namespace Vim.UnitTest
                 _globalSettings.WrapScan = false;
                 var result = FindNextPattern("dog", SearchPath.Forward, _textBuffer.GetPoint(0), 1);
                 Assert.True(result.IsNotFound);
-                Assert.True(result.AsNotFound().Item2);
+                Assert.True(result.AsNotFound().CanFindWithWrap);
             }
 
             /// <summary>
@@ -355,7 +355,7 @@ namespace Vim.UnitTest
                 _globalSettings.WrapScan = false;
                 var result = FindNextPattern("dog", SearchPath.Backward, _textBuffer.GetPoint(0), 1);
                 Assert.True(result.IsNotFound);
-                Assert.True(result.AsNotFound().Item2);
+                Assert.True(result.AsNotFound().CanFindWithWrap);
             }
 
             /// <summary>

--- a/Test/VimCoreTest/SettingsCommonTest.cs
+++ b/Test/VimCoreTest/SettingsCommonTest.cs
@@ -97,11 +97,11 @@ namespace Vim.UnitTest
         {
             var all = _settings.Settings;
             var value = all.Single(x => x.Name == NumberSettingName);
-            var prev = value.Value.AsNumber().Item;
+            var prev = value.Value.AsNumber().Number;
             Assert.NotEqual(42, prev);
             Assert.True(_settings.TrySetValue(NumberSettingName, SettingValue.NewNumber(42)));
             value = all.Single(x => x.Name == NumberSettingName);
-            Assert.Equal(prev, value.Value.AsNumber().Item);
+            Assert.Equal(prev, value.Value.AsNumber().Number);
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace Vim.UnitTest
             Assert.True(_settings.TrySetValue(GlobalSettingNames.IgnoreCaseName, SettingValue.NewToggle(true)));
             var value = _settings.GetSetting(GlobalSettingNames.IgnoreCaseName);
             Assert.True(value.IsSome());
-            Assert.True(value.Value.Value.AsToggle().Item);
+            Assert.True(value.Value.Value.AsToggle().Toggle);
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace Vim.UnitTest
             Assert.True(_settings.TrySetValue(GlobalSettingNames.ScrollOffsetName, SettingValue.NewNumber(42)));
             var value = _settings.GetSetting(GlobalSettingNames.ScrollOffsetName);
             Assert.True(value.IsSome());
-            Assert.Equal(42, value.Value.Value.AsNumber().Item);
+            Assert.Equal(42, value.Value.Value.AsNumber().Number);
         }
 
         /// <summary>
@@ -250,14 +250,14 @@ namespace Vim.UnitTest
         public void SetByAbbreviation_Number()
         {
             Assert.True(_settings.TrySetValueFromString(NumberSetting.Abbreviation, "2"));
-            Assert.Equal(2, NumberSetting.Value.AsNumber().Item);
+            Assert.Equal(2, NumberSetting.Value.AsNumber().Number);
         }
 
         [Fact]
         public void SetByAbbreviation_Toggle()
         {
             Assert.True(_settings.TrySetValueFromString(ToggleSetting.Abbreviation, "true"));
-            Assert.True(ToggleSetting.Value.AsToggle().Item);
+            Assert.True(ToggleSetting.Value.AsToggle().Toggle);
         }
 
         [Fact]
@@ -268,7 +268,7 @@ namespace Vim.UnitTest
                 {
                     var setting = args.Setting;
                     Assert.Equal(ToggleSettingName, setting.Name);
-                    Assert.True(setting.Value.AsToggle().Item);
+                    Assert.True(setting.Value.AsToggle().Toggle);
                     didRun = true;
                 };
             _settings.TrySetValue(ToggleSettingName, SettingValue.NewToggle(true));
@@ -283,7 +283,7 @@ namespace Vim.UnitTest
                 {
                     var setting = args.Setting;
                     Assert.Equal(ToggleSettingName, setting.Name);
-                    Assert.True(setting.Value.AsToggle().Item);
+                    Assert.True(setting.Value.AsToggle().Toggle);
                     didRun = true;
                 };
             _settings.TrySetValueFromString(ToggleSettingName, "true");

--- a/Test/VimCoreTest/StoredVisualSelectionTest.cs
+++ b/Test/VimCoreTest/StoredVisualSelectionTest.cs
@@ -71,7 +71,7 @@ namespace Vim.UnitTest
                 var sel = StoredVisualSelection.NewCharacterLine(lineCount: 2, lastLineMaxOffset: -1);
                 var point = textBuffer.GetPointInLine(line: 3, column: 2);
                 var visualSelection = sel.GetVisualSelection(point, count: 1);
-                Assert.Equal(SearchPath.Backward, visualSelection.AsCharacter().Item2);
+                Assert.Equal(SearchPath.Backward, visualSelection.AsCharacter().SearchPath);
 
                 var span = visualSelection.VisualSpan.Spans.Single();
                 Assert.Equal(textBuffer.GetPointInLine(line: 3, column: 1), span.Start);

--- a/Test/VimCoreTest/StoredVisualSelectionTest.cs
+++ b/Test/VimCoreTest/StoredVisualSelectionTest.cs
@@ -21,7 +21,7 @@ namespace Vim.UnitTest
                 var textBuffer = CreateTextBuffer("hello");
                 var storedVisualSelection = StoredVisualSelection.NewCharacter(count);
                 var visualSpan = storedVisualSelection.GetVisualSelection(textBuffer.GetStartPoint(), 1).VisualSpan;
-                Assert.Equal(count, visualSpan.AsCharacter().Item.Length);
+                Assert.Equal(count, visualSpan.AsCharacter().CharacterSpan.Length);
                 Assert.Equal("hello".Substring(0, count), visualSpan.Spans.Single().GetText());
             }
 
@@ -34,7 +34,7 @@ namespace Vim.UnitTest
                 var textBuffer = CreateTextBuffer("dog", "cat", "tree", "pony");
                 var storedVisualSelection = StoredVisualSelection.NewLine(count);
                 var visualSpan = storedVisualSelection.GetVisualSelection(textBuffer.GetStartPoint(), 1).VisualSpan;
-                Assert.Equal(count, visualSpan.AsLine().Item.Count);
+                Assert.Equal(count, visualSpan.AsLine().LineRange.Count);
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/TextChangeTest.cs
+++ b/Test/VimCoreTest/TextChangeTest.cs
@@ -88,7 +88,7 @@ namespace Vim.UnitTest
                             TextChange.NewInsert("cat"),
                             TextChange.NewDeleteLeft(3)),
                         TextChange.NewDeleteRight(3));
-                    Assert.Equal(3, textChange.AsDeleteRight().Item);
+                    Assert.Equal(3, textChange.AsDeleteRight().Count);
                 }
 
                 /// <summary>
@@ -103,7 +103,7 @@ namespace Vim.UnitTest
                         TextChange.NewCombination(
                             TextChange.NewInsert("cat"),
                             TextChange.NewDeleteLeft(3)));
-                    Assert.Equal(3, textChange.AsDeleteRight().Item);
+                    Assert.Equal(3, textChange.AsDeleteRight().Count);
                 }
             }
 
@@ -115,7 +115,7 @@ namespace Vim.UnitTest
                     var textChange = TextChange.CreateReduced(
                         TextChange.NewInsert("a"),
                         TextChange.NewInsert("b"));
-                    Assert.Equal("ab", textChange.AsInsert().Item);
+                    Assert.Equal("ab", textChange.AsInsert().Text);
                 }
 
                 [Fact]
@@ -124,7 +124,7 @@ namespace Vim.UnitTest
                     var textChange = TextChange.CreateReduced(
                         TextChange.NewDeleteLeft(5),
                         TextChange.NewDeleteLeft(6));
-                    Assert.Equal(11, textChange.AsDeleteLeft().Item);
+                    Assert.Equal(11, textChange.AsDeleteLeft().Count);
                 }
 
                 [Fact]
@@ -133,7 +133,7 @@ namespace Vim.UnitTest
                     var textChange = TextChange.CreateReduced(
                         TextChange.NewDeleteRight(5),
                         TextChange.NewDeleteRight(6));
-                    Assert.Equal(11, textChange.AsDeleteRight().Item);
+                    Assert.Equal(11, textChange.AsDeleteRight().Count);
                 }
 
                 [Fact]
@@ -142,7 +142,7 @@ namespace Vim.UnitTest
                     var textChange = TextChange.CreateReduced(
                         TextChange.NewInsert("cat"),
                         TextChange.NewDeleteLeft(2));
-                    Assert.Equal("c", textChange.AsInsert().Item);
+                    Assert.Equal("c", textChange.AsInsert().Text);
                 }
 
                 [Fact]
@@ -151,7 +151,7 @@ namespace Vim.UnitTest
                     var textChange = TextChange.CreateReduced(
                         TextChange.NewInsert("cat"),
                         TextChange.NewDeleteLeft(4));
-                    Assert.Equal(1, textChange.AsDeleteLeft().Item);
+                    Assert.Equal(1, textChange.AsDeleteLeft().Count);
                 }
 
                 [Fact]
@@ -160,7 +160,7 @@ namespace Vim.UnitTest
                     var textChange = TextChange.CreateReduced(
                         TextChange.NewInsert("cat"),
                         TextChange.NewDeleteLeft(3));
-                    Assert.Equal("", textChange.AsInsert().Item);
+                    Assert.Equal("", textChange.AsInsert().Text);
                 }
 
                 /// <summary>
@@ -175,7 +175,7 @@ namespace Vim.UnitTest
                             TextChange.NewInsert("pr"),
                             TextChange.NewDeleteLeft(2)),
                         TextChange.NewInsert("protected"));
-                    Assert.Equal("protected", textChange.AsInsert().Item);
+                    Assert.Equal("protected", textChange.AsInsert().Text);
                 }
 
                 /// <summary>
@@ -190,7 +190,7 @@ namespace Vim.UnitTest
                         TextChange.NewCombination(
                             TextChange.NewDeleteLeft(2),
                             TextChange.NewInsert("protected")));
-                    Assert.Equal("protected", textChange.AsInsert().Item);
+                    Assert.Equal("protected", textChange.AsInsert().Text);
                 }
             }
         }

--- a/Test/VimCoreTest/TextChangeTrackerTest.cs
+++ b/Test/VimCoreTest/TextChangeTrackerTest.cs
@@ -228,8 +228,8 @@ namespace Vim.UnitTest
             _textBuffer.Replace(new Span(0, 3), "dog");
             var change = _tracker.CurrentChange.Value;
             Assert.True(change.IsCombination);
-            Assert.True(change.AsCombination().Item1.IsDeleteLeft(3));
-            Assert.True(change.AsCombination().Item2.IsInsert("dog"));
+            Assert.True(change.AsCombination().Left.IsDeleteLeft(3));
+            Assert.True(change.AsCombination().Right.IsInsert("dog"));
         }
 
         /// <summary>
@@ -243,8 +243,8 @@ namespace Vim.UnitTest
             _textBuffer.Replace(new Span(0, 5), "dog");
             var change = _tracker.CurrentChange.Value;
             Assert.True(change.IsCombination);
-            Assert.True(change.AsCombination().Item1.IsDeleteLeft(5));
-            Assert.True(change.AsCombination().Item2.IsInsert("dog"));
+            Assert.True(change.AsCombination().Left.IsDeleteLeft(5));
+            Assert.True(change.AsCombination().Right.IsInsert("dog"));
         }
 
         /// <summary>
@@ -258,8 +258,8 @@ namespace Vim.UnitTest
             _textBuffer.Replace(new Span(0, 3), "house");
             var change = _tracker.CurrentChange.Value;
             Assert.True(change.IsCombination);
-            Assert.True(change.AsCombination().Item1.IsDeleteLeft(3));
-            Assert.True(change.AsCombination().Item2.IsInsert("house"));
+            Assert.True(change.AsCombination().Left.IsDeleteLeft(3));
+            Assert.True(change.AsCombination().Right.IsInsert("house"));
         }
 
         /// <summary>
@@ -274,8 +274,8 @@ namespace Vim.UnitTest
             _textBuffer.Replace(new Span(1, 3), "cat");
             var change = _trackerRaw.CurrentChange.Value;
             Assert.True(change.IsCombination);
-            Assert.True(change.AsCombination().Item1.IsInsert("i"));
-            Assert.True(change.AsCombination().Item2.IsCombination);
+            Assert.True(change.AsCombination().Left.IsInsert("i"));
+            Assert.True(change.AsCombination().Right.IsCombination);
         }
     }
 }

--- a/Test/VimCoreTest/VimIntegrationTest.cs
+++ b/Test/VimCoreTest/VimIntegrationTest.cs
@@ -254,7 +254,7 @@ let x = 42
 ";
                 Run(text);
                 Assert.False(_globalSettings.HighlightSearch);
-                Assert.Equal(42, Vim.VariableMap["x"].AsNumber().Item);
+                Assert.Equal(42, Vim.VariableMap["x"].AsNumber().Number);
             }
 
             /// <summary>

--- a/Test/VimCoreTest/VimIntegrationTest.cs
+++ b/Test/VimCoreTest/VimIntegrationTest.cs
@@ -308,7 +308,7 @@ autocmd BufEnter *.html set ts=12
 ";
                 Run(text);
 
-                var errorArray = ((VimRcState.LoadSucceeded)_vim.VimRcState).Item2;
+                var errorArray = ((VimRcState.LoadSucceeded)_vim.VimRcState).Errors;
                 Assert.Single(errorArray);
                 Assert.Equal(Resources.Interpreter_UnknownOption("foo"), errorArray[0]);
             }

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -3437,7 +3437,7 @@ namespace Vim.UnitTest
             {
                 var data = UnnamedRegister.StringData;
                 Assert.True(data.IsBlock);
-                Assert.Equal(lines, ((StringData.Block)data).Item);
+                Assert.Equal(lines, ((StringData.Block)data).BlockTexts);
             }
 
             public sealed class BlockTest : YankSelectionTest

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -515,7 +515,7 @@ namespace Vim.UnitTest
                     _vimBuffer.ProcessNotation($"1{kind}");
                     Assert.Equal(ModeKind.VisualLine, _vimBuffer.ModeKind);
                     var selection = _vimBuffer.VisualLineMode.VisualSelection;
-                    var range = selection.AsLine().Item1;
+                    var range = selection.AsLine().LineRange;
                     Assert.Equal(range, _textBuffer.GetLineRange(startLine: 0, endLine: 0));
                 }
 
@@ -530,7 +530,7 @@ namespace Vim.UnitTest
                     _vimBuffer.ProcessNotation($"2{kind}");
                     Assert.Equal(ModeKind.VisualLine, _vimBuffer.ModeKind);
                     var selection = _vimBuffer.VisualLineMode.VisualSelection;
-                    var range = selection.AsLine().Item1;
+                    var range = selection.AsLine().LineRange;
                     Assert.Equal(range, _textBuffer.GetLineRange(startLine: 0, endLine: 1));
                 }
             }

--- a/Test/VimCoreTest/VisualSelectionTest.cs
+++ b/Test/VimCoreTest/VisualSelectionTest.cs
@@ -302,7 +302,7 @@ namespace Vim.UnitTest
                 {
                     Create("cats dogs");
                     var visualSelection = VisualSelection.CreateForPoints(VisualKind.Character, _textBuffer.GetPoint(3), _textBuffer.GetPoint(0), tabStop: 4);
-                    var characterSpan = visualSelection.AsCharacter().Item1;
+                    var characterSpan = visualSelection.AsCharacter().CharacterSpan;
                     Assert.Equal(0, characterSpan.Start.Position);
                     Assert.Equal(3, characterSpan.Last.Value.Position);
                     Assert.Equal(4, characterSpan.End.Position);
@@ -314,8 +314,8 @@ namespace Vim.UnitTest
                     Create("cat", "dog");
                     var visualSelection = VisualSelection.CreateForPoints(VisualKind.Character, _textBuffer.GetPoint(3), _textBuffer.GetPoint(0), tabStop: 4);
                     var character = visualSelection.AsCharacter();
-                    Assert.True(character.Item1.IncludeLastLineLineBreak);
-                    Assert.Equal(SearchPath.Backward, character.Item2);
+                    Assert.True(character.CharacterSpan.IncludeLastLineLineBreak);
+                    Assert.Equal(SearchPath.Backward, character.SearchPath);
                 }
 
                 [WpfFact]
@@ -324,8 +324,8 @@ namespace Vim.UnitTest
                     Create("cat", "dog");
                     var visualSelection = VisualSelection.CreateForPoints(VisualKind.Character, _textBuffer.GetPoint(0), _textBuffer.GetPoint(3), tabStop: 4);
                     var character = visualSelection.AsCharacter();
-                    Assert.True(character.Item1.IncludeLastLineLineBreak);
-                    Assert.Equal(SearchPath.Forward, character.Item2);
+                    Assert.True(character.CharacterSpan.IncludeLastLineLineBreak);
+                    Assert.Equal(SearchPath.Forward, character.SearchPath);
                 }
 
                 /// <summary>
@@ -337,8 +337,8 @@ namespace Vim.UnitTest
                     Create("cat", "dog");
                     var visualSelection = VisualSelection.CreateForPoints(VisualKind.Character, _textBuffer.GetPoint(0), _textBuffer.GetPoint(4), tabStop: 4);
                     var character = visualSelection.AsCharacter();
-                    Assert.True(character.Item1.IncludeLastLineLineBreak);
-                    Assert.Equal(SearchPath.Forward, character.Item2);
+                    Assert.True(character.CharacterSpan.IncludeLastLineLineBreak);
+                    Assert.Equal(SearchPath.Forward, character.SearchPath);
                 }
             }
 
@@ -352,7 +352,7 @@ namespace Vim.UnitTest
                 {
                     Create("cats dogs");
                     var visualSelection = VisualSelection.CreateForPoints(VisualKind.Line, _textBuffer.GetPoint(3), _textBuffer.GetPoint(1), tabStop: 4);
-                    Assert.Equal(_textBuffer.GetLineRange(0), visualSelection.AsLine().Item1);
+                    Assert.Equal(_textBuffer.GetLineRange(0), visualSelection.AsLine().LineRange);
                 }
 
                 /// <summary>
@@ -365,7 +365,7 @@ namespace Vim.UnitTest
                 {
                     Create("cat", "dog", "bear");
                     var visualSpan = VisualSelection.CreateForPoints(VisualKind.Line, _textBuffer.GetPoint(0), caretPoint: _textBuffer.GetPointInLine(1, 0), tabStop: 4);
-                    Assert.Equal(_textBuffer.GetLineRange(0, 1), visualSpan.AsLine().Item1);
+                    Assert.Equal(_textBuffer.GetLineRange(0, 1), visualSpan.AsLine().LineRange);
                 }
 
                 /// <summary>
@@ -379,7 +379,7 @@ namespace Vim.UnitTest
                 {
                     Create("cats", "", "dogs", "");
                     var visualSelection = VisualSelection.CreateForVirtualPoints(VisualKind.Line, _textBuffer.GetVirtualPoint(0), _textBuffer.GetVirtualPointInLine(1, 0), tabStop: 4, useVirtualSpace);
-                    Assert.Equal(_textBuffer.GetLineRange(0, 1), visualSelection.AsLine().Item1);
+                    Assert.Equal(_textBuffer.GetLineRange(0, 1), visualSelection.AsLine().LineRange);
                 }
             }
 
@@ -409,7 +409,7 @@ namespace Vim.UnitTest
                         _textBuffer.GetPoint(3),
                         _textBuffer.GetPoint(1),
                         tabStop: 4);
-                    Assert.Equal(_textBuffer.GetSpan(1, 3), visualSelection.AsBlock().Item1.BlockSpans.Head);
+                    Assert.Equal(_textBuffer.GetSpan(1, 3), visualSelection.AsBlock().BlockSpan.BlockSpans.Head);
                 }
 
                 /// <summary>
@@ -426,7 +426,7 @@ namespace Vim.UnitTest
                         _textBuffer.GetPoint(2),
                         _textBuffer.GetPointInLine(1, 1),
                         tabStop: 4);
-                    Assert.Equal(_textBuffer.GetBlockSpan(1, 2, 0, 2), visualSelection.AsBlock().Item1);
+                    Assert.Equal(_textBuffer.GetBlockSpan(1, 2, 0, 2), visualSelection.AsBlock().BlockSpan);
                 }
 
                 /// <summary>
@@ -444,7 +444,7 @@ namespace Vim.UnitTest
                         _textBuffer.GetPointInLine(1, 0),
                         tabStop: 4);
                     var blockSpan = new BlockSpan(_textBuffer.GetPoint(0), tabStop: 4, spaces: 2, height: 2);
-                    Assert.Equal(blockSpan, visualSelection.AsBlock().Item1);
+                    Assert.Equal(blockSpan, visualSelection.AsBlock().BlockSpan);
                 }
 
                 /// <summary>
@@ -461,7 +461,7 @@ namespace Vim.UnitTest
                         _textBuffer.GetPointInLine(1, 1),
                         tabStop: 4);
                     var blockSpan = new BlockSpan(_textBuffer.GetPointInLine(0, 2), tabStop: 4, spaces: 3, height: 2);
-                    Assert.Equal(blockSpan, visualSelection.AsBlock().Item1);
+                    Assert.Equal(blockSpan, visualSelection.AsBlock().BlockSpan);
                 }
 
                 [WpfFact]
@@ -474,7 +474,7 @@ namespace Vim.UnitTest
                         _textBuffer.GetPointInLine(1, 3),
                         tabStop: 4);
                     var blockSpan = new BlockSpan(_textBuffer.GetPointInLine(0, 1), tabStop: 4, spaces: 3, height: 2);
-                    Assert.Equal(blockSpan, visualSelection.AsBlock().Item1);
+                    Assert.Equal(blockSpan, visualSelection.AsBlock().BlockSpan);
                 }
 
                 [WpfFact]
@@ -486,7 +486,7 @@ namespace Vim.UnitTest
                         _textBuffer.GetPointInLine(0, 2),
                         _textBuffer.GetPointInLine(1, 2),
                         tabStop: 4);
-                    var blockSpan = visualSelection.AsBlock().Item1;
+                    var blockSpan = visualSelection.AsBlock().BlockSpan;
 
                     var endPoint = _textBuffer.GetPointInLine(1, 3);
                     Assert.Equal('g', endPoint.GetChar());
@@ -504,7 +504,7 @@ namespace Vim.UnitTest
                 {
                     Create("hello world");
                     var visualSelection = VisualSelection.CreateInitial(VisualKind.Character, _textBuffer.GetVirtualPoint(0), 4, SelectionKind.Exclusive, false);
-                    Assert.Equal(0, visualSelection.AsCharacter().Item1.Length);
+                    Assert.Equal(0, visualSelection.AsCharacter().CharacterSpan.Length);
                 }
 
                 [WpfFact]
@@ -512,7 +512,7 @@ namespace Vim.UnitTest
                 {
                     Create("hello world");
                     var visualSelection = VisualSelection.CreateInitial(VisualKind.Character, _textBuffer.GetVirtualPoint(0), 4, SelectionKind.Inclusive, false);
-                    Assert.Equal(1, visualSelection.AsCharacter().Item1.Length);
+                    Assert.Equal(1, visualSelection.AsCharacter().CharacterSpan.Length);
                 }
 
                 [WpfFact]
@@ -522,8 +522,8 @@ namespace Vim.UnitTest
                     var virtualPoint = _textBuffer.GetVirtualPointInLine(0, 20);
                     var visualSelection = VisualSelection.CreateInitial(VisualKind.Character,
                         virtualPoint, 4, SelectionKind.Exclusive, true);
-                    Assert.Equal(virtualPoint, visualSelection.AsCharacter().Item1.VirtualStart);
-                    Assert.Equal(0, visualSelection.AsCharacter().Item1.VirtualLength);
+                    Assert.Equal(virtualPoint, visualSelection.AsCharacter().CharacterSpan.VirtualStart);
+                    Assert.Equal(0, visualSelection.AsCharacter().CharacterSpan.VirtualLength);
                 }
 
                 [WpfFact]
@@ -533,8 +533,8 @@ namespace Vim.UnitTest
                     var virtualPoint = _textBuffer.GetVirtualPointInLine(0, 20);
                     var visualSelection = VisualSelection.CreateInitial(VisualKind.Character,
                         virtualPoint, 4, SelectionKind.Inclusive, true);
-                    Assert.Equal(virtualPoint, visualSelection.AsCharacter().Item1.VirtualStart);
-                    Assert.Equal(1, visualSelection.AsCharacter().Item1.VirtualLength);
+                    Assert.Equal(virtualPoint, visualSelection.AsCharacter().CharacterSpan.VirtualStart);
+                    Assert.Equal(1, visualSelection.AsCharacter().CharacterSpan.VirtualLength);
                 }
             }
         }
@@ -566,7 +566,7 @@ namespace Vim.UnitTest
                 var visualSpan = VisualSpan.NewBlock(blockSpan);
                 var visualSelection = VisualSelection.CreateForward(visualSpan);
                 var otherVisualSelection = visualSelection.AdjustForSelectionKind(SelectionKind.Exclusive);
-                var otherBlockSpan = otherVisualSelection.AsBlock().Item1;
+                var otherBlockSpan = otherVisualSelection.AsBlock().BlockSpan;
                 Assert.Equal(blockSpan.Start, otherBlockSpan.Start);
                 Assert.Equal(1, otherBlockSpan.SpacesLength);
                 Assert.Equal(2, otherBlockSpan.Height);

--- a/Test/VimCoreTest/VisualSpanTest.cs
+++ b/Test/VimCoreTest/VisualSpanTest.cs
@@ -32,7 +32,7 @@ namespace Vim.UnitTest
                     _textView.Selection.Select(_textBuffer.GetPoint(0), _textBuffer.GetPoint(5));
                     TestableSynchronizationContext.RunAll();
                     var visualSpan = VisualSpan.CreateForSelection(_textView, VisualKind.Character, tabStop: 4);
-                    var characterSpan = visualSpan.AsCharacter().Item;
+                    var characterSpan = visualSpan.AsCharacter().CharacterSpan;
                     Assert.True(characterSpan.IncludeLastLineLineBreak);
                     Assert.Equal(1, characterSpan.LineCount);
                 }
@@ -45,7 +45,7 @@ namespace Vim.UnitTest
                     TestableSynchronizationContext.RunAll();
                     Assert.Equal(1, _textView.Selection.StreamSelectionSpan.End.Position.GetContainingLine().LineNumber);
                     var visualSpan = VisualSpan.CreateForSelection(_textView, VisualKind.Character, tabStop: 4);
-                    var characterSpan = visualSpan.AsCharacter().Item;
+                    var characterSpan = visualSpan.AsCharacter().CharacterSpan;
                     Assert.Equal(2, characterSpan.LineCount);
                     Assert.True(characterSpan.IncludeLastLineLineBreak);
                 }
@@ -81,9 +81,9 @@ namespace Vim.UnitTest
                     _textView.Selection.Select(point1, point2);
                     TestableSynchronizationContext.RunAll();
                     var visualSpan = VisualSpan.CreateForVirtualSelection(_textView, VisualKind.Character, tabStop: 4, useVirtualSpace: true);
-                    Assert.Equal(point1, visualSpan.AsCharacter().Item.VirtualStart);
-                    Assert.Equal(point2, visualSpan.AsCharacter().Item.VirtualEnd);
-                    Assert.Equal(span.Length, visualSpan.AsCharacter().Item.VirtualLength);
+                    Assert.Equal(point1, visualSpan.AsCharacter().CharacterSpan.VirtualStart);
+                    Assert.Equal(point2, visualSpan.AsCharacter().CharacterSpan.VirtualEnd);
+                    Assert.Equal(span.Length, visualSpan.AsCharacter().CharacterSpan.VirtualLength);
                 }
             }
 
@@ -97,7 +97,7 @@ namespace Vim.UnitTest
                 {
                     Create("hello world");
                     var visualSpan = VisualSpan.CreateForSelection(_textView, VisualKind.Line, _vimBuffer.LocalSettings.TabStop);
-                    Assert.Equal(_textBuffer.GetLineRange(0), visualSpan.AsLine().Item);
+                    Assert.Equal(_textBuffer.GetLineRange(0), visualSpan.AsLine().LineRange);
                 }
             }
 
@@ -113,7 +113,7 @@ namespace Vim.UnitTest
                     Create("hello world");
                     var visualSpan = VisualSpan.CreateForSelection(_textView, VisualKind.Block, _vimBuffer.LocalSettings.TabStop);
                     var blockSpan = new BlockSpan(_textBuffer.GetPoint(0), tabStop: _vimBuffer.LocalSettings.TabStop, spaces: 1, height: 1);
-                    Assert.Equal(blockSpan, visualSpan.AsBlock().Item);
+                    Assert.Equal(blockSpan, visualSpan.AsBlock().BlockSpan);
                 }
             }
         }
@@ -133,7 +133,7 @@ namespace Vim.UnitTest
                     var point = _textBuffer.GetPoint(2);
                     var visualSpan = VisualSpan.CreateForSelectionPoints(VisualKind.Block, point, point, _vimBuffer.LocalSettings.TabStop);
                     var blockSpan = new BlockSpan(point, _vimBuffer.LocalSettings.TabStop, spaces: 1, height: 1);
-                    Assert.Equal(blockSpan, visualSpan.AsBlock().Item);
+                    Assert.Equal(blockSpan, visualSpan.AsBlock().BlockSpan);
                 }
 
                 [WpfFact]
@@ -142,7 +142,7 @@ namespace Vim.UnitTest
                     Create("big cat", "big dog");
                     var visualSpan = VisualSpan.CreateForSelectionPoints(VisualKind.Block, _textBuffer.GetPoint(2), _textBuffer.GetPoint(0), _vimBuffer.LocalSettings.TabStop);
                     var blockSpan = new BlockSpan(_textBuffer.GetPoint(0), _vimBuffer.LocalSettings.TabStop, 2, 1);
-                    Assert.Equal(blockSpan, visualSpan.AsBlock().Item);
+                    Assert.Equal(blockSpan, visualSpan.AsBlock().BlockSpan);
                 }
 
                 /// <summary>
@@ -155,7 +155,7 @@ namespace Vim.UnitTest
                     Create("big cat", "big dog");
                     var visualSpan = VisualSpan.CreateForSelectionPoints(VisualKind.Block, _textBuffer.GetPoint(2), _textBuffer.GetPointInLine(1, 1), _vimBuffer.LocalSettings.TabStop);
                     var blockSpan = new BlockSpan(_textBuffer.GetPoint(1), _vimBuffer.LocalSettings.TabStop, 1, 2);
-                    Assert.Equal(blockSpan, visualSpan.AsBlock().Item);
+                    Assert.Equal(blockSpan, visualSpan.AsBlock().BlockSpan);
                 }
 
                 /// <summary>
@@ -168,7 +168,7 @@ namespace Vim.UnitTest
                     Create("big cat", "big dog");
                     var visualSpan = VisualSpan.CreateForSelectionPoints(VisualKind.Block, _textBuffer.GetPoint(1), _textBuffer.GetPointInLine(1, 3), _vimBuffer.LocalSettings.TabStop);
                     var blockSpan = new BlockSpan(_textBuffer.GetPoint(1), _vimBuffer.LocalSettings.TabStop, 2, 2);
-                    Assert.Equal(blockSpan, visualSpan.AsBlock().Item);
+                    Assert.Equal(blockSpan, visualSpan.AsBlock().BlockSpan);
                 }
             }
 
@@ -183,8 +183,8 @@ namespace Vim.UnitTest
                     Create("dog cat");
                     var point = _textBuffer.GetPoint(2);
                     var visualSpan = VisualSpan.CreateForSelectionPoints(VisualKind.Character, point, point, _vimBuffer.LocalSettings.TabStop);
-                    Assert.Equal(point, visualSpan.AsCharacter().Item.Start);
-                    Assert.Equal(0, visualSpan.AsCharacter().Item.Length);
+                    Assert.Equal(point, visualSpan.AsCharacter().CharacterSpan.Start);
+                    Assert.Equal(0, visualSpan.AsCharacter().CharacterSpan.Length);
                 }
 
                 /// <summary>
@@ -205,9 +205,9 @@ namespace Vim.UnitTest
                     var point2 = _textBuffer.GetVirtualPointInLine(0, 4);
                     var span = new VirtualSnapshotSpan(point1, point2);
                     var visualSpan = VisualSpan.CreateForVirtualSelectionPoints(VisualKind.Character, point1, point2, _vimBuffer.LocalSettings.TabStop, true);
-                    Assert.Equal(point1, visualSpan.AsCharacter().Item.VirtualStart);
-                    Assert.Equal(point2, visualSpan.AsCharacter().Item.VirtualEnd);
-                    Assert.Equal(span.Length, visualSpan.AsCharacter().Item.VirtualLength);
+                    Assert.Equal(point1, visualSpan.AsCharacter().CharacterSpan.VirtualStart);
+                    Assert.Equal(point2, visualSpan.AsCharacter().CharacterSpan.VirtualEnd);
+                    Assert.Equal(span.Length, visualSpan.AsCharacter().CharacterSpan.VirtualLength);
                 }
             }
 


### PR DESCRIPTION
Recently was having a bit of trouble following a few of our tests due to the heavy use of `Item1`, `Item2`, etc ... in the code. This is the default naming scheme for discriminated union values and the only option when I originally started VsVim. Now there is the option of giving Discriminated Union values explicit names and they map into the generated members. 

I did an experiment where I forced the naming of all values and saw how it impacted the test code. Overall I like the effects. But it's a bit change wanted to get some feedback about the approach. 