### PR TITLE
Fix surrogate pair block insert

### DIFF
--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -317,6 +317,8 @@ type SnapshotCodePoint =
 
     member x.IsInsideLineBreakOrEnd = x.IsEndPoint || x.IsInsideLineBreak
 
+    member x.IsSurrogatePair = x.CodePointInfo = CodePointInfo.SurrogatePairHighCharacter
+
     /// Is the unicode character at this point represented by the specified value? This will only match
     /// for characters in the BMP plane.
     member x.IsCharacter(c: char) = 
@@ -896,6 +898,8 @@ and [<Struct>] [<StructuralEquality>] [<NoComparison>] [<DebuggerDisplay("{ToStr
 
     /// The SnapshotColumn in which this overlap occurs
     member x.Column: SnapshotColumn = x._column
+
+    member x.CodePoint = x.Column.CodePoint
 
     member x.Line = x.Column.Line
 

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -203,7 +203,7 @@ type internal InsertUtil
                 let lineNumber = startLineNumber + i
                 let line = SnapshotUtil.GetLine currentSnapshot lineNumber
                 let column = SnapshotOverlapColumn.GetColumnForSpacesOrEnd(line, spaces, _localSettings.TabStop)
-                if column.SpacesBefore > 0 && not column.CodePoint.IsSurrogatePair then
+                if column.SpacesBefore > 0 && column.Column.IsCharacter '\t' then
                     let text = StringUtil.RepeatChar column.TotalSpaces ' '
                     let span = column.Column.Span
                     textEdit.Replace(span.Span, text) |> ignore

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -203,7 +203,7 @@ type internal InsertUtil
                 let lineNumber = startLineNumber + i
                 let line = SnapshotUtil.GetLine currentSnapshot lineNumber
                 let column = SnapshotOverlapColumn.GetColumnForSpacesOrEnd(line, spaces, _localSettings.TabStop)
-                if column.SpacesBefore > 0 then
+                if column.SpacesBefore > 0 && not column.CodePoint.IsSurrogatePair then
                     let text = StringUtil.RepeatChar column.TotalSpaces ' '
                     let span = column.Column.Span
                     textEdit.Replace(span.Span, text) |> ignore

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -1231,6 +1231,108 @@ namespace Vim.UnitTest
                 }
             }
 
+            public sealed class SurrogatePairTest: BlockInsertTest
+            {
+                /// <summary>
+                /// Block insert should not be splitting surrogate pairs into spaces as it does for non-surrogate
+                /// pairs which comprise multiple spaces.
+                /// </summary>
+                [WpfFact]
+                public void MiddleOfSurrogatePair()
+                {
+                    const string alien = "\U0001F47D"; // 👽
+                    Create(
+                        "dogs",
+                        $"{alien}{alien}{alien}",
+                        "trees");
+                    _vimBuffer.ProcessNotation(@"l<C-q>jjI#<Esc>");
+                    Assert.Equal(
+                        new[]
+                        {
+                            "d#ogs",
+                            $"#{alien}{alien}{alien}",
+                            "t#rees"
+                        },
+                        _textBuffer.GetLines());
+                }
+
+                [WpfFact]
+                public void MiddleOfSurrogatePairNonFirstColumn()
+                {
+                    const string alien = "\U0001F47D"; // 👽
+                    Create(
+                        "dogs",
+                        $"{alien}{alien}{alien}",
+                        "trees");
+                    _vimBuffer.ProcessNotation(@"lll<C-q>jjI#<Esc>");
+                    Assert.Equal(
+                        new[]
+                        {
+                            "dog#s",
+                            $"{alien}#{alien}{alien}",
+                            "tre#es"
+                        },
+                        _textBuffer.GetLines());
+                }
+
+                [WpfFact]
+                public void Normal()
+                {
+                    const string alien = "\U0001F47D"; // 👽
+                    Create(
+                        "doggies",
+                        $"{alien}{alien}{alien}",
+                        "trees");
+                    _vimBuffer.ProcessNotation(@"ll<C-q>jjI#<Esc>");
+                    Assert.Equal(
+                        new[]
+                        {
+                            "do#ggies",
+                            $"{alien}#{alien}{alien}",
+                            "tr#ees"
+                        },
+                        _textBuffer.GetLines());
+                }
+
+                [WpfFact]
+                public void EndOfLine()
+                {
+                    const string alien = "\U0001F47D"; // 👽
+                    Create(
+                        "dos",
+                        $"{alien}",
+                        "bi");
+                    _vimBuffer.ProcessNotation(@"ll<C-q>jjIg<Esc>");
+                    Assert.Equal(
+                        new[]
+                        {
+                            "dogs",
+                            $"{alien}g",
+                            "big",
+                        },
+                        _textBuffer.GetLines());
+                }
+
+                [WpfFact]
+                public void StartingOnSurrogatePair()
+                {
+                    const string alien = "\U0001F47D"; // 👽
+                    Create(
+                        $"{alien}{alien}{alien}",
+                        "dogs",
+                        "trees");
+                    _vimBuffer.ProcessNotation(@"l<C-q>jjI#<Esc>");
+                    Assert.Equal(
+                        new[]
+                        {
+                            $"{alien}#{alien}{alien}",
+                            "do#gs",
+                            "tr#ees",
+                        },
+                        _textBuffer.GetLines());
+                }
+            }
+
             public sealed class InsertTabTest : BlockInsertTest
             {
                 /// <summary>


### PR DESCRIPTION
This addresses block insert around surrogate pairs. Particularly when
the block insert column is in the middle of a wide surrogate pair. This
should be done by pretending the column was the start of the surrogate
pair. This is different than wide characters which are not surrogate
pairs; those are converted to spaces first and then block insert occurs
in those spaces.

closes #2344