### PR TITLE
Simple tooltip for the marks

### DIFF
--- a/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphFactory.cs
+++ b/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphFactory.cs
@@ -28,6 +28,7 @@ namespace Vim.UI.Wpf.Implementation.MarkGlyph
                 var foregroundBrush = textRunProperties.ForegroundBrush;
                 var typeface = textRunProperties.Typeface;
                 var fontSize = textRunProperties.FontRenderingEmSize;
+                var tooltip = $"VsVim Marks {chars}";
 
                 // Don't display any more than three mark characters.
                 if (chars.Length > 3)
@@ -52,6 +53,7 @@ namespace Vim.UI.Wpf.Implementation.MarkGlyph
                     FontWeight = typeface.Weight,
                     FontStyle = typeface.Style,
                     FontSize = fontSize,
+                    ToolTip = tooltip,
                 };
 
                 return textBlock;


### PR DESCRIPTION
Adds a simple tooltip display for our marks. Helps in a couple of cases:

1. The glyph currently caps the display at three marks. This is practical given there is limited space here. The tooltip though can contain all of the marks. 
1. Helps explain what the glyphs are. Had a couple of coworkers ask what all of the `.[]` were showing up in the well after updating VsVim. Once I pointed it it was the marks they had they were pretty happy about the feature. 

closes #2354