### PR TITLE
Fix discriminated union names

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -17,11 +17,11 @@ open StringBuilderExtensions
 [<NoComparison>]
 [<StructuralEquality>]
 type internal NumberValue =
-    | Decimal of int64
-    | Octal of uint64
-    | Hex of uint64
-    | Binary of uint64
-    | Alpha of char
+    | Decimal of Decimal: int64
+    | Octal of Octal: uint64
+    | Hex of Hex: uint64
+    | Binary of Binary: uint64
+    | Alpha of Alpha: char
 
     with
 

--- a/Src/VimCore/HistoryUtil.fs
+++ b/Src/VimCore/HistoryUtil.fs
@@ -7,7 +7,7 @@ namespace Vim
 [<NoEquality>]
 type HistoryState =
     | Empty 
-    | Index of (string list) * int
+    | Index of HistoryList: (string list) * Index: int
 
 [<RequireQualifiedAccess>]
 [<NoComparison>]
@@ -19,7 +19,7 @@ type HistoryCommand =
     | Cancel
     | Back
     | Paste
-    | PasteSpecial of WordKind
+    | PasteSpecial of WordKind: WordKind
     | Clear
 
 type internal HistorySession<'TData, 'TResult>

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -17,10 +17,10 @@ type internal BackspaceCommand =
     | None
 
     /// Backspace over the set number of characters
-    | Characters of int
+    | Characters of Count: int
 
     /// Replace the number of characters with the specified string
-    | Replace of int * string
+    | Replace of Count: int * ReplaceText: string
 
 /// This type houses the functionality for many of the insert mode commands
 type internal InsertUtil

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -138,9 +138,9 @@ type InsertKind =
 
     /// This Insert is a repeat operation this holds the count and 
     /// whether or not a newline should be inserted after the text
-    | Repeat of int * bool * TextChange
+    | Repeat of Count: int * AddNewLine: bool * TextChange: TextChange
 
-    | Block of bool * BlockSpan
+    | Block of AtEndOfLine: bool * BlockSpan: BlockSpan
 
 /// The CTRL-R command comes in a number of varieties which really come down to just the 
 /// following options.  Detailed information is available on ':help i_CTRL-R_CTRL-R'
@@ -165,14 +165,14 @@ type PasteFlags =
 type ActiveEditItem = 
 
     /// In the middle of a word completion session
-    | WordCompletion of IWordCompletionSession 
+    | WordCompletion of WordCompletionSession: IWordCompletionSession 
 
     /// In the middle of a paste operation.  Waiting for the register to paste from
     | Paste 
 
     /// In the middle of one of the special paste operations.  The provided flags should 
     /// be passed along to the final Paste operation
-    | PasteSpecial of PasteFlags
+    | PasteSpecial of PasteFlag: PasteFlags
 
     /// In Replace mode, will overwrite using the selected Register
     | OverwriteReplace
@@ -184,7 +184,7 @@ type ActiveEditItem =
     | Digraph1
 
     /// In the middle of a digraph operation. Wait for the second digraph key
-    | Digraph2 of KeyInput
+    | Digraph2 of KeyInput: KeyInput
 
     /// No active items
     | None
@@ -211,8 +211,8 @@ type InsertSessionData = {
 
 [<RequireQualifiedAccess>]
 type RawInsertCommand =
-    | InsertCommand of KeyInputSet * InsertCommand * CommandFlags
-    | CustomCommand of (KeyInput -> ProcessResult)
+    | InsertCommand of KeyInputSet: KeyInputSet * InsertCommand: InsertCommand * CommandFlags: CommandFlags
+    | CustomCommand of CustomFunc: (KeyInput -> ProcessResult)
 
 type internal InsertMode
     ( 

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -952,7 +952,7 @@ type QuotedStringData =  {
 type VisualMotionResult =
 
     /// The mapping succeeded
-    | Succeeded of MotionResult
+    | Succeeded of MotionResult: MotionResult
 
     /// The motion simply produced no data
     | FailedNoMotionResult

--- a/Src/VimCore/UndoRedoOperations.fs
+++ b/Src/VimCore/UndoRedoOperations.fs
@@ -15,14 +15,14 @@ type UndoRedoData =
     /// The stack contains 'count' normal undo / redo transactions which line up
     /// with Vim behavior.  The count is kept here instead of having a stack of 'count'
     /// depth in order to keep memory allocations minimal.
-    | Normal of int
+    | Normal of Count: int
 
     /// The stack contains 'count' normal undo / redo transactions which line up 
     /// with a single Vim undo / redo transaction.  
     ///
     /// The bool is true when this is a closed linked transaction.  It has been fully completed
     /// and is no longer being built by closing transactions
-    | Linked of int * bool
+    | Linked of Count: int * IsCompleted: bool
 
 [<RequireQualifiedAccess>]
 type TransactionCloseResult =

--- a/Test/VimCoreTest/CodeHygieneTest.cs
+++ b/Test/VimCoreTest/CodeHygieneTest.cs
@@ -113,7 +113,7 @@ namespace Vim.UnitTest
                 {
                     any = true;
                     var anyItem = false;
-                    foreach (var prop in type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly))
+                    foreach (var prop in type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
                     {
                         if (prop.Name.StartsWith("Item"))
                         {
@@ -124,7 +124,7 @@ namespace Vim.UnitTest
 
                     if (anyItem)
                     {
-                        list.Add($"{type.BaseType.Name}.{type.Name} values do not have an expliict name");
+                        list.Add($"{type.BaseType.Name}.{type.Name} values do not have an explicit name");
                     }
                 }
 

--- a/Test/VimCoreTest/UndoRedoOperationsTest.cs
+++ b/Test/VimCoreTest/UndoRedoOperationsTest.cs
@@ -408,9 +408,9 @@ namespace Vim.UnitTest
                 _undoRedoOperationsRaw.Undo(1);
                 Assert.Equal(1, _undoCount);
                 Assert.Equal(1, _undoRedoOperationsRaw.UndoStack.Length);
-                Assert.Equal(9, _undoRedoOperationsRaw.UndoStack.Head.AsNormal().Item);
+                Assert.Equal(9, _undoRedoOperationsRaw.UndoStack.Head.AsNormal().Count);
                 Assert.Equal(1, _undoRedoOperationsRaw.RedoStack.Length);
-                Assert.Equal(1, _undoRedoOperationsRaw.RedoStack.Head.AsNormal().Item);
+                Assert.Equal(1, _undoRedoOperationsRaw.RedoStack.Head.AsNormal().Count);
             }
 
             /// <summary>
@@ -510,7 +510,7 @@ namespace Vim.UnitTest
                 _undoRedoOperations.Redo(1);
                 Assert.Equal(1, _redoCount);
                 Assert.Equal(1, _undoRedoOperationsRaw.RedoStack.Length);
-                Assert.Equal(9, _undoRedoOperationsRaw.RedoStack.Head.AsNormal().Item);
+                Assert.Equal(9, _undoRedoOperationsRaw.RedoStack.Head.AsNormal().Count);
             }
         }
 


### PR DESCRIPTION
The check to force the use of named members in discriminated unions wasn't catching internal types. This fixes the rules and the found violations.

closes #2374 