### PR TITLE
Fix MEF composition error

### DIFF
--- a/Test/VsVimSharedTest/VsVimHostTest.cs
+++ b/Test/VsVimSharedTest/VsVimHostTest.cs
@@ -82,6 +82,7 @@ namespace Vim.VisualStudio.UnitTest
                 _factory.Create<ISharedServiceFactory>(MockBehavior.Loose).Object,
                 _vimApplicationSettings.Object,
                 _extensionAdapterBroker.Object,
+                ProtectedOperations,
                 sp.Object);
             _host = _hostRaw;
         }


### PR DESCRIPTION
This fixes a MEF composition error that occurs more frequently on older
versions of Visual Studio. There appears to be a timing issue with
accessing the output window on the UI thread during composition.

Unfortunately I'm not able to see what is going wrong as it's happening
within the DTE layer. The fix though is pretty straight forward:

1. Delay the initialization of the Output Window to idle
1. Catch exceptions coming from that code and raise errors vs. letting
them be unhandled

closes #2249