### PR TITLE
Remove ISmartTagBroker

### DIFF
--- a/Src/VimCore/MefInterfaces.fs
+++ b/Src/VimCore/MefInterfaces.fs
@@ -23,9 +23,6 @@ type IDisplayWindowBroker =
     // Is Quick Info active
     abstract IsQuickInfoActive: bool 
 
-    /// Is there a smart tip window active
-    abstract IsSmartTagSessionActive: bool
-
     /// Dismiss any completion windows on the given ITextView
     abstract DismissDisplayWindows: unit -> unit
 

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -630,7 +630,7 @@ type internal InsertMode
 
         x.ApplyAfterEdits()
 
-        if _broker.IsCompletionActive || _broker.IsSignatureHelpActive || _broker.IsQuickInfoActive || _broker.IsSmartTagSessionActive then
+        if _broker.IsCompletionActive || _broker.IsSignatureHelpActive || _broker.IsQuickInfoActive then
             _broker.DismissDisplayWindows()
 
         // Save the last edit point before moving the column to the left

--- a/Src/VimWpf/Implementation/Misc/DisplayWindowBroker.cs
+++ b/Src/VimWpf/Implementation/Misc/DisplayWindowBroker.cs
@@ -13,20 +13,17 @@ namespace Vim.UI.Wpf.Implementation.Misc
         private readonly ITextView _textView;
         private readonly ICompletionBroker _completionBroker;
         private readonly ISignatureHelpBroker _signatureHelpBroker;
-        private readonly ISmartTagBroker _smartTagBroker;
         private readonly IQuickInfoBroker _quickInfoBroker;
 
         internal DisplayWindowBroker(
             ITextView textView,
             ICompletionBroker completionBroker,
             ISignatureHelpBroker signatureHelpBroker,
-            ISmartTagBroker smartTagBroker,
             IQuickInfoBroker quickInfoBroker)
         {
             _textView = textView;
             _completionBroker = completionBroker;
             _signatureHelpBroker = signatureHelpBroker;
-            _smartTagBroker = smartTagBroker;
             _quickInfoBroker = quickInfoBroker;
         }
 
@@ -45,24 +42,6 @@ namespace Vim.UI.Wpf.Implementation.Misc
         bool IDisplayWindowBroker.IsSignatureHelpActive
         {
             get { return _signatureHelpBroker.IsSignatureHelpActive(_textView); }
-        }
-
-        bool IDisplayWindowBroker.IsSmartTagSessionActive
-        {
-            get
-            {
-                if (_smartTagBroker.IsSmartTagActive(_textView))
-                {
-                    foreach (var session in _smartTagBroker.GetSessions(_textView))
-                    {
-                        if (session.State == SmartTagState.Expanded)
-                        {
-                            return true;
-                        }
-                    }
-                }
-                return false;
-            }
         }
 
         ITextView IDisplayWindowBroker.TextView
@@ -101,19 +80,16 @@ namespace Vim.UI.Wpf.Implementation.Misc
 
         private readonly ICompletionBroker _completionBroker;
         private readonly ISignatureHelpBroker _signatureHelpBroker;
-        private readonly ISmartTagBroker _smartTagBroker;
         private readonly IQuickInfoBroker _quickInfoBroker;
 
         [ImportingConstructor]
         internal DisplayWindowBrokerFactoryService(
             ICompletionBroker completionBroker,
             ISignatureHelpBroker signatureHelpBroker,
-            ISmartTagBroker smartTagBroker,
             IQuickInfoBroker quickInfoBroker)
         {
             _completionBroker = completionBroker;
             _signatureHelpBroker = signatureHelpBroker;
-            _smartTagBroker = smartTagBroker;
             _quickInfoBroker = quickInfoBroker;
         }
 
@@ -125,7 +101,6 @@ namespace Vim.UI.Wpf.Implementation.Misc
                         textView,
                         _completionBroker,
                         _signatureHelpBroker,
-                        _smartTagBroker,
                         _quickInfoBroker));
         }
     }

--- a/Src/VsVimShared/Extensions.cs
+++ b/Src/VsVimShared/Extensions.cs
@@ -770,8 +770,7 @@ namespace Vim.VisualStudio
             return
                 displayWindowBroker.IsCompletionActive ||
                 displayWindowBroker.IsQuickInfoActive ||
-                displayWindowBroker.IsSignatureHelpActive ||
-                displayWindowBroker.IsSmartTagSessionActive;
+                displayWindowBroker.IsSignatureHelpActive;
         }
 
         #endregion

--- a/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
+++ b/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
@@ -89,13 +89,6 @@ namespace Vim.VisualStudio.Implementation.Misc
                     keyInput.Key == VimKey.Back;
             }
 
-            if (_broker.IsSmartTagSessionActive)
-            {
-                return
-                    keyInput.IsArrowKey ||
-                    keyInput == KeyInputUtil.EnterKey;
-            }
-
             if (_broker.IsSignatureHelpActive)
             {
                 return keyInput.IsArrowKey;

--- a/Test/VimCoreTest/InsertModeTest.cs
+++ b/Test/VimCoreTest/InsertModeTest.cs
@@ -77,7 +77,6 @@ namespace Vim.UnitTest
             _broker.SetupGet(x => x.IsCompletionActive).Returns(false);
             _broker.SetupGet(x => x.IsQuickInfoActive).Returns(false);
             _broker.SetupGet(x => x.IsSignatureHelpActive).Returns(false);
-            _broker.SetupGet(x => x.IsSmartTagSessionActive).Returns(false);
             _insertUtil = _factory.Create<IInsertUtil>();
             _insertUtil.Setup(x => x.NewUndoSequence());
             _motionUtil = _factory.Create<IMotionUtil>();
@@ -374,7 +373,6 @@ namespace Vim.UnitTest
                 _broker.SetupGet(x => x.IsCompletionActive).Returns(false).Verifiable();
                 _broker.SetupGet(x => x.IsQuickInfoActive).Returns(false).Verifiable();
                 _broker.SetupGet(x => x.IsSignatureHelpActive).Returns(false).Verifiable();
-                _broker.SetupGet(x => x.IsSmartTagSessionActive).Returns(false).Verifiable();
                 SetupRunCompleteMode(true);
                 var res = _mode.Process(KeyInputUtil.EscapeKey);
                 Assert.True(res.IsSwitchMode(ModeKind.Normal));
@@ -390,7 +388,6 @@ namespace Vim.UnitTest
             {
                 _textView.SetText("hello world", "", "again");
                 _textView.MoveCaretTo(_textView.GetLine(1).Start.Position, 4);
-                _broker.SetupGet(x => x.IsSmartTagSessionActive).Returns(false).Verifiable();
                 SetupRunCompleteMode(true);
                 _mode.Process(KeyInputUtil.EscapeKey);
                 _factory.Verify();

--- a/Test/VimWpfTest/DisplayWindowBrokerTest.cs
+++ b/Test/VimWpfTest/DisplayWindowBrokerTest.cs
@@ -11,7 +11,6 @@ namespace Vim.UI.Wpf.UnitTest
 {
     public class DisplayWindowBrokerTest
     {
-        private readonly Mock<ISmartTagBroker> _smartTagBroker;
         private readonly Mock<ICompletionBroker> _completionBroker;
         private readonly Mock<ISignatureHelpBroker> _signatureBroker;
         private readonly Mock<IQuickInfoBroker> _quickInfoBroker;
@@ -21,7 +20,6 @@ namespace Vim.UI.Wpf.UnitTest
 
         public DisplayWindowBrokerTest()
         {
-            _smartTagBroker = new Mock<ISmartTagBroker>();
             _completionBroker = new Mock<ICompletionBroker>();
             _signatureBroker = new Mock<ISignatureHelpBroker>();
             _quickInfoBroker = new Mock<IQuickInfoBroker>();
@@ -30,59 +28,8 @@ namespace Vim.UI.Wpf.UnitTest
                 _textView.Object,
                 _completionBroker.Object,
                 _signatureBroker.Object,
-                _smartTagBroker.Object,
                 _quickInfoBroker.Object);
             _broker = _brokerRaw;
-        }
-
-        [Fact]
-        public void IsSmartTagSessionActive1()
-        {
-            _smartTagBroker.Setup(x => x.IsSmartTagActive(_textView.Object)).Returns(false).Verifiable();
-            Assert.False(_broker.IsSmartTagSessionActive);
-            _smartTagBroker.Verify();
-        }
-
-        [Fact]
-        public void IsSmartTagSessionActive2()
-        {
-            _smartTagBroker.Setup(x => x.IsSmartTagActive(_textView.Object)).Returns(true).Verifiable();
-            _smartTagBroker
-                .Setup(x => x.GetSessions(_textView.Object))
-                .Returns((new List<ISmartTagSession>()).AsReadOnly())
-                .Verifiable();
-            Assert.False(_broker.IsSmartTagSessionActive);
-            _smartTagBroker.Verify();
-        }
-
-        [Fact]
-        public void IsSmartTagSessionActive3()
-        {
-            var session = new Mock<ISmartTagSession>();
-            session.SetupGet(x => x.State).Returns(SmartTagState.Collapsed);
-            var list = Enumerable.Repeat(session.Object, 1).ToList().AsReadOnly();
-            _smartTagBroker.Setup(x => x.IsSmartTagActive(_textView.Object)).Returns(true).Verifiable();
-            _smartTagBroker
-                .Setup(x => x.GetSessions(_textView.Object))
-                .Returns(list)
-                .Verifiable();
-            Assert.False(_broker.IsSmartTagSessionActive);
-            _smartTagBroker.Verify();
-        }
-
-        [Fact]
-        public void IsSmartTagSessionActive4()
-        {
-            var session = new Mock<ISmartTagSession>();
-            session.SetupGet(x => x.State).Returns(SmartTagState.Expanded);
-            var list = Enumerable.Repeat(session.Object, 1).ToList().AsReadOnly();
-            _smartTagBroker.Setup(x => x.IsSmartTagActive(_textView.Object)).Returns(true).Verifiable();
-            _smartTagBroker
-                .Setup(x => x.GetSessions(_textView.Object))
-                .Returns(list)
-                .Verifiable();
-            Assert.True(_broker.IsSmartTagSessionActive);
-            _smartTagBroker.Verify();
         }
 
         [Fact]

--- a/Test/VsVimSharedTest/Utils/VsSimulation.cs
+++ b/Test/VsVimSharedTest/Utils/VsSimulation.cs
@@ -319,7 +319,6 @@ namespace Vim.VisualStudio.UnitTest.Utils
             _displayWindowBroker.SetupGet(x => x.IsCompletionActive).Returns(false);
             _displayWindowBroker.SetupGet(x => x.IsQuickInfoActive).Returns(false);
             _displayWindowBroker.SetupGet(x => x.IsSignatureHelpActive).Returns(false);
-            _displayWindowBroker.SetupGet(x => x.IsSmartTagSessionActive).Returns(false);
 
             _vimApplicationSettings = _factory.Create<IVimApplicationSettings>();
             _vimApplicationSettings.SetupGet(x => x.UseEditorDefaults).Returns(true);


### PR DESCRIPTION
This type is deleted in Dev16 which means VsVim can't load as long as it
continues to use the type in the core DLLs. I considered moving the
usage to the VS specific DLLs. However upon further inspection I don't
think the usage is needed anymore. Most of the logic is ensuring we
allow arrow keys to pass through to the menu for smart tags / ligt
bulbs. That happens even with all of the smart tag logic disabled.

Given that just deleting the implementation for now. Can revisit with a
VS specific approach if we end up finding the need for it.