### PR TITLE
Make assembly version same as product version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,10 @@
     <OutputPath>$(BinariesPath)$(Configuration)\$(MSBuildProjectName)</OutputPath>
     <BaseIntermediateOutputPath>$(BinariesPath)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
 
+    <AssemblyVersion>2.6.0.0</AssemblyVersion>
+    <FileVersion>$(AssemblyVersion)</FileVersion>
+    <InformationalVersion>$(AssemblyVersion)</InformationalVersion>
+
     <!-- The version of VS that should be targetted for testing. Prefer the
          current VS version but allow it to be changed via environment 
          variable for testing other versions --> 

--- a/Scripts/Deploy.ps1
+++ b/Scripts/Deploy.ps1
@@ -124,6 +124,12 @@ function Test-Version() {
     if ($manifestVersion -ne $version) { 
         throw "The version $version doesn't match up with the manifest version of $manifestVersion" 
     }
+
+    $data = [xml](Get-Content "Directory.Build.props")
+    $assemblyVersion = $data.Project.PropertyGroup[0].AssemblyVersion
+    if ($assemblyVersion -ne $version) { 
+        throw "The version $version doesn't match up with the assembly version of $assemblyVersion" 
+    }
 }
 
 

--- a/Src/VimCore/AssemblyInfo.fs
+++ b/Src/VimCore/AssemblyInfo.fs
@@ -3,9 +3,11 @@
 #light
 namespace Vim
 
+open System.Reflection
 open System.Runtime.CompilerServices
 
 [<assembly:Extension()>]
+[<assembly:AssemblyVersion(VimConstants.VersionNumber)>]
 [<assembly:InternalsVisibleTo("Vim.Core.UnitTest")>]
 [<assembly:InternalsVisibleTo("Vim.UnitTest.Utils")>]
 [<assembly:InternalsVisibleTo("Vim.UI.Wpf.UnitTest")>]

--- a/Src/VimCore/Constants.fs
+++ b/Src/VimCore/Constants.fs
@@ -36,12 +36,7 @@ module VimConstants =
     [<Literal>]
     let MainKeyProcessorName = "VsVim";
 
-#if DEBUG
-    [<Literal>]
-    let VersionNumber = "2.6.99.99 Debug"
-#else
     [<Literal>]
     let VersionNumber = "2.6.0.0"
-#endif
 
 

--- a/Src/VimWpf/Properties/AssemblyInfo.cs
+++ b/Src/VimWpf/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Vim;
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Test/VsVimSharedTest/CodeHygieneTest.cs
+++ b/Test/VsVimSharedTest/CodeHygieneTest.cs
@@ -15,6 +15,18 @@ namespace Vim.VisualStudio.UnitTest
     {
         private readonly Assembly _assembly = typeof(CodeHygieneTest).Assembly;
 
+        private static Assembly[] GetCoreAssemblyList()
+        {
+            return new[]
+            {
+                typeof(IVimHost).Assembly,
+                typeof(VimHost).Assembly,
+                typeof(VsVimHost).Assembly,
+                typeof(VsVimPackage).Assembly,
+                typeof(ISharedService).Assembly,
+            };
+        }
+
         [Fact]
         public void TestNamespace()
         {
@@ -58,14 +70,7 @@ namespace Vim.VisualStudio.UnitTest
         [Fact]
         public void FSharpCoreReferences()
         {
-            var assemblyList = new[]
-            {
-                typeof(IVimHost).Assembly,
-                typeof(VimHost).Assembly,
-                typeof(VsVimHost).Assembly
-            };
-
-            Assert.Equal(assemblyList.Length, assemblyList.Distinct().Count());
+            var assemblyList = GetCoreAssemblyList();
 
             foreach (var assembly in assemblyList)
             {
@@ -73,6 +78,22 @@ namespace Vim.VisualStudio.UnitTest
                 {
                     Assert.NotEqual("FSharp.Core", assemblyRef.Name, StringComparer.OrdinalIgnoreCase);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Make sure the core assemblies all have the same version and that it matches the release 
+        /// version.
+        /// </summary>
+        [Fact]
+        public void AssemblyVersion()
+        {
+            var assemblyList = GetCoreAssemblyList();
+            var version = Version.Parse(VimConstants.VersionNumber);
+            foreach (var assembly in assemblyList)
+            {
+                var assemblyVersion = assembly.GetName().Version;
+                Assert.Equal(version, assemblyVersion);
             }
         }
     }

--- a/Test/VsVimSharedTest/VsVimSharedTest.csproj
+++ b/Test/VsVimSharedTest/VsVimSharedTest.csproj
@@ -43,6 +43,7 @@
     <ProjectReference Include="..\..\Src\VimCore\VimCore.fsproj" />
     <ProjectReference Include="..\..\Src\VimWpf\VimWpf.csproj" />
     <ProjectReference Include="..\..\Src\VsVimShared\VsVimShared.csproj" />
+    <ProjectReference Include="..\..\Src\VsVim\VsVim.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\VsCommands.txt" />


### PR DESCRIPTION
This change will enforce the assembly version information matches up
with the product version.

Having the assembly version match the product version can potentially
help track down installation / MEF issues. The assembly version is
included in most log files even on load failures. Seeing if the versions
match the product version can help identify what type of problem is
happening.

For instance if they don't match then there is some type of installation
or MEF corruption issue at hand.

Related to #2400