### PR TITLE
Typo fix in unit tests

### DIFF
--- a/Test/VimCoreTest/InsertModeTest.cs
+++ b/Test/VimCoreTest/InsertModeTest.cs
@@ -556,7 +556,7 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
-            /// Ensure that CTRL-N is mapped to MovePrevious in the IWordCompletionSession
+            /// Ensure that CTRL-P is mapped to MovePrevious in the IWordCompletionSession
             /// </summary>
             [WpfFact]
             public void Process_WordCompletion_CtrlP()


### PR DESCRIPTION
Well it's a long story how I ended up in unit tests, noticed typo in comment, might as well fix it while still in visual studio...