### PR TITLE
Mark glyph improvements

### DIFF
--- a/Src/VimWpf/Implementation/MarkGlyph/MarkDisplayUtil.cs
+++ b/Src/VimWpf/Implementation/MarkGlyph/MarkDisplayUtil.cs
@@ -10,7 +10,7 @@ namespace Vim.UI.Wpf.Implementation.MarkGlyph
     [Export(typeof(IMarkDisplayUtil))]
     internal sealed class MarkDisplayUtil : IMarkDisplayUtil
     {
-        private string _hideMarks;
+        private string _hideMarks = "";
 
         public string HideMarks => _hideMarks;
         public event EventHandler HideMarksChanged;

--- a/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphFactoryProvider.cs
+++ b/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphFactoryProvider.cs
@@ -11,7 +11,7 @@ namespace Vim.UI.Wpf.Implementation.MarkGlyph
     [TextViewRole(PredefinedTextViewRoles.Editable)]
     [TagType(typeof(MarkGlyphTag))]
     [Name("MarkGlyph")]
-    [Order(After = "VsTextMarker")]
+    [Order(Before = "VsTextMarker")]
     internal sealed class MarkGlyphFactoryProvider : IGlyphFactoryProvider
     {
         private readonly IVim _vim;

--- a/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphTaggerSource.cs
+++ b/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphTaggerSource.cs
@@ -158,8 +158,8 @@ namespace Vim.UI.Wpf.Implementation.MarkGlyph
                         --_activeMarks;
                         result = true;
                     }
-                    _lineNumberMap.Remove(mark);
                 }
+                _lineNumberMap[mark] = -1;
                 return result;
             }
 

--- a/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphTaggerSource.cs
+++ b/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphTaggerSource.cs
@@ -149,18 +149,18 @@ namespace Vim.UI.Wpf.Implementation.MarkGlyph
             // Check first whether this mark is hidden.
             if (IsMarkHidden(mark))
             {
-                if (_lineNumberMap.TryGetValue(mark, out int lineNumber) && lineNumber != -1)
+                var result = false;
+                if (_lineNumberMap.TryGetValue(mark, out int lineNumber))
                 {
-                    // Transition from active to inactive.
-                    --_activeMarks;
-                    return true;
+                    if (lineNumber != -1)
+                    {
+                        // Transition from active to inactive.
+                        --_activeMarks;
+                        result = true;
+                    }
+                    _lineNumberMap.Remove(mark);
                 }
-                else
-                {
-                    // It might become unhidden.
-                    _lineNumberMap[mark] = -1;
-                }
-                return false;
+                return result;
             }
 
             // Get old line number.

--- a/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphTaggerSource.cs
+++ b/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphTaggerSource.cs
@@ -123,7 +123,7 @@ namespace Vim.UI.Wpf.Implementation.MarkGlyph
             UpdateAllMarks();
         }
 
-        HashSet<char> ExpandHideMarksSetting(string setting)
+        private static HashSet<char> ExpandHideMarksSetting(string setting)
         {
             var result = new HashSet<char>();
             if (setting == "-")
@@ -136,8 +136,14 @@ namespace Vim.UI.Wpf.Implementation.MarkGlyph
                 var c1 = setting[i];
                 if (i + 2 < setting.Length && setting[i + 1] == '-')
                 {
-                    // Expand range, e.g. 'a-z'.
+                    // Expand range, e.g. 'a-z' or 'z-a'.
                     var c2 = setting[i + 2];
+                    if (c2 < c1)
+                    {
+                        var tmp = c1;
+                        c1 = c2;
+                        c2 = tmp;
+                    }
                     for (var c = c1; c <= c2; c++)
                     {
                         result.Add(c);

--- a/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphTaggerSource.cs
+++ b/Src/VimWpf/Implementation/MarkGlyph/MarkGlyphTaggerSource.cs
@@ -21,7 +21,7 @@ namespace Vim.UI.Wpf.Implementation.MarkGlyph
 
         private bool _isVisible;
         private int _activeMarks;
-        private string _hideMarks;
+        private HashSet<char> _hideMarks;
 
         private EventHandler _changedEvent;
 
@@ -34,7 +34,7 @@ namespace Vim.UI.Wpf.Implementation.MarkGlyph
             _isVisible = true;
             _activeMarks = 0;
             _markDisplayUtil = markDisplayUtil;
-            _hideMarks = _markDisplayUtil.HideMarks;
+            _hideMarks = ExpandHideMarksSetting(_markDisplayUtil.HideMarks);
 
             LoadNewBufferMarks();
             CachePairs();
@@ -119,8 +119,38 @@ namespace Vim.UI.Wpf.Implementation.MarkGlyph
 
         private void OnHideMarksChanged(object sender, EventArgs e)
         {
-            _hideMarks = _markDisplayUtil.HideMarks;
+            _hideMarks = ExpandHideMarksSetting(_markDisplayUtil.HideMarks);
             UpdateAllMarks();
+        }
+
+        HashSet<char> ExpandHideMarksSetting(string setting)
+        {
+            var result = new HashSet<char>();
+            if (setting == "-")
+            {
+                setting = "!-~";
+            }
+            var i = 0;
+            while (i < setting.Length)
+            {
+                var c1 = setting[i];
+                if (i + 2 < setting.Length && setting[i + 1] == '-')
+                {
+                    // Expand range, e.g. 'a-z'.
+                    var c2 = setting[i + 2];
+                    for (var c = c1; c <= c2; c++)
+                    {
+                        result.Add(c);
+                    }
+                    i += 3;
+                }
+                else
+                {
+                    result.Add(c1);
+                    i += 1;
+                }
+            }
+            return result;
         }
 
         private void OnIsVisibleChanged(object sender, TextViewEventArgs e)


### PR DESCRIPTION
#### Issues

- Fixes #2402
- Closes #2419
- Closes #2425

#### Changes

- Fixes a null-reference exception if `MarkDisplayUtil` is accessed before it is synced with the setting
- Fixes hiding or unhiding marks while the editor is running
- Moves mark glyphs behind other glyphs (e.g., breakpoints) in the indicator margin
- Adds the capability to express a range of marks to hide, e.g. `a-z` to hide all lettered local marks
- Adds the capability to easily hide all marks using `:set vsvim_hidemarks=-`