### PR TITLE
Avoid clearing the last edit point for multi-part text changes

### DIFF
--- a/Src/VimCore/Modes_Insert_Components.fs
+++ b/Src/VimCore/Modes_Insert_Components.fs
@@ -252,9 +252,14 @@ type internal TextChangeTracker
                 let newSpan = SnapshotSpan(args.After, change.NewSpan)
                 _operations.RecordLastChange oldSpan newSpan
         else
-            // When there are multiple changes it is usually the result of a projection 
-            // buffer edit coming from a web page edit.  For now that's unsupported
-            _vimTextBuffer.LastEditPoint <- None
+            // When there are multiple changes it is usually the result of a
+            // projection  buffer edit coming from a web page edit.  For now
+            // that's unsupported. Another possible cause is an extension that
+            // mass-edits line endings, e.g. see issue #2440.
+            //
+            // If we do nothing, the automatic tracking will correctly update
+            // the previous last edit point in its own text change handler.
+            ()
 
     /// Attempt to merge the change operations together
     member x.MergeChange oldTextChange (oldChange: ITextChange) newTextChange (newChange: ITextChange) =

--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -779,6 +779,27 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
+            /// Make sure external multi-part edits don't clear the last edit point
+            /// </summary>
+            [WpfFact]
+            public void InsertNonVim_MultiPart()
+            {
+                // Reported in issue #2440.
+                Create("big", "bad", "");
+                _textBuffer.Insert(3, " cat");
+                Assert.Equal(new[] { "big cat", "bad", "", }, _textBuffer.GetLines());
+                Assert.Equal(6, LastEditPoint.Value);
+                using (var edit = _textBuffer.CreateEdit())
+                {
+                    edit.Insert(_textBuffer.GetPointInLine(0, 0), "foo ");
+                    edit.Insert(_textBuffer.GetPointInLine(1, 0), "bar ");
+                    edit.Apply();
+                }
+                Assert.Equal(new[] { "foo big cat", "bar bad", "", }, _textBuffer.GetLines());
+                Assert.Equal(6, LastEditPoint.Value);
+            }
+
+            /// <summary>
             /// When there is a deletion of text then the LastEditPoint should point to the start
             /// of the deleted text
             /// </summary>


### PR DESCRIPTION
#### Issues

- Fixes #2440