### PR TITLE
Make incremental search asynchronous

### DIFF
--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -35,6 +35,7 @@ module internal CommonUtil =
                     Resources.Common_PatternNotFound
 
             statusUtil.OnError (format searchData.Pattern)
+        | SearchResult.Cancelled _ -> statusUtil.OnError Resources.Common_SearchCancelled
         | SearchResult.Error (_, msg) -> statusUtil.OnError msg
 
 type internal CommonOperations

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4080,9 +4080,6 @@ type IIncrementalSearchSession =
     /// Key that uniquely identifies this session
     abstract Key: obj
 
-    /// True when a search is occurring
-    abstract InSearch: bool
-
     /// When in the middle of a search this will return the SearchData for 
     /// the search
     abstract SearchData: SearchData 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4115,8 +4115,11 @@ type IncrementalSearchSessionEventArgs(_session: IIncrementalSearchSession) =
 
 type IIncrementalSearch = 
 
-    /// True when a search is occurring
-    abstract InSearch: bool
+    /// The active IIncrementalSearchSession
+    abstract ActiveSession: IIncrementalSearchSession option
+
+    /// True when there is an IIncrementalSearchSession in progress
+    abstract HasActiveSession: bool
 
     /// True when the search is in a paste wait state
     abstract InPasteWait: bool
@@ -4129,6 +4132,9 @@ type IIncrementalSearch =
     abstract CurrentSearchText: string
 
     abstract CreateSession: searchPath: SearchPath -> IIncrementalSearchSession
+
+    /// Cancel the active session if there is one.
+    abstract CancelSession: unit -> unit
 
     [<CLIEvent>]
     abstract SessionCreated: IDelegateEvent<System.EventHandler<IncrementalSearchSessionEventArgs>>

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4077,6 +4077,9 @@ type IJumpList =
 
 type IIncrementalSearchSession = 
 
+    /// Key that uniquely identifies this session
+    abstract Key: obj
+
     /// True when a search is occurring
     abstract InSearch: bool
 
@@ -4086,6 +4089,12 @@ type IIncrementalSearchSession =
 
     /// When a search is complete within the session this will hold the result
     abstract SearchResult: SearchResult option
+
+    /// Start an incremental search in the ITextView
+    abstract Start: unit -> BindData<SearchResult>
+
+    /// Reset the search to the specified text
+    abstract ResetSearch: searchText: string -> unit
 
     /// Cancel an incremental search which is currently in progress
     abstract Cancel: unit -> unit
@@ -4099,10 +4108,12 @@ type IIncrementalSearchSession =
     [<CLIEvent>]
     abstract SessionComplete: IDelegateEvent<System.EventHandler<EventArgs>>
 
-type IIncrementalSearch = 
+type IncrementalSearchSessionEventArgs(_session: IIncrementalSearchSession) = 
+    inherit System.EventArgs()
 
-    /// Key that uniquely identifies this session
-    abstract Key: obj
+    member x.Session = _session
+
+type IIncrementalSearch = 
 
     /// True when a search is occurring
     abstract InSearch: bool
@@ -4113,10 +4124,14 @@ type IIncrementalSearch =
     /// The ITextStructureNavigator used for finding 'word' values in the ITextBuffer
     abstract WordNavigator: ITextStructureNavigator
 
-    /// Begin an incremental search in the ITextView
-    abstract Start: path: SearchPath -> BindData<SearchResult>
+    abstract CurrentSearchData: SearchData
 
+    abstract CurrentSearchText: string
 
+    abstract CreateSession: searchPath: SearchPath -> IIncrementalSearchSession
+
+    [<CLIEvent>]
+    abstract SessionCreated: IDelegateEvent<System.EventHandler<IncrementalSearchSessionEventArgs>>
 
 type RecordRegisterEventArgs(_register: Register, _isAppend: bool) =
     inherit System.EventArgs()

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -13,6 +13,7 @@ open System.IO
 open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
 open System.Collections.Generic
+open System.Threading.Tasks
 open Vim.Interpreter
 open System
 
@@ -3570,6 +3571,8 @@ and BindData<'T> = {
 
 } with
 
+    member x.CreateBindResult() = BindResult.NeedMoreInput x
+
     /// Used for BindData where there can only be a complete result for a given 
     /// KeyInput.
     static member CreateForKeyInput keyRemapMode valueFunc =
@@ -4080,6 +4083,13 @@ type IIncrementalSearchSession =
     /// Key that uniquely identifies this session
     abstract Key: obj
 
+    /// Whether or not the search has started
+    abstract IsStarted: bool
+
+    /// Whether or not the session is complete. True when the session has finished the search
+    /// or was cancelled.
+    abstract IsCompleted: bool
+
     /// When in the middle of a search this will return the SearchData for 
     /// the search
     abstract SearchData: SearchData 
@@ -4093,8 +4103,12 @@ type IIncrementalSearchSession =
     /// Reset the search to the specified text
     abstract ResetSearch: searchText: string -> unit
 
-    /// Cancel an incremental search which is currently in progress
+    /// Cancel the session without completing
     abstract Cancel: unit -> unit
+
+    /// This will resolve to SearchResult for the current value of SearchData once the
+    /// search is complete
+    abstract GetSearchResultAsync: unit -> Task<SearchResult>
 
     [<CLIEvent>]
     abstract SearchStart: IDelegateEvent<System.EventHandler<SearchDataEventArgs>>

--- a/Src/VimCore/IncrementalSearch.fs
+++ b/Src/VimCore/IncrementalSearch.fs
@@ -5,44 +5,128 @@ open Microsoft.VisualStudio.Text.Operations
 open Microsoft.VisualStudio.Text.Editor
 open Microsoft.VisualStudio.Text.Outlining
 open NullableUtil
+open System
+open System.Diagnostics
 open Vim.VimCoreExtensions
 
-type IncrementalSearchData = { 
-
-    /// Most recent result of the search
-    SearchResult: SearchResult
-
-    /// Most recent search text being usde
-    SearchText: string
-
-} with 
-
-    member x.SearchData = x.SearchResult.SearchData
-
-    static member Default = 
-        let searchData = SearchData("", SearchPath.Forward, false)
-        let searchResult = SearchResult.NotFound (searchData, false)
-        {
-            SearchResult = searchResult
-            SearchText = ""
-        }
-
+/// Represents an incremental search session. The session is created when the initial 
+/// `/` key is pressed and is updated until the session is completed, with enter, or 
+/// cancelled.
 type internal IncrementalSearchSession
     (
         _key: obj,
-        _historySession: IHistorySession<ITrackingPoint, SearchResult>,
-        _incrementalSearchData: IncrementalSearchData
+        _vimBuffer: IVimBuffer,
+        _operations: ICommonOperations,
+        _searchPath: SearchPath,
+        _isWrap: bool
     ) =
 
-    let mutable _incrementalSearchData = _incrementalSearchData
+    let mutable _searchData = SearchData("", _searchPath, _isWrap)
+    let mutable _searchResult : SearchResult option = None
+    let mutable _isActive = true
+    let _globalSettings = _vimBuffer.GlobalSettings
+    let _searchStart = StandardEvent<SearchDataEventArgs>()
+    let _searchEnd = StandardEvent<SearchResultEventArgs>()
+    let _sessionComplete = StandardEvent<EventArgs>()
 
     member x.Key = _key
+    member x.IsWrap = _isWrap
+    member x.IsActive = _isActive
+    member x.SearchPath = _searchPath
+    member x.SearchData = _searchData
+    member x.SearchResult = _searchResult
+    member x.IsSearchCompleted = Option.isSome _searchResult
 
-    member x.HistorySession = _historySession
+    /// There is a big gap between the behavior and documentation of key mapping for an 
+    /// incremental search operation.  The documentation properly documents the language
+    /// mapping in "help language-mapping" and 'help imsearch'.  But it doesn't document
+    /// that command mapping should used when 'imsearch' doesn't apply although it's
+    /// the practice in implementation
+    member x.RemapMode = KeyRemapMode.Command
 
-    member x.IncrementalSearchData 
-        with get() = _incrementalSearchData
-        and set value = _incrementalSearchData <- value
+    // Reset the view to it's original state.  We should only be doing this if the
+    // 'incsearch' option is set.  Otherwise the view shouldn't change during an 
+    // incremental search
+    member x.ResetView () =
+        if _globalSettings.IncrementalSearch then
+             _operations.EnsureAtCaret ViewFlags.Standard
+
+    member private x.RunActive defaultValue func =
+        if x.IsActive then func ()
+        else defaultValue
+
+    /// Run the search for the specified text.  This will do the search, update the caret 
+    /// position and raise events
+    member private x.RunSearch (startPoint: ITrackingPoint) searchText: unit =
+        // TODO: have to check for a search in progress and cancel it
+
+        // Update all the data for the start of the search
+        _searchData <- SearchData.Parse searchText _searchData.Kind _searchData.Options
+        _searchResult <- None
+        _searchStart.Trigger x (SearchDataEventArgs(_searchData))
+
+        // Actually execute the search. 
+        // TODO: Goal is to make this next part async
+
+        let searchResult = 
+            if StringUtil.IsNullOrEmpty searchText then
+                SearchResult.NotFound (_searchData, CanFindWithWrap=false)
+            else
+                match TrackingPointUtil.GetPoint _vimBuffer.TextView.TextSnapshot startPoint with
+                | None -> SearchResult.NotFound (_searchData, false)
+                | Some point -> _vimBuffer.Vim.SearchService.FindNextPattern point _searchData _vimBuffer.VimTextBuffer.WordNavigator 1
+
+        // Search is completed now update the results
+
+        // Update our state based on the SearchResult.  Only update the view if the 'incsearch'
+        // option is set
+        if _globalSettings.IncrementalSearch then
+            match searchResult with
+            | SearchResult.Found (_, span, _, _) -> _operations.EnsureAtPoint span.Start ViewFlags.Standard
+            | SearchResult.NotFound _ -> x.ResetView()
+            | SearchResult.Cancelled _ -> x.ResetView()
+            | SearchResult.Error _ -> x.ResetView()
+
+        // Update all of our internal state before we start raising events 
+        _searchResult <- Some searchResult
+        _searchEnd.Trigger x (SearchResultEventArgs(searchResult))
+
+    /// Called when the processing is completed.  Raise the completed event and return
+    /// the final SearchResult
+    member private x.RunCompleted() =
+        // TODO: in the async case this should wait for the completion 
+        _isActive <- false
+        _sessionComplete.Trigger x (EventArgs.Empty)
+        0
+
+    member private x.RunCancelled() =
+        // TODO: in the async case this should set the SearchResult to Cancelled if it hasn't finished 
+        // yet.
+        _isActive <- false
+        _sessionComplete.Trigger x (EventArgs.Empty)
+
+    interface IHistoryClient<ITrackingPoint, int> with
+        member x.HistoryList = _vimBuffer.VimData.SearchHistory
+        member x.RegisterMap = _vimBuffer.Vim.RegisterMap
+        member x.RemapMode = x.RemapMode
+        member x.Beep() = _operations.Beep()
+        member x.ProcessCommand searchPoint searchText = x.RunActive searchPoint (fun () -> 
+            x.RunSearch searchPoint searchText
+            searchPoint)
+        member x.Completed _ _ = x.RunActive 0 (fun () -> x.RunCompleted())
+        member x.Cancelled _ = x.RunActive () (fun () -> x.RunCancelled())
+
+    interface IIncrementalSearchSession with
+        member x.InSearch = Option.isNone _searchResult
+        member x.SearchData = _searchData
+        member x.SearchResult = _searchResult
+        member x.Cancel() = x.RunCancelled()
+        [<CLIEvent>]
+        member x.SearchStart = _searchStart.Publish
+        [<CLIEvent>]
+        member x.SearchEnd = _searchEnd.Publish
+        [<CLIEvent>]
+        member x.SessionComplete = _sessionComplete.Publish
 
 type internal IncrementalSearch
     (
@@ -59,20 +143,19 @@ type internal IncrementalSearch
     let _textView = _operations.TextView
     let _searchService = _vimBufferData.Vim.SearchService
     let mutable _incrementalSearchSession: IncrementalSearchSession option = None
-    let _currentSearchUpdated = StandardEvent<SearchResultEventArgs>()
-    let _currentSearchCompleted = StandardEvent<SearchResultEventArgs>()
-    let _currentSearchCancelled = StandardEvent<SearchDataEventArgs>()
 
-    member x.CurrentIncrementalSearchData =
+    static member EmptySearchData = SearchData("", SearchPath.Forward, isWrap= false)
+    static member EmptySearchText = ""
+
+    member x.CurrentSearchData = 
         match _incrementalSearchSession with
-        | Some incrementalSearchSession -> incrementalSearchSession.IncrementalSearchData
-        | None -> IncrementalSearchData.Default
+        | Some session -> session.SearchData
+        | None -> IncrementalSearch.EmptySearchData
 
-    member x.CurrentSearchData = x.CurrentIncrementalSearchData.SearchResult.SearchData
-
-    member x.CurrentSearchResult = x.CurrentIncrementalSearchData.SearchResult
-
-    member x.CurrentSearchText =  x.CurrentIncrementalSearchData.SearchText
+    member x.CurrentSearchText =
+        match _incrementalSearchSession with
+        | Some session -> session.SearchText
+        | None -> IncrementalSearch.EmptySearchText
 
     member x.InSearch = Option.isSome _incrementalSearchSession
 
@@ -81,39 +164,22 @@ type internal IncrementalSearch
         | Some session -> session.HistorySession.InPasteWait
         | None -> false
 
-    /// There is a big gap between the behavior and documentation of key mapping for an 
-    /// incremental search operation.  The documentation properly documents the language
-    /// mapping in "help language-mapping" and 'help imsearch'.  But it doesn't document
-    /// that command mapping should used when 'imsearch' doesn't apply although it's
-    /// the practice in implementation
-    ///
-    /// TODO: actually implement the 'imsearch' option and fix this
-    member x.RemapMode = KeyRemapMode.Command
-
     member x.IsCurrentSession key = 
         match _incrementalSearchSession with
         | None -> false
         | Some incrementalSearchSession -> incrementalSearchSession.Key = key
 
     /// Begin the incremental search along the specified path
-    member x.Begin path = 
+    member x.Start path = 
 
         // If there is an existing session going on then we need to cancel it 
         x.Cancel()
-
-        let start = TextViewUtil.GetCaretPoint _textView
-        let searchData = SearchData(StringUtil.Empty, path, _globalSettings.WrapScan)
-        let searchResult = SearchResult.NotFound (searchData, false)
-        let incrementalSearchData = {
-            SearchResult = searchResult
-            SearchText = ""
-        }
-        let startPoint = start.Snapshot.CreateTrackingPoint(start.Position, PointTrackingMode.Negative)
+        Debug.Assert(Option.isNone _incrementalSearchSession)
 
         let key = obj()
 
         // This local will only run the 'func' with the created session is still active.  If it is 
-        // not active then nothing will happen and 'defaultValue' will be returned
+        // not active then nothing will happen and 'defaultValue' will be returned. 
         let runActive func defaultValue = 
             match _incrementalSearchSession with
             | None -> defaultValue
@@ -122,6 +188,13 @@ type internal IncrementalSearch
                     func incrementalSearchSession 
                 else   
                     defaultValue
+
+        let runCancelled (session: IncrementalSearchSession) =
+            x.ResetView()
+            if not session.IsSearchCompleted then 
+                let searchResult = SearchResult.Cancelled session.SearchData
+                _searchEnd.Trigger x (SearchResultEventArgs(searchResult))
+            _incrementalSearchSession <- None
             
         let historyClient = { 
             new IHistoryClient<ITrackingPoint, SearchResult> with
@@ -131,84 +204,28 @@ type internal IncrementalSearch
                 member this.Beep() = _operations.Beep()
                 member this.ProcessCommand data command = runActive (fun session -> x.RunSearch session data command) data
                 member this.Completed (data: ITrackingPoint) _ = runActive (fun session -> x.RunCompleted session data) IncrementalSearchData.Default.SearchResult
-                member this.Cancelled (data: ITrackingPoint) = runActive (fun session -> x.RunCancelled session) ()
+                member this.Cancelled _ = runActive runCancelled ()
             }
+
+        let start = TextViewUtil.GetCaretPoint _textView
+        let startPoint = start.Snapshot.CreateTrackingPoint(start.Position, PointTrackingMode.Negative)
         let vimBuffer = _vimBufferData.Vim.GetVimBuffer _textView
         let historySession = HistoryUtil.CreateHistorySession historyClient startPoint StringUtil.Empty vimBuffer
-        _incrementalSearchSession <- Some (IncrementalSearchSession(key, historySession, incrementalSearchData))
+        let incrementalSearchSession = IncrementalSearchSession(key, historySession, path, _globalSettings.WrapScan)
+        _incrementalSearchSession <- Some incrementalSearchSession
 
-        // Raise the event
-        _currentSearchUpdated.Trigger x (SearchResultEventArgs(searchResult))
+        // Raise the event pair
+        _searchStart.Trigger x (SearchDataEventArgs(incrementalSearchSession.SearchData))
+        _searchEnd.Trigger x (SearchResultEventArgs(Option.get incrementalSearchSession.SearchResult))
 
         historySession.CreateBindDataStorage().CreateBindData()
 
-    // Reset the view to it's original state.  We should only be doing this if the
-    // 'incsearch' option is set.  Otherwise the view shouldn't change during an 
-    // incremental search
-    member x.ResetView () =
-        if _globalSettings.IncrementalSearch then
-             _operations.EnsureAtCaret ViewFlags.Standard
-
-    member x.RunSearch incrementalSearchSession (startPoint: ITrackingPoint) rawPattern =
-        let incrementalSearchData = x.RunSearchCore incrementalSearchSession startPoint rawPattern
-        incrementalSearchSession.IncrementalSearchData <- incrementalSearchData
-        let args = SearchResultEventArgs(incrementalSearchData.SearchResult)
-        _currentSearchUpdated.Trigger x args
-        startPoint
-
-    /// Run the search for the specified text.  This will do the search, update the caret 
-    /// position and raise events
-    member x.RunSearchCore incrementalSearchSession (startPoint: ITrackingPoint) rawPattern =
-
-        // Get the SearchResult value for the new text
-        let incrementalSearchData = incrementalSearchSession.IncrementalSearchData
-        let searchData = SearchData.Parse rawPattern incrementalSearchData.SearchData.Kind incrementalSearchData.SearchData.Options
-        let searchResult =
-            if StringUtil.IsNullOrEmpty rawPattern then
-                SearchResult.NotFound (searchData, false)
-            else
-                match TrackingPointUtil.GetPoint _textView.TextSnapshot startPoint with
-                | None -> SearchResult.NotFound (searchData, false)
-                | Some point -> _searchService.FindNextPattern point searchData _wordNavigator 1
-
-        // Update our state based on the SearchResult.  Only update the view if the 'incsearch'
-        // option is set
-        if _globalSettings.IncrementalSearch then
-            match searchResult with
-            | SearchResult.Found (_, span, _, _) -> _operations.EnsureAtPoint span.Start ViewFlags.Standard
-            | SearchResult.NotFound _ -> x.ResetView ()
-            | SearchResult.Error _ -> x.ResetView ()
-
-        // Update all of our internal state before we start raising events 
-        { SearchResult = searchResult; SearchText = rawPattern }
-
-    /// Called when the processing is completed.  Raise the completed event and return
-    /// the final SearchResult
-    member x.RunCompleted incrementalSearchSession startPoint =
-        if StringUtil.IsNullOrEmpty incrementalSearchSession.IncrementalSearchData.SearchData.Pattern then
-            // When the user simply hits Enter on an empty incremental search then
-            // we should be re-using the 'LastSearch' value.
-            let incrementalSearchData = x.RunSearchCore incrementalSearchSession startPoint _vimData.LastSearchData.Pattern
-            incrementalSearchSession.IncrementalSearchData <- incrementalSearchData
-
-        let searchResult = incrementalSearchSession.IncrementalSearchData.SearchResult
-        _vimData.LastSearchData <- searchResult.SearchData.LastSearchData
-        _currentSearchCompleted.Trigger x (SearchResultEventArgs(searchResult))
-        _incrementalSearchSession <- None
-        searchResult
-
-    /// Cancel the search.  Provide the last value searched for
-    member x.RunCancelled incrementalSearchSession =
-        x.ResetView ()
-        _currentSearchCancelled.Trigger x (SearchDataEventArgs(incrementalSearchSession.IncrementalSearchData.SearchData))
-        _incrementalSearchSession <- None
 
     member x.Cancel() =
         match _incrementalSearchSession with 
         | None -> ()
-        | Some incrementalSearchSession -> 
-            incrementalSearchSession.HistorySession.Cancel()
-            x.RunCancelled incrementalSearchSession
+        | Some incrementalSearchSession -> incrementalSearchSession.HistorySession.Cancel()
+        Debug.Assert(Option.isNone _incrementalSearchSession)
 
     member x.ResetSearch pattern = 
         match _incrementalSearchSession with 
@@ -220,16 +237,13 @@ type internal IncrementalSearch
         member x.InPasteWait = x.InPasteWait
         member x.WordNavigator = _wordNavigator
         member x.CurrentSearchData = x.CurrentSearchData
-        member x.CurrentSearchResult = x.CurrentSearchResult
         member x.CurrentSearchText = x.CurrentSearchText
         member x.Begin kind = x.Begin kind
         member x.Cancel () = x.Cancel()
         member x.ResetSearch pattern = x.ResetSearch pattern
         [<CLIEvent>]
-        member x.CurrentSearchUpdated = _currentSearchUpdated.Publish
+        member x.SearchStart = _searchStart.Publish
         [<CLIEvent>]
-        member x.CurrentSearchCompleted = _currentSearchCompleted.Publish 
-        [<CLIEvent>]
-        member x.CurrentSearchCancelled = _currentSearchCancelled.Publish
+        member x.SearchEnd = _searchEnd.Publish 
 
 

--- a/Src/VimCore/IncrementalSearch.fs
+++ b/Src/VimCore/IncrementalSearch.fs
@@ -6,6 +6,7 @@ open Microsoft.VisualStudio.Text.Editor
 open Microsoft.VisualStudio.Text.Outlining
 open NullableUtil
 open System
+open System.Collections.Generic
 open System.Diagnostics
 open System.Threading
 open System.Threading.Tasks
@@ -13,9 +14,15 @@ open Vim.VimCoreExtensions
 
 [<RequireQualifiedAccess>]
 type SearchState = 
-    | NeverRun
-    | InProgress of Key: obj
+    | NeverRun of SearchResult: SearchResult
+    | InProgress of Key: obj * TaskCompletionSource: TaskCompletionSource<SearchResult>
     | Complete of SearchResult: SearchResult
+
+[<RequireQualifiedAccess>]
+type SessionState = 
+    | NotStarted
+    | Started of HistorySession: IHistorySession<ITrackingPoint, SearchResult>
+    | Completed
 
 /// Represents an incremental search session. The session is created when the initial 
 /// `/` key is pressed and is updated until the session is completed, with enter, or 
@@ -29,9 +36,8 @@ type internal IncrementalSearchSession
     ) =
 
     let mutable _searchData = SearchData("", _searchPath, _isWrap)
-    let mutable _searchState = SearchState.NeverRun
-    let mutable _historySession : IHistorySession<ITrackingPoint, SearchResult> option = None
-    let mutable _isActive = true
+    let mutable _searchState = SearchState.NeverRun (SearchResult.NotFound (_searchData, CanFindWithWrap=false))
+    let mutable _sessionState = SessionState.NotStarted
     let _key = obj()
     let _globalSettings = _vimBufferData.Vim.GlobalSettings
     let _textView = _operations.TextView
@@ -41,25 +47,27 @@ type internal IncrementalSearchSession
 
     member x.Key = _key
     member x.IsWrap = _isWrap
-    member x.IsStarted = Option.isSome _historySession
-    member x.IsActive = _isActive
+    member x.IsNotStarted = match _sessionState with | SessionState.NotStarted _ -> true | _ -> false
+    member x.IsStarted = match _sessionState with | SessionState.Started _ -> true | _ -> false
+    member x.IsCompleted = match _sessionState with | SessionState.Completed -> true | _ -> false
+    member x.IsActive = x.IsStarted && not x.IsCompleted
     member x.SearchPath = _searchPath
     member x.SearchData = _searchData
     member x.SearchResult = 
         match _searchState with
-        | SearchState.NeverRun -> None
+        | SearchState.NeverRun searchResult -> Some searchResult
         | SearchState.InProgress _ -> None
         | SearchState.Complete searchResult -> Some searchResult
     member x.IsSearchInProgress = 
         match _searchState with
-        | SearchState.NeverRun -> false
+        | SearchState.NeverRun _-> false
         | SearchState.InProgress _ -> true
         | SearchState.Complete _ -> false
-    member x.HistorySession = _historySession
     member x.InPasteWait =
-        match _historySession with
-        | Some session -> session.InPasteWait
-        | None -> false
+        match _sessionState with
+        | SessionState.NotStarted -> false
+        | SessionState.Started historySession -> historySession.InPasteWait
+        | SessionState.Completed -> false
 
     [<CLIEvent>]
     member x.SessionComplete = _sessionComplete.Publish
@@ -79,21 +87,28 @@ type internal IncrementalSearchSession
              _operations.EnsureAtCaret ViewFlags.Standard
 
     member x.ResetSearch pattern = 
-        match _historySession with 
-        | Some historySession -> historySession.ResetCommand pattern
-        | None -> ()
+        match _sessionState with
+        | SessionState.NotStarted -> ()
+        | SessionState.Started historySession -> historySession.ResetCommand pattern
+        | SessionState.Completed -> ()
 
     /// Begin the incremental search along the specified path
     member x.Start() = 
-        if x.IsStarted then
+        if not x.IsNotStarted then
             raise (InvalidOperationException())
 
         let start = TextViewUtil.GetCaretPoint _textView
         let vimBuffer = _vimBufferData.Vim.GetVimBuffer _textView
         let startPoint = start.Snapshot.CreateTrackingPoint(start.Position, PointTrackingMode.Negative)
         let historySession = HistoryUtil.CreateHistorySession x startPoint StringUtil.Empty vimBuffer
-        _historySession <- Some historySession
+        _sessionState <- SessionState.Started historySession
         historySession.CreateBindDataStorage().CreateBindData()
+
+    member x.GetSearchResultAsync() =
+        match _searchState with
+        | SearchState.NeverRun searchResult -> Task.FromResult(searchResult)
+        | SearchState.InProgress (_, tcs) -> tcs.Task
+        | SearchState.Complete searchResult -> Task.FromResult(searchResult)
 
     member private x.RunActive defaultValue func =
         if x.IsActive then func ()
@@ -130,7 +145,7 @@ type internal IncrementalSearchSession
                 // by the UI thread. In that case SearchEnd has already been raised with a 
                 // Cancelled value and there is no more work to do.
                 match _searchState with
-                | SearchState.InProgress currentKey when currentKey = searchKey -> x.RunSearchImplEnd(searchResult, updateView=true)
+                | SearchState.InProgress (currentKey, _) when currentKey = searchKey -> x.RunSearchImplEnd(searchResult, updateView=true)
                 | _ -> ()
 
             // This is used in the background and must be careful to use types which are immutable
@@ -158,7 +173,7 @@ type internal IncrementalSearchSession
         // Update all the data for the start of the search
         let searchKey = obj()
         _searchData <- SearchData.Parse searchText _searchData.Kind _searchData.Options
-        _searchState <- SearchState.InProgress searchKey
+        _searchState <- SearchState.InProgress (searchKey, (new TaskCompletionSource<SearchResult>()))
         _searchStart.Trigger x (SearchDataEventArgs(_searchData))
 
         // Get the data required to complete the search
@@ -166,6 +181,13 @@ type internal IncrementalSearchSession
         (point, searchKey, _searchData, _vimBufferData.Vim.SearchService, _vimBufferData.VimTextBuffer.WordNavigator)
 
     member private x.RunSearchImplEnd(searchResult, updateView) =
+        match _searchState with
+        | SearchState.InProgress (_, tcs) -> tcs.SetResult(searchResult)
+        | _ -> ()
+
+        // Update all of our internal state before we start raising events 
+        _searchState <- SearchState.Complete searchResult
+
         // Update our state based on the SearchResult.  Only update the view if the 'incsearch'
         // option is set
         if _globalSettings.IncrementalSearch && updateView then
@@ -175,8 +197,6 @@ type internal IncrementalSearchSession
             | SearchResult.Cancelled _ -> x.ResetView()
             | SearchResult.Error _ -> x.ResetView()
 
-        // Update all of our internal state before we start raising events 
-        _searchState <- SearchState.Complete searchResult
         _searchEnd.Trigger x (SearchResultEventArgs(searchResult))
 
     /// Called when the processing is completed.  Raise the completed event and return
@@ -191,7 +211,7 @@ type internal IncrementalSearchSession
                 | _ -> false
 
             match _searchState with
-            | SearchState.NeverRun ->
+            | SearchState.NeverRun _ ->
                 // When the user simply hits Enter on an empty incremental search then
                 // we should be re-using the 'LastSearch' value.
                 x.RunSearchSyncWithResult(startPoint, vimData.LastSearchData.Pattern)
@@ -203,12 +223,17 @@ type internal IncrementalSearchSession
                 x.RunSearchSyncWithResult(startPoint, _searchData.Pattern)
 
         vimData.LastSearchData <- _searchData
-        x.CompleteSession()
+        x.RunCompleteSession()
         searchResult
 
     member private x.RunCancel() =
         x.MaybeCancelSearchInProgress(updateView=true)
-        x.CompleteSession()
+        x.RunCompleteSession()
+
+    member private x.RunCompleteSession() =
+        Debug.Assert(x.IsStarted)
+        _sessionState <- SessionState.Completed
+        _sessionComplete.Trigger x (EventArgs.Empty)
 
     /// If there is an unfinished search cancel it
     member private x.MaybeCancelSearchInProgress(updateView) =
@@ -217,16 +242,9 @@ type internal IncrementalSearchSession
         | _ -> ()
 
     member x.Cancel() =
-        if not x.IsActive then
-            raise (InvalidOperationException())
-        match _historySession with
-        | Some historySession -> historySession.Cancel()
-        | None -> ()
-
-    member private x.CompleteSession() =
-        Debug.Assert(x.IsActive)
-        _isActive <- false
-        _sessionComplete.Trigger x (EventArgs.Empty)
+        match _sessionState with
+        | SessionState.Started historySession -> historySession.Cancel()
+        | _ -> raise (InvalidOperationException())
 
     interface IHistoryClient<ITrackingPoint, SearchResult> with
         member x.HistoryList = _vimBufferData.Vim.VimData.SearchHistory
@@ -241,11 +259,14 @@ type internal IncrementalSearchSession
 
     interface IIncrementalSearchSession with
         member x.Key = _key
+        member x.IsStarted = x.IsStarted
+        member x.IsCompleted = x.IsCompleted
         member x.SearchData = _searchData
         member x.SearchResult = x.SearchResult
         member x.ResetSearch pattern = x.ResetSearch pattern
         member x.Start() = x.Start()
         member x.Cancel() = x.Cancel()
+        member x.GetSearchResultAsync() = x.GetSearchResultAsync()
         [<CLIEvent>]
         member x.SearchStart = _searchStart.Publish
         [<CLIEvent>]

--- a/Src/VimCore/IncrementalSearch.fs
+++ b/Src/VimCore/IncrementalSearch.fs
@@ -201,7 +201,7 @@ type internal IncrementalSearchSession
 
     /// Called when the processing is completed.  Raise the completed event and return
     /// the final SearchResult
-    member private x.RunCompleted startPoint =
+    member private x.RunCompleted(startPoint, searchText) =
         let vimData = _vimBufferData.Vim.VimData
         let searchResult = 
 
@@ -220,7 +220,7 @@ type internal IncrementalSearchSession
                 // If the search is still in progress then we need to force it to be complete here. Need
                 // to avoid the tempatation to use methods like Task.Wait as that can cause deadlocks. Instead
                 // just synchronously run the search here. 
-                x.RunSearchSyncWithResult(startPoint, _searchData.Pattern)
+                x.RunSearchSyncWithResult(startPoint, searchText)
 
         vimData.LastSearchData <- _searchData
         x.RunCompleteSession()
@@ -254,7 +254,7 @@ type internal IncrementalSearchSession
         member x.ProcessCommand searchPoint searchText = x.RunActive searchPoint (fun () -> 
             x.RunSearchAsync searchPoint searchText
             searchPoint)
-        member x.Completed searchPoint _ = x.RunActive (SearchResult.Error (_searchData, "Invalid Operation")) (fun () -> x.RunCompleted searchPoint)
+        member x.Completed searchPoint searchText = x.RunActive (SearchResult.Error (_searchData, "Invalid Operation")) (fun () -> x.RunCompleted(searchPoint, searchText))
         member x.Cancelled _ = x.RunActive () (fun () -> x.RunCancel())
 
     interface IIncrementalSearchSession with

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1546,6 +1546,7 @@ type VimInterpreter
                 _commonOperations.MoveCaretToPoint point ViewFlags.Standard
                 _vimData.LastSearchData <- searchData
             | SearchResult.NotFound _ -> ()
+            | SearchResult.Cancelled _ -> ()
             | SearchResult.Error _ -> ())
 
     /// Run the :set command.  Process each of the arguments 

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -388,7 +388,7 @@ type internal NormalMode
             x.Reset()
             ProcessResult.Handled ModeSwitch.NoSwitch
         | BindResult.Cancelled -> 
-            _incrementalSearch.Cancel()
+            _incrementalSearch.CancelSession()
             x.Reset()
             ProcessResult.Handled ModeSwitch.NoSwitch
 

--- a/Src/VimCore/Modes_Visual_SelectionTracker.fs
+++ b/Src/VimCore/Modes_Visual_SelectionTracker.fs
@@ -34,14 +34,8 @@ type internal SelectionTracker
     do 
         _textChangedHandler <- ToggleHandler.Create (_textView.TextBuffer.Changed) (fun (args:TextContentChangedEventArgs) -> this.OnTextChanged(args))
 
-        _incrementalSearch.CurrentSearchUpdated
-        |> Observable.add (fun args -> _lastIncrementalSearchResult <- Some args.SearchResult)
-        
-        _incrementalSearch.CurrentSearchCancelled
-        |> Observable.add (fun _ -> _lastIncrementalSearchResult <- None)
-
-        _incrementalSearch.CurrentSearchCompleted 
-        |> Observable.add (fun _ -> _lastIncrementalSearchResult <- None)
+        _incrementalSearch.SessionCreated
+        |> Observable.add (fun args -> this.OnIncrementalSearchSessionCreated(args.Session))
 
     member x.AnchorPoint = Option.get _anchorPoint
 
@@ -93,6 +87,23 @@ type internal SelectionTracker
         _textChangedHandler.Remove()
         _anchorPoint <- None
 
+    member x.OnIncrementalSearchSessionCreated (session: IIncrementalSearchSession) =
+        _lastIncrementalSearchResult <- None
+
+        // Whenever a search completes we want to track the result in the selection. The one exception
+        // is when the search is cancelled. That happens when the developer:
+        // - types ctrl-c: the session complete event will clear the data
+        // - types a new letter: just let the last result stay until a new result shows up
+        session.SearchEnd 
+        |> Observable.add (fun args -> 
+            _lastIncrementalSearchResult <- 
+                match args.SearchResult with
+                | SearchResult.Cancelled _ -> _lastIncrementalSearchResult
+                | _ -> Some args.SearchResult)
+
+        session.SessionComplete
+        |> Observable.add (fun _ -> _lastIncrementalSearchResult <- None)
+
     /// Update the selection based on the current state of the ITextView
     member x.UpdateSelection() = 
 
@@ -101,17 +112,15 @@ type internal SelectionTracker
         | Some anchorPoint ->
             let simulatedCaretPoint = 
                 let caretPoint = TextViewUtil.GetCaretVirtualPoint _textView 
-                if _incrementalSearch.InSearch then
-                    match _lastIncrementalSearchResult with
-                    | None -> caretPoint
-                    | Some searchResult ->
-                        match searchResult with
-                        | SearchResult.NotFound _ -> caretPoint
-                        | SearchResult.Error _ -> caretPoint
-                        | SearchResult.Found (_, span, _, _) ->
-                            VirtualSnapshotPointUtil.OfPoint span.Start
-                else
-                    caretPoint
+                match _lastIncrementalSearchResult with
+                | None -> caretPoint
+                | Some searchResult ->
+                    match searchResult with
+                    | SearchResult.NotFound _ -> caretPoint
+                    | SearchResult.Error _ -> caretPoint
+                    | SearchResult.Cancelled _ -> caretPoint
+                    | SearchResult.Found (_, span, _, _) ->
+                        VirtualSnapshotPointUtil.OfPoint span.Start
 
             // Update the selection only.  Don't move the caret here.  It's either properly positioned
             // or we're simulating the selection based on incremental search

--- a/Src/VimCore/Modes_Visual_SelectionTracker.fs
+++ b/Src/VimCore/Modes_Visual_SelectionTracker.fs
@@ -99,7 +99,12 @@ type internal SelectionTracker
             _lastIncrementalSearchResult <- 
                 match args.SearchResult with
                 | SearchResult.Cancelled _ -> _lastIncrementalSearchResult
-                | _ -> Some args.SearchResult)
+                | _ -> Some args.SearchResult
+
+            // Incremental search completes asynchronously in the majority case. Hence we need to update
+            // the selection immediately vs. waiting for another component to call UpdateSelection as that
+            // call isn't necessarily coming.
+            x.UpdateSelection())
 
         session.SessionComplete
         |> Observable.add (fun _ -> _lastIncrementalSearchResult <- None)
@@ -119,8 +124,7 @@ type internal SelectionTracker
                     | SearchResult.NotFound _ -> caretPoint
                     | SearchResult.Error _ -> caretPoint
                     | SearchResult.Cancelled _ -> caretPoint
-                    | SearchResult.Found (_, span, _, _) ->
-                        VirtualSnapshotPointUtil.OfPoint span.Start
+                    | SearchResult.Found (_, span, _, _) -> VirtualSnapshotPointUtil.OfPoint span.Start
 
             // Update the selection only.  Don't move the caret here.  It's either properly positioned
             // or we're simulating the selection based on incremental search

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -225,8 +225,6 @@ type internal VisualMode
             else
                 match _runner.Run ki with
                 | BindResult.NeedMoreInput _ -> 
-                    // Commands like incremental search can move the caret and be incomplete.  Need to 
-                    // update the selection while waiting for the next key
                     _selectionTracker.UpdateSelection()
                     ProcessResult.HandledNeedMoreInput
 

--- a/Src/VimCore/MotionCapture.fs
+++ b/Src/VimCore/MotionCapture.fs
@@ -161,12 +161,13 @@ type internal MotionCapture
 
             // Store the caret point before the search begins
             let before = TextViewUtil.GetCaretPoint _textView
-            let result = _incrementalSearch.Begin path
+            let result = _incrementalSearch.CreateSession(path).Start()
 
             result.Convert (fun searchResult ->
                 match searchResult with
                 | SearchResult.Found (searchData, _, _, _) -> Motion.Search searchData
                 | SearchResult.NotFound (searchData, _) -> Motion.Search searchData 
+                | SearchResult.Cancelled searchData -> Motion.Search searchData
                 | SearchResult.Error (searchData, _) -> Motion.Search searchData)
 
         BindDataStorage.Complex activateFunc

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -2853,6 +2853,7 @@ type internal MotionUtil
             match searchResult with
             | SearchResult.Error _ -> None
             | SearchResult.NotFound _ -> None
+            | SearchResult.Cancelled _ -> None
             | SearchResult.Found (_, span, _, _) ->
                 // Create the MotionResult for the provided MotionArgument and the 
                 // start and end points of the search.  Need to be careful because
@@ -3010,6 +3011,7 @@ type internal MotionUtil
                 match searchResult with
                 | SearchResult.Error _ -> None
                 | SearchResult.NotFound _ -> None
+                | SearchResult.Cancelled _ -> None
                 | SearchResult.Found (_, span, _, _) ->
 
                     let motionKind = MotionKind.CharacterWiseExclusive

--- a/Src/VimCore/Resources.fs
+++ b/Src/VimCore/Resources.fs
@@ -30,6 +30,7 @@ module internal Resources =
     let Common_SelectionInvalid = "An invalid selection was detected"
     let Common_SearchForwardWrapped = "search hit BOTTOM, continuing at TOP"
     let Common_SearchBackwardWrapped = "search hit TOP, continuing at BOTTOM"
+    let Common_SearchCancelled = "Search was cancelled"
     let Common_SearchHitBottomWithout name = sprintf "search hit BOTTOM without match for: %s" name
     let Common_SearchHitTopWithout name = sprintf "search hit TOP without match for: %s" name
     let Common_SubstituteComplete subs lines = sprintf "%d substitutions on %d lines" subs lines

--- a/Src/VimCore/SearchService.fs
+++ b/Src/VimCore/SearchService.fs
@@ -261,6 +261,7 @@ type internal SearchService
         match x.FindNextCore serviceSearchData point 1 with
         | SearchResult.Found (_, span, _, _) -> Some span
         | SearchResult.NotFound _ -> None
+        | SearchResult.Cancelled _ -> None
         | SearchResult.Error _ -> None
 
     member x.ApplySearchOffsetData (serviceSearchData: ServiceSearchData) (span: SnapshotSpan): SnapshotSpan option =

--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -132,8 +132,8 @@ type internal ModeMap
             oldMode.OnLeave()
 
             // Incremental search should not persist between mode changes.  
-            if _incrementalSearch.InSearch then
-                _incrementalSearch.Cancel()
+            if _incrementalSearch.HasActiveSession then
+                _incrementalSearch.CancelSession()
 
             _vimTextBuffer.SwitchMode kind arg
 

--- a/Src/VimEditorHost/Extensions.cs
+++ b/Src/VimEditorHost/Extensions.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Projection;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Vim.EditorHost
 {

--- a/Src/VimEditorHost/Extensions.cs
+++ b/Src/VimEditorHost/Extensions.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Projection;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Vim.EditorHost
 {

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -901,6 +901,8 @@ namespace Vim.UnitTest
             return GetBlockSpan(vimBuffer.TextBuffer, column, length, startLine, lineCount, vimBuffer.LocalSettings.TabStop);
         }
 
+        public static async Task GetSearchCompleteAsync(this IVimBuffer vimBuffer) => await vimBuffer.IncrementalSearch.GetSearchCompleteAsync();
+
         #endregion
 
         #region ITextSnapshot
@@ -1388,7 +1390,7 @@ namespace Vim.UnitTest
 
         public static BindResult<T> Run<T>(this BindData<T> data, params KeyInput[] keyInputs)
         {
-            BindResult<T> result = null;
+            BindResult<T> result = data.CreateBindResult();
             foreach (var keyInput in keyInputs)
             {
                 result = result.Run(keyInput);
@@ -1495,6 +1497,15 @@ namespace Vim.UnitTest
             {
                 args.Session.SearchEnd += (_2, args2) => action(args2.SearchResult);
             };
+        }
+
+        public static async Task GetSearchCompleteAsync(this IIncrementalSearch search)
+        {
+            if (search.HasActiveSession)
+            {
+                var session = search.ActiveSession.Value;
+                await session.GetSearchResultAsync();
+            }
         }
 
         #endregion

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -1426,11 +1426,29 @@ namespace Vim.UnitTest
         public static BindResult<SearchResult> DoSearch(this IIncrementalSearch search, string text, SearchPath path = null, bool enter = true)
         {
             path = path ?? SearchPath.Forward;
-            var result = search.Begin(path).Run(text);
+            var result = search.CreateSession(path).Start().Run(text);
             return enter
                 ? result.Run(VimKey.Enter)
                 : result;
         }
+
+        public static void OnSearchStart(this IIncrementalSearch search, Action<SearchData> action)
+        {
+            search.SessionCreated += (_, args) =>
+            {
+                args.Session.SearchStart += (_2, args2) => action(args2.SearchData);
+            };
+        }
+
+        public static void OnSearchEnd(this IIncrementalSearch search, Action<SearchResult> action)
+        {
+            search.SessionCreated += (_, args) =>
+            {
+                args.Session.SearchEnd += (_2, args2) => action(args2.SearchResult);
+            };
+        }
+
+        public static BindData<SearchResult> Begin(this IIncrementalSearch search, SearchPath searchPath) => search.CreateSession(searchPath).Start();
 
         #endregion
 

--- a/Src/VimTestUtils/VimUtil.cs
+++ b/Src/VimTestUtils/VimUtil.cs
@@ -177,7 +177,6 @@ namespace Vim.UnitTest
                 bindDataStorage);
         }
 
-
         internal static Command CreateNormalCommand(
             NormalCommand command = null,
             CommandData commandData = null)
@@ -321,5 +320,19 @@ namespace Vim.UnitTest
             var parser = CreateParser();
             return parser.ParseExpression(expr);
         }
+
+        internal static KeyInput[] ConvertTextToKeyInput(string text) => text.Select(KeyInputUtil.CharToKeyInput).ToArray();
+
+        internal static KeyInput[] ConvertTextToKeyInput(string text, bool enter)
+        {
+            var keyInputs = text.Select(KeyInputUtil.CharToKeyInput);
+            if (enter)
+            {
+                keyInputs = keyInputs.Concat(new[] { KeyInputUtil.EnterKey });
+            }
+            return keyInputs.ToArray();
+        }
+
+        internal static KeyInput[] ConvertVimKeysToKeyInput(params VimKey[] vimKeys) => vimKeys.Select(KeyInputUtil.VimKeyToKeyInput).ToArray();
     }
 }

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaretController.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaretController.cs
@@ -76,7 +76,7 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
         {
             // The caret should be invisible during incremental search no matter what mode we are
             // in
-            if (_vimBuffer.IncrementalSearch.InSearch)
+            if (_vimBuffer.IncrementalSearch.HasActiveSession)
             {
                 _blockCaret.CaretDisplay = CaretDisplay.Invisible;
                 return;

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -119,7 +119,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                 }
 
                 var search = _vimBuffer.IncrementalSearch;
-                if (search.InSearch && search.InPasteWait)
+                if (search.HasActiveSession && search.InPasteWait)
                 {
                     return true;
                 }
@@ -572,7 +572,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         /// </summary>
         private void ToggleLanguage()
         {
-            var isForInsert = !_vimBuffer.IncrementalSearch.InSearch;
+            var isForInsert = !_vimBuffer.IncrementalSearch.HasActiveSession;
             _commonOperations.ToggleLanguage(isForInsert);
         }
 
@@ -639,9 +639,9 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                         break;
                     case EditKind.SearchBackward:
                     case EditKind.SearchForward:
-                        if (_vimBuffer.IncrementalSearch.InSearch)
+                        if (_vimBuffer.IncrementalSearch.ActiveSession.IsSome())
                         {
-                            _vimBuffer.IncrementalSearch.ResetSearch(commandText);
+                            _vimBuffer.IncrementalSearch.ActiveSession.Value.ResetSearch(commandText);
                         }
                         break;
                     case EditKind.None:
@@ -963,7 +963,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                 return EditKind.Command;
             }
 
-            if (_vimBuffer.IncrementalSearch.InSearch)
+            if (_vimBuffer.IncrementalSearch.HasActiveSession)
             {
                 return _vimBuffer.IncrementalSearch.CurrentSearchData.Kind.IsAnyForward
                     ? EditKind.SearchForward

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginUtil.cs
@@ -42,7 +42,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             }
 
             var search = vimBuffer.IncrementalSearch;
-            if (search.InSearch && search.InPasteWait)
+            if (search.HasActiveSession && search.InPasteWait)
             {
                 return true;
             }
@@ -63,7 +63,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         private static string GetStatusOther(IVimBuffer vimBuffer, IMode currentMode)
         {
             var search = vimBuffer.IncrementalSearch;
-            if (search.InSearch)
+            if (search.HasActiveSession)
             {
                 var searchText = search.CurrentSearchText;
                 var prefix = search.CurrentSearchData.Path.IsForward ? "/" : "?";
@@ -194,7 +194,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
 
         public static string GetShowCommandText(IVimBuffer vimBuffer)
         {
-            if (vimBuffer.IncrementalSearch.InSearch)
+            if (vimBuffer.IncrementalSearch.HasActiveSession)
             {
                 return string.Empty;
             }

--- a/Src/VimWpf/Implementation/ImeCoordinator/ImeCoordinator.cs
+++ b/Src/VimWpf/Implementation/ImeCoordinator/ImeCoordinator.cs
@@ -334,7 +334,7 @@ namespace Vim.UI.Wpf.Implementation.ImeCoordinator
                     return InputMode.Insert;
 
                 case ModeKind.Normal:
-                    if (vimBuffer.IncrementalSearch.InSearch)
+                    if (vimBuffer.IncrementalSearch.HasActiveSession)
                     {
                         // User is in the middle of a '/' or '?' search.
                         return InputMode.Search;

--- a/Src/VsVim/VsVim.csproj
+++ b/Src/VsVim/VsVim.csproj
@@ -18,7 +18,6 @@
          will fail and trigger a bulid error 
     -->
     <DeployExtension Condition="'$(AppVeyor)' != ''">False</DeployExtension>
-    <DeployExtension Condition="'$(VisualStudioVersion)' != '15.0'">False</DeployExtension>
     <!-- This is needed to prevent forced migrations when opening the project in Vs2017 -->
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
   </PropertyGroup>

--- a/Test/VimCoreTest/IncrementalSearchTaggerSourceTest.cs
+++ b/Test/VimCoreTest/IncrementalSearchTaggerSourceTest.cs
@@ -54,7 +54,7 @@ namespace Vim.UnitTest
         public void GetTags_AfterSearchCompleted()
         {
             Create("dog cat bar");
-            _search.DoSearch("dog");
+            _search.DoSearchAsync("dog");
             Assert.Empty(GetTags());
         }
 
@@ -65,7 +65,7 @@ namespace Vim.UnitTest
         public void GetTags_InSearchWithMatch()
         {
             Create("dog cat bar");
-            _search.DoSearch("dog", enter: false);
+            _search.DoSearchAsync("dog", enter: false);
             Assert.Equal("dog", GetTags().Single().Span.GetText());
         }
 
@@ -78,7 +78,7 @@ namespace Vim.UnitTest
         {
             Create("dog cat bar");
             _vimBuffer.SwitchMode(ModeKind.VisualCharacter, ModeArgument.None);
-            _search.DoSearch("dog", enter: false);
+            _search.DoSearchAsync("dog", enter: false);
             Assert.Empty(GetTags());
         }
 
@@ -89,7 +89,7 @@ namespace Vim.UnitTest
         public void GetTags_NoneIfDisabled()
         {
             Create("dog cat bar");
-            _search.DoSearch("dog", enter: false);
+            _search.DoSearchAsync("dog", enter: false);
             _globalSettings.IncrementalSearch = false;
             Assert.Empty(GetTags());
         }

--- a/Test/VimCoreTest/IncrementalSearchTaggerSourceTest.cs
+++ b/Test/VimCoreTest/IncrementalSearchTaggerSourceTest.cs
@@ -4,6 +4,7 @@ using Vim.EditorHost;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace Vim.UnitTest
 {
@@ -51,10 +52,10 @@ namespace Vim.UnitTest
         /// After the search is completed we shouldn't be returning any results
         /// </summary>
         [WpfFact]
-        public void GetTags_AfterSearchCompleted()
+        public async Task GetTags_AfterSearchCompleted()
         {
             Create("dog cat bar");
-            _search.DoSearchAsync("dog");
+            await _search.DoSearchAsync("dog");
             Assert.Empty(GetTags());
         }
 
@@ -62,10 +63,10 @@ namespace Vim.UnitTest
         /// Get tags should return the current match while searching
         /// </summary>
         [WpfFact]
-        public void GetTags_InSearchWithMatch()
+        public async Task GetTags_InSearchWithMatch()
         {
             Create("dog cat bar");
-            _search.DoSearchAsync("dog", enter: false);
+            await _search.DoSearchAsync("dog", enter: false);
             Assert.Equal("dog", GetTags().Single().Span.GetText());
         }
 
@@ -74,11 +75,11 @@ namespace Vim.UnitTest
         /// visual mode values.  
         /// </summary>
         [WpfFact]
-        public void GetTags_NoneInVisualMode()
+        public async Task GetTags_NoneInVisualMode()
         {
             Create("dog cat bar");
             _vimBuffer.SwitchMode(ModeKind.VisualCharacter, ModeArgument.None);
-            _search.DoSearchAsync("dog", enter: false);
+            await _search.DoSearchAsync("dog", enter: false);
             Assert.Empty(GetTags());
         }
 
@@ -86,10 +87,10 @@ namespace Vim.UnitTest
         /// Don't return any tags if we're currently disabled
         /// </summary>
         [WpfFact]
-        public void GetTags_NoneIfDisabled()
+        public async Task GetTags_NoneIfDisabled()
         {
             Create("dog cat bar");
-            _search.DoSearchAsync("dog", enter: false);
+            await _search.DoSearchAsync("dog", enter: false);
             _globalSettings.IncrementalSearch = false;
             Assert.Empty(GetTags());
         }

--- a/Test/VimCoreTest/IncrementalSearchTest.cs
+++ b/Test/VimCoreTest/IncrementalSearchTest.cs
@@ -325,6 +325,11 @@ namespace Vim.UnitTest
 
                 var bindResult = session.Start().Run("dog ", enter: false);
                 Assert.Equal(3, count);
+
+                // There is a pending search for the ' '. It can't complete yet because this test doesn't
+                // pump any messages. But another test could pump messages that would cause this to complete
+                // and trigger the SearchEnd handler. Cancel here so that doesn't happen
+                session.Cancel();
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/MotionCaptureTest.cs
+++ b/Test/VimCoreTest/MotionCaptureTest.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Vim.Extensions;
 using Vim.UnitTest.Mock;
 using Xunit;
+using System;
 
 namespace Vim.UnitTest
 {
@@ -385,11 +386,11 @@ namespace Vim.UnitTest
         {
             _textView.SetText("cat dog");
             var didRun = false;
-            _incrementalSearch.CurrentSearchUpdated += (_, args) =>
+            _incrementalSearch.OnSearchEnd(searchResult =>
             {
-                Assert.True(SearchKind.ForwardWithWrap == args.SearchResult.SearchData.Kind);
+                Assert.True(SearchKind.ForwardWithWrap == searchResult.SearchData.Kind);
                 didRun = true;
-            };
+            });
             Process("/cat");
             Assert.True(didRun);
         }
@@ -400,11 +401,11 @@ namespace Vim.UnitTest
             _textView.SetText("cat dog");
             _localSettings.GlobalSettings.WrapScan = false;
             var didRun = false;
-            _incrementalSearch.CurrentSearchUpdated += (_, args) =>
+            _incrementalSearch.OnSearchEnd(searchResult =>
             {
-                Assert.True(SearchKind.Forward == args.SearchResult.SearchData.Kind);
+                Assert.True(SearchKind.Forward == searchResult.SearchData.Kind);
                 didRun = true;
-            };
+            });
             Process("/cat");
             Assert.True(didRun);
         }
@@ -414,11 +415,11 @@ namespace Vim.UnitTest
         {
             _textView.SetText("cat dog");
             var didRun = false;
-            _incrementalSearch.CurrentSearchUpdated += (_, args) =>
+            _incrementalSearch.OnSearchEnd(searchResult =>
             {
-                Assert.True(SearchKind.BackwardWithWrap == args.SearchResult.SearchData.Kind);
+                Assert.True(SearchKind.BackwardWithWrap == searchResult.SearchData.Kind);
                 didRun = true;
-            };
+            });
             Process("?cat");
             Assert.True(didRun);
         }
@@ -429,11 +430,11 @@ namespace Vim.UnitTest
             _textView.SetText("cat dog");
             _localSettings.GlobalSettings.WrapScan = false;
             var didRun = false;
-            _incrementalSearch.CurrentSearchUpdated += (_, args) =>
+            _incrementalSearch.OnSearchEnd(searchResult =>
             {
-                Assert.True(SearchKind.Backward == args.SearchResult.SearchData.Kind);
+                Assert.True(SearchKind.Backward == searchResult.SearchData.Kind);
                 didRun = true;
-            };
+            });
             Process("?cat");
             Assert.True(didRun);
         }
@@ -509,7 +510,7 @@ namespace Vim.UnitTest
         [WpfFact]
         public void Search_EnsureIncrementalSearchNotStarted()
         {
-            Assert.False(_incrementalSearch.InSearch);
+            Assert.False(_incrementalSearch.HasActiveSession);
         }
 
         /// <summary>
@@ -519,7 +520,7 @@ namespace Vim.UnitTest
         public void Search_EnsureStartedOnSlash()
         {
             _capture.GetMotionAndCount('/');
-            Assert.True(_incrementalSearch.InSearch);
+            Assert.True(_incrementalSearch.HasActiveSession);
         }
 
         /// <summary>
@@ -531,7 +532,7 @@ namespace Vim.UnitTest
             var result = _capture.GetMotionAndCount('/');
             Assert.True(result.IsNeedMoreInput);
             result.AsNeedMoreInput().BindData.BindFunction.Invoke(KeyInputUtil.VimKeyToKeyInput(VimKey.Escape));
-            Assert.False(_incrementalSearch.InSearch);
+            Assert.False(_incrementalSearch.HasActiveSession);
         }
 
         [WpfFact]

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -4648,7 +4648,7 @@ namespace Vim.UnitTest
                 }
             }
 
-            public sealed class MiscTest : IncrementalSearchTest
+            public sealed class IncrementalMiscTest : IncrementalSearchTest
             {
                 [WpfFact]
                 public void KeyRemapMode_CommandInIncrementalSearch()

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -1830,7 +1830,7 @@ namespace Vim.UnitTest
                 Create("cat", "");
                 _vimBuffer.ProcessNotation("y/<Esc>");
                 Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
-                Assert.False(_vimBuffer.IncrementalSearch.InSearch);
+                Assert.False(_vimBuffer.IncrementalSearch.HasActiveSession);
             }
         }
 
@@ -4153,7 +4153,7 @@ namespace Vim.UnitTest
                 {
                     Create("cat dog bear");
                     _vimBuffer.Process("/DOG");
-                    Assert.True(_vimBuffer.IncrementalSearch.CurrentSearchResult.IsNotFound);
+                    Assert.True(_vimBuffer.IncrementalSearch.ActiveSession.Value.SearchResult.Value.IsNotFound);
                     _vimBuffer.Process(@"\c", enter: true);
                     Assert.Equal(4, _textView.GetCaretPoint().Position);
                 }
@@ -4645,6 +4645,37 @@ namespace Vim.UnitTest
                     _vimBuffer.ProcessNotation("/big/;/dog", enter: true);
                     Assert.Equal(8, _textView.GetCaretPoint().Position);
                     Assert.Equal("dog", _vimData.LastSearchData.Pattern);
+                }
+            }
+
+            public sealed class MiscTest : IncrementalSearchTest
+            {
+                [WpfFact]
+                public void KeyRemapMode_CommandInIncrementalSearch()
+                {
+                    Create("foobar");
+                    _vimBuffer.Process('/');
+                    Assert.Equal(KeyRemapMode.Command, _normalMode.KeyRemapMode);
+                }
+
+                [WpfFact]
+                public void IsWaitingForInput2()
+                {
+                    Create("foobar");
+                    _vimBuffer.Process('/');
+                    Assert.True(_normalMode.CommandRunner.IsWaitingForMoreInput);
+                }
+
+                /// <summary>
+                /// When in a need more state, process everything
+                /// </summary>
+                [WpfFact]
+                public void CanProcess4()
+                {
+                    Create("cat dog");
+                    _vimBuffer.Process(KeyInputUtil.CharToKeyInput('/'));
+                    Assert.True(_normalMode.CanProcess(KeyInputUtil.CharToKeyInput('U')));
+                    Assert.True(_normalMode.CanProcess(KeyInputUtil.CharToKeyInput('Z')));
                 }
             }
         }

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -9,6 +9,7 @@ using Vim.UnitTest.Exports;
 using Vim.UnitTest.Mock;
 using Xunit;
 using Microsoft.FSharp.Core;
+using System.Threading.Tasks;
 
 namespace Vim.UnitTest
 {
@@ -4149,10 +4150,11 @@ namespace Vim.UnitTest
                 /// at the end of the string
                 /// </summary>
                 [WpfFact]
-                public void CaseInsensitiveAtEndOfSearhString()
+                public async Task CaseInsensitiveAtEndOfSearhString()
                 {
                     Create("cat dog bear");
                     _vimBuffer.Process("/DOG");
+                    await _vimBuffer.IncrementalSearch.GetSearchCompleteAsync();
                     Assert.True(_vimBuffer.IncrementalSearch.ActiveSession.Value.SearchResult.Value.IsNotFound);
                     _vimBuffer.Process(@"\c", enter: true);
                     Assert.Equal(4, _textView.GetCaretPoint().Position);

--- a/Test/VimCoreTest/NormalModeTest.cs
+++ b/Test/VimCoreTest/NormalModeTest.cs
@@ -136,21 +136,6 @@ namespace Vim.UnitTest
         }
 
         /// <summary>
-        /// When in a need more state, process everything
-        /// </summary>
-        [WpfFact]
-        public void CanProcess4()
-        {
-            Create(s_defaultLines);
-            _incrementalSearch
-                .Setup(x => x.Begin(SearchPath.Forward))
-                .Returns(VimUtil.CreateBindData<SearchResult>());
-            _mode.Process(KeyInputUtil.CharToKeyInput('/'));
-            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('U')));
-            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('Z')));
-        }
-
-        /// <summary>
         /// Ensure that all of the core characters are valid Normal Mode commands.  They all should
         /// be 
         /// </summary>
@@ -934,53 +919,6 @@ namespace Vim.UnitTest
 
         #region Incremental Search
 
-        /// <summary>
-        /// Make sure the incremental search begins when the '/' is typed
-        /// </summary>
-        [WpfFact]
-        public void IncrementalSearch_BeginOnForwardSearchChar()
-        {
-            Create("foo bar");
-            _incrementalSearch
-                .Setup(x => x.Begin(SearchPath.Forward))
-                .Returns(VimUtil.CreateBindData<SearchResult>())
-                .Verifiable();
-            _mode.Process('/');
-            _incrementalSearch.Verify();
-        }
-
-        /// <summary>
-        /// Make sure the incremental search beigns when the '?' is typed
-        /// </summary>
-        [WpfFact]
-        public void IncrementalSearch_BeginOnBackwardSearchChar()
-        {
-            Create("foo bar");
-            _incrementalSearch
-                .Setup(x => x.Begin(SearchPath.Backward))
-                .Returns(VimUtil.CreateBindData<SearchResult>())
-                .Verifiable();
-            _mode.Process('?');
-            _incrementalSearch.Verify();
-        }
-
-        /// <summary>
-        /// Once incremental search begins, make sure it handles any keystroke
-        /// </summary>
-        [WpfFact]
-        public void IncrementalSearch_HandlesAnyKey()
-        {
-            Create("foo bar");
-            _incrementalSearch
-                .Setup(x => x.Begin(SearchPath.Forward))
-                .Returns(VimUtil.CreateBindData<SearchResult>())
-                .Verifiable();
-            _mode.Process('/');
-            var ki = KeyInputUtil.CharToKeyInput((char)7);
-            _mode.Process(ki);
-            _incrementalSearch.Verify();
-        }
-
         #endregion
 
         #region Next / Previous Word
@@ -1249,17 +1187,6 @@ namespace Vim.UnitTest
         }
 
         [WpfFact]
-        public void KeyRemapMode_CommandInIncrementalSearch()
-        {
-            Create("foobar");
-            _incrementalSearch
-                .Setup(x => x.Begin(SearchPath.Forward))
-                .Returns(VimUtil.CreateBindData<SearchResult>(remapMode: KeyRemapMode.Command));
-            _mode.Process('/');
-            Assert.Equal(KeyRemapMode.Command, _mode.KeyRemapMode);
-        }
-
-        [WpfFact]
         public void KeyRemapMode_OperatorPendingAfterY()
         {
             Create("");
@@ -1302,17 +1229,6 @@ namespace Vim.UnitTest
         {
             Create("foobar");
             Assert.False(_mode.CommandRunner.IsWaitingForMoreInput);
-        }
-
-        [WpfFact]
-        public void IsWaitingForInput2()
-        {
-            Create("foobar");
-            _incrementalSearch
-                .Setup(x => x.Begin(SearchPath.Forward))
-                .Returns(VimUtil.CreateBindData<SearchResult>());
-            _mode.Process('/');
-            Assert.True(_mode.CommandRunner.IsWaitingForMoreInput);
         }
 
         [WpfFact]

--- a/Test/VimCoreTest/VimIntegrationTest.cs
+++ b/Test/VimCoreTest/VimIntegrationTest.cs
@@ -59,9 +59,9 @@ namespace Vim.UnitTest
             {
                 var vimBuffer = CreateVimBuffer("hello world");
                 vimBuffer.ProcessNotation("/wo");
-                Assert.True(vimBuffer.IncrementalSearch.InSearch);
+                Assert.True(vimBuffer.IncrementalSearch.HasActiveSession);
                 vimBuffer.SwitchMode(ModeKind.VisualCharacter, ModeArgument.None);
-                Assert.False(vimBuffer.IncrementalSearch.InSearch);
+                Assert.False(vimBuffer.IncrementalSearch.HasActiveSession);
             }
 
             /// <summary>

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -2856,11 +2856,12 @@ namespace Vim.UnitTest
             }
 
             [WpfFact]
-            public void IncrementalSearch_CharModeShouldExtendToSearchResult()
+            public async Task IncrementalSearch_CharModeShouldExtendToSearchResult()
             {
                 Create("dog", "cat");
                 EnterMode(ModeKind.VisualCharacter, new SnapshotSpan(_textView.GetLine(0).Start, 1));
                 _vimBuffer.Process("/o");
+                await _vimBuffer.GetSearchCompleteAsync();
                 Assert.Equal(new SnapshotSpan(_textView.GetLine(0).Start, 2), _textView.GetSelectionSpan());
             }
 

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -11,6 +11,7 @@ using Xunit;
 using Xunit.Extensions;
 using System.Collections.Generic;
 using Vim.UnitTest.Exports;
+using System.Threading.Tasks;
 
 namespace Vim.UnitTest
 {
@@ -2834,21 +2835,23 @@ namespace Vim.UnitTest
 
             [WpfTheory]
             [MemberData(nameof(VirtualEditOptions))]
-            public void IncrementalSearch_LineModeShouldSelectFullLine(string virtualEdit)
+            public async Task IncrementalSearch_LineModeShouldSelectFullLine(string virtualEdit)
             {
                 Create("dog", "cat", "tree");
                 _globalSettings.VirtualEdit = virtualEdit;
                 SwitchEnterMode(ModeKind.VisualLine, _textView.GetLineRange(0, 1).ExtentIncludingLineBreak);
                 _vimBuffer.Process("/c");
+                await _vimBuffer.GetSearchCompleteAsync();
                 Assert.Equal(_textView.GetLineRange(0, 1).ExtentIncludingLineBreak, _textView.GetSelectionSpan());
             }
 
             [WpfFact]
-            public void IncrementalSearch_LineModeShouldSelectFullLineAcrossBlanks()
+            public async Task IncrementalSearch_LineModeShouldSelectFullLineAcrossBlanks()
             {
                 Create("dog", "", "cat", "tree");
                 EnterMode(ModeKind.VisualLine, _textView.GetLineRange(0, 1).ExtentIncludingLineBreak);
                 _vimBuffer.Process("/ca");
+                await _vimBuffer.GetSearchCompleteAsync();
                 Assert.Equal(_textView.GetLineRange(0, 2).ExtentIncludingLineBreak, _textView.GetSelectionSpan());
             }
 

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -2883,7 +2883,7 @@ namespace Vim.UnitTest
                 Create("cat", "dog", "tree");
                 _vimBuffer.ProcessNotation("vl/dog<Esc>");
                 Assert.Equal(ModeKind.VisualCharacter, _vimBuffer.ModeKind);
-                Assert.False(_vimBuffer.IncrementalSearch.InSearch);
+                Assert.False(_vimBuffer.IncrementalSearch.HasActiveSession);
                 Assert.Equal("ca", _textView.GetSelectionSpan().GetText());
             }
 
@@ -2896,7 +2896,7 @@ namespace Vim.UnitTest
                 Create("cat", "dog", "tree");
                 _vimBuffer.ProcessNotation("vl/dog<Enter>");
                 Assert.Equal(ModeKind.VisualCharacter, _vimBuffer.ModeKind);
-                Assert.False(_vimBuffer.IncrementalSearch.InSearch);
+                Assert.False(_vimBuffer.IncrementalSearch.HasActiveSession);
                 Assert.Equal(_textBuffer.GetLine(1).Start, _textView.GetCaretPoint());
             }
 

--- a/Test/VimWpfTest/BlockCaretControllerTest.cs
+++ b/Test/VimWpfTest/BlockCaretControllerTest.cs
@@ -26,7 +26,7 @@ namespace Vim.UI.Wpf.UnitTest
             _settings = _factory.Create<IVimGlobalSettings>(MockBehavior.Loose);
             _localSettings = MockObjectFactory.CreateLocalSettings(global: _settings.Object, factory: _factory);
             _incrementalSearch = _factory.Create<IIncrementalSearch>();
-            _incrementalSearch.SetupGet(x => x.InSearch).Returns(false);
+            _incrementalSearch.SetupGet(x => x.HasActiveSession).Returns(false);
             _buffer = _factory.Create<IVimBuffer>(MockBehavior.Strict);
             _buffer.SetupGet(x => x.ModeKind).Returns(ModeKind.Command);
             _buffer.SetupGet(x => x.TextView).Returns(_textView.Object);
@@ -115,7 +115,7 @@ namespace Vim.UI.Wpf.UnitTest
             var mode = new Mock<INormalMode>();
             _buffer.SetupGet(x => x.NormalMode).Returns(mode.Object);
             _buffer.SetupGet(x => x.ModeKind).Returns(ModeKind.Normal);
-            _incrementalSearch.SetupGet(x => x.InSearch).Returns(true);
+            _incrementalSearch.SetupGet(x => x.HasActiveSession).Returns(true);
 
             _caret.SetupSet(x => x.CaretDisplay = CaretDisplay.Invisible).Verifiable();
             _controller.Update();
@@ -171,7 +171,7 @@ namespace Vim.UI.Wpf.UnitTest
         [Fact]
         public void VisualMode_InIncrementalSearch()
         {
-            _incrementalSearch.SetupGet(x => x.InSearch).Returns(true);
+            _incrementalSearch.SetupGet(x => x.HasActiveSession).Returns(true);
             _buffer.SetupGet(x => x.ModeKind).Returns(ModeKind.VisualCharacter);
 
             _caret.SetupSet(x => x.CaretDisplay = CaretDisplay.Invisible).Verifiable();

--- a/Test/VimWpfTest/CommandMarginControllerTest.cs
+++ b/Test/VimWpfTest/CommandMarginControllerTest.cs
@@ -34,7 +34,7 @@ namespace Vim.UI.Wpf.UnitTest
             _marginControl.CommandLineTextBox.Text = string.Empty;
 
             _search = _factory.Create<IIncrementalSearch>();
-            _search.SetupGet(x => x.InSearch).Returns(false);
+            _search.SetupGet(x => x.HasActiveSession).Returns(false);
             _search.SetupGet(x => x.InPasteWait).Returns(false);
             _vimBuffer = new MockVimBuffer
             {
@@ -143,7 +143,7 @@ namespace Vim.UI.Wpf.UnitTest
                 searchKind = searchKind ?? SearchKind.Forward;
 
                 var data = new SearchData(pattern, SearchOffsetData.None, searchKind, searchOptions);
-                _search.SetupGet(x => x.InSearch).Returns(true).Verifiable();
+                _search.SetupGet(x => x.HasActiveSession).Returns(true).Verifiable();
                 _search.SetupGet(x => x.CurrentSearchData).Returns(data).Verifiable();
                 _search.SetupGet(x => x.CurrentSearchText).Returns(pattern).Verifiable();
             }
@@ -417,7 +417,7 @@ namespace Vim.UI.Wpf.UnitTest
                 mode.SetupGet(x => x.CommandRunner).Returns(runner.Object);
                 runner.SetupGet(x => x.Inputs).Returns(FSharpList<KeyInput>.Empty);
                 _globalSettings.SetupGet(x => x.ShowCommand).Returns(true);
-                _search.SetupGet(x => x.InSearch).Returns(false).Verifiable();
+                _search.SetupGet(x => x.HasActiveSession).Returns(false).Verifiable();
                 mode.SetupGet(x => x.Command).Returns("foo");
                 mode.SetupGet(x => x.ModeKind).Returns(ModeKind.Normal);
                 _vimBuffer.BufferedKeyInputsImpl = FSharpList<KeyInput>.Empty;
@@ -532,7 +532,7 @@ namespace Vim.UI.Wpf.UnitTest
                 _vimBuffer.ModeImpl = mode.Object;
                 SimulateSearch("cat", SearchKind.Backward);
                 SimulateKeystroke();
-                _search.SetupGet(x => x.InSearch).Returns(false);
+                _search.SetupGet(x => x.HasActiveSession).Returns(false);
                 SimulateKeystroke();
                 Assert.Equal(Resources.VisualCharacterBanner, _marginControl.CommandLineTextBox.Text);
             }

--- a/Test/VimWpfTest/CommandMarginUtilTest.cs
+++ b/Test/VimWpfTest/CommandMarginUtilTest.cs
@@ -24,7 +24,7 @@ namespace Vim.UI.Wpf.UnitTest
             _factory = new MockRepository(MockBehavior.Strict);
             
             _search = _factory.Create<IIncrementalSearch>();
-            _search.SetupGet(x => x.InSearch).Returns(false);
+            _search.SetupGet(x => x.HasActiveSession).Returns(false);
             
             _normalMode = _factory.Create<INormalMode>();
             _normalMode.SetupGet(x => x.Command).Returns(string.Empty);


### PR DESCRIPTION
This change makes incremental search asynchronous up until the point the developer hits the <kbd>Enter</kbd> key. Key strokes typed up until this point will spawn search requests on the thread pool and update the incremental search state when they complete. In the case another key stroke is typed before the search completes then a new search will be started and the existing one ignored. 

Ideally the existing searches would be cancelled when a new key press occurs. But the editor APIs don't allow for cancellation in their `ITextSearchService` APIs. Hence there is nothing to really do but let the search run its course. That doesn't affect the UI responsiveness though. 

The bulk of the work here is getting the unit tests updated. Many tests just work because they complete a search with <kbd>Enter</kbd> hence don't observe the asynchronous nature here. Many others though verify the state of vim in the middle of a search. Those necessarily have to move to `async` in order to correctly validate the state.

Dogfooding this I see a significant improvement when searching in extremely large files. Before I could watch my key strokes be typed out as the search progressed on. Now I can type and just wait for the las search to take hold. 

closes #2465 
