### PR TITLE
Fix load error in C# script executor

### DIFF
--- a/Src/VsSpecific/VsSpecific/CSharpScriptExecutor.cs
+++ b/Src/VsSpecific/VsSpecific/CSharpScriptExecutor.cs
@@ -11,7 +11,7 @@ using Vim.Interpreter;
 
 namespace Vim.VisualStudio.Specific
 {
-    internal sealed class CSharpScriptExecutor : ICSharpScriptExecutor
+    internal sealed partial class CSharpScriptExecutor : ICSharpScriptExecutor
     {
         private const string ScriptFolder = "vsvimscripts";
         private Dictionary<string, Script<object>> _scripts = new Dictionary<string, Script<object>>(StringComparer.OrdinalIgnoreCase);

--- a/Src/VsSpecific/VsSpecific/NotSupportedCSharpScriptExecutor.cs
+++ b/Src/VsSpecific/VsSpecific/NotSupportedCSharpScriptExecutor.cs
@@ -1,0 +1,14 @@
+﻿using Vim.Interpreter;
+
+namespace Vim.VisualStudio.Specific
+{
+    internal sealed class NotSupportedCSharpScriptExecutor : ICSharpScriptExecutor
+    {
+        internal static readonly ICSharpScriptExecutor Instance = new NotSupportedCSharpScriptExecutor();
+
+        void ICSharpScriptExecutor.Execute(IVim vim, CallInfo callInfo, bool createEachTime)
+        {
+            vim.ActiveStatusUtil.OnError("csx not supported");
+        }
+    }
+}

--- a/Src/VsSpecific/VsSpecific/SharedService.CSharpScript.cs
+++ b/Src/VsSpecific/VsSpecific/SharedService.CSharpScript.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Runtime.CompilerServices;
 using Vim.Interpreter;
 
 namespace Vim.VisualStudio.Specific
@@ -6,12 +8,39 @@ namespace Vim.VisualStudio.Specific
 
     internal partial class SharedService
     {
-        private ICSharpScriptExecutor _cSharpScriptExecutor = new CSharpScriptExecutor();
+        private Lazy<ICSharpScriptExecutor> _lazyExecutor = new Lazy<ICSharpScriptExecutor>(CreateExecutor);
 
         private void RunCSharpScript(IVim vim, CallInfo callInfo, bool createEachTime)
         {
-            _cSharpScriptExecutor.Execute(vim, callInfo, createEachTime);
+            _lazyExecutor.Value.Execute(vim, callInfo, createEachTime);
         }
+
+        private static ICSharpScriptExecutor CreateExecutor()
+        {
+            try
+            {
+                return CreateCSharpExecutor();
+            }
+            catch
+            {
+                // Failure is expected here in certain cases. 
+            }
+
+            return NotSupportedCSharpScriptExecutor.Instance;
+        }
+
+        /// <summary>
+        /// The creation of <see cref="CSharpScriptExecutor"/> will load the Microsoft.CodeAnalysis
+        /// assemblies. This method deliberately has inlining disabled so that the attempted load 
+        /// will happen in this method call and not be inlined into the caller. This lets us better
+        /// trap failure. 
+        /// 
+        /// The majority of VS workloads will have these assemblies and hence this will be safe. But
+        /// there are workloads, Python and C++ for example, which will not install them. In that 
+        /// case C# script execution won't be supported and this method will fail.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ICSharpScriptExecutor CreateCSharpExecutor() => new CSharpScriptExecutor();
     }
 
 #else
@@ -20,7 +49,7 @@ namespace Vim.VisualStudio.Specific
     {
         private void RunCSharpScript(IVim vim, CallInfo callInfo, bool createEachTime)
         {
-           vim.ActiveStatusUtil.OnError("csx not supported");
+            NotSupportedCSharpScriptExecutor.Instance.Execute(vim, callInfo, createEachTime);
         }
     }
 

--- a/Src/VsSpecific/VsSpecific/VsSpecific.projitems
+++ b/Src/VsSpecific/VsSpecific/VsSpecific.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NotSupportedCSharpScriptExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CSharpScriptExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CSharpScriptGlobals.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SharedService.CSharpScript.cs" />


### PR DESCRIPTION
There are work loads of Visual Studio that don't have the C# scripting
assemblies installed. For example C++ and Python can do this.

For such work loads the C# script execution functionality won't load
correctly. Need to guard against this case and fall back to not
supported behavior when it happens.

closes #2500